### PR TITLE
ci: establish M0A security and dependency gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       time: "06:15"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - java
     groups:
       maven-minor-patch:
         applies-to: version-updates
@@ -28,9 +25,6 @@ updates:
       time: "06:30"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - javascript
     groups:
       npm-minor-patch:
         applies-to: version-updates
@@ -48,9 +42,6 @@ updates:
       time: "06:45"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - github-actions
     groups:
       actions-minor-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /apps/api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - java
+    groups:
+      maven-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:45"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,38 +14,48 @@ permissions:
   packages: read
   actions: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   java:
     name: CodeQL / Java
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL for Java
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: java-kotlin
           build-mode: none
 
       - name: Analyze Java
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:java-kotlin"
 
   javascript:
     name: CodeQL / JavaScript-TypeScript
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL for JavaScript/TypeScript
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: javascript-typescript
 
       - name: Analyze JavaScript/TypeScript
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
+jobs:
+  java:
+    name: CodeQL / Java
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL for Java
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: none
+
+      - name: Analyze Java
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"
+
+  javascript:
+    name: CodeQL / JavaScript-TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL for JavaScript/TypeScript
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Analyze JavaScript/TypeScript
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,16 +6,23 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           fail-on-scopes: runtime,development,unknown

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime,development,unknown


### PR DESCRIPTION
## Problem

M0A already has functional API/Contract/Web verification, but `main` still lacks dedicated code-scanning, dependency-diff review, and automated dependency maintenance.

## Solution

- CodeQL advanced workflow for Java and JavaScript/TypeScript on PRs, `main`, and a weekly schedule;
- Dependency Review on every PR, blocking newly introduced high/critical known vulnerabilities across runtime/development/unknown scopes;
- weekly Dependabot version updates for Maven (`/apps/api`), npm/pnpm workspace (`/`), and GitHub Actions (`/`);
- minor/patch version updates grouped per ecosystem while major version changes remain separate;
- immutable full-SHA action pins, non-persisted checkout credentials, finite timeouts, and concurrency cancellation;
- no application behavior changes.

## Verification evidence

Repository-admin prerequisites were completed on 2026-08-09:

- Dependency Graph enabled and SBOM endpoint available;
- Dependabot security updates enabled;
- secret scanning and push protection enabled;
- private vulnerability reporting enabled;
- squash-only merge policy enabled and stale merged branches removed.

Fresh checks on head `1393d6f1261ad7aa93282d923fc51df178ec20c9`:

- CodeQL run `31312757103` — success for Java and JavaScript/TypeScript;
- Dependency Review run `31312757097` — success after Dependency Graph enablement.

## Dependabot

`.github/dependabot.yml` configures weekly version updates for Maven, npm/pnpm, and GitHub Actions. Minor/patch version updates are grouped per ecosystem; major updates remain individually reviewable. Security updates are not folded into ordinary version-update groups.

## Merge gate

All security gates are now green. This PR is ready for squash merge. Repository-state/changelog synchronization will follow from current `main` so stale historical state from this long-lived branch is not reintroduced.