### PR TITLE
chore: clean and clarify public repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Support and contribution guidance
+    url: https://github.com/True-Ruslan/zakup-gotov/blob/main/.github/SUPPORT.md
+    about: Choose the right channel before opening an issue or pull request.
   - name: Security vulnerability
     url: https://github.com/True-Ruslan/zakup-gotov/blob/main/SECURITY.md
     about: Do not report vulnerabilities publicly; follow the security policy.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,12 @@
+# Support
+
+Zakup Gotov is currently pre-release and does not yet provide a supported production service.
+
+Use the appropriate channel:
+
+- **Reproducible bug:** open a Bug Report issue and include the environment, steps, expected behavior, and actual behavior.
+- **Product/engineering proposal:** open a Feature Request with the problem being solved and measurable success criteria.
+- **Contribution:** read `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, and `docs/ENGINEERING.md` before opening a pull request.
+- **Security vulnerability:** do **not** open a public issue. Follow `SECURITY.md` and use GitHub Private Vulnerability Reporting when enabled.
+
+Retailer credentials, private endpoints, precise user addresses, access tokens, or other sensitive data must never be posted in public support threads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Safe Actuator operational surface exposing only health, liveness, readiness, and non-sensitive info over HTTP.
 - Executable Actuator security test that rejects HTTP exposure of environment, configuration-properties, and metrics endpoints.
 - `docs/OBSERVABILITY.md` defining telemetry naming, low-cardinality constraints, provider redaction rules, and liveness/readiness semantics.
+- Reproducible `./scripts/verify.sh` developer verification entrypoint covering backend, real PostgreSQL/Testcontainers, generated OpenAPI drift, client checks, and web checks/build.
+- `docs/DEVELOPMENT.md` with pinned prerequisites, local run instructions, focused verification commands, Playwright setup, and Docker/Testcontainers troubleshooting.
+- `docs/README.md` documentation index separating current state, roadmap, ADRs, specifications, implementation plans, and history.
+- `docs/REPOSITORY_GOVERNANCE.md` defining merge, branch, Actions, security-feature, and future release-governance policy.
+- `.github/SUPPORT.md` routing bugs, proposals, contributions, and confidential security reports to appropriate channels.
+- Approved repository-governance and Docker/GHCR release-engineering specification, including multi-platform images, Compose distribution, supply-chain evidence, and backend-first provider policy.
 
 ### Changed
 
@@ -58,6 +64,9 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Next.js anonymous telemetry is disabled in CI.
 - Spring MVC request-detail logging is explicitly disabled by default.
 - Health component/details disclosure is explicitly disabled while Kubernetes-style liveness/readiness probe groups are enabled.
+- Public README was reorganized around product value, honest implementation status, CI visibility, quick verification, architecture, security, and a compact documentation map.
+- `PROJECT_STATE.md` was converted from a stale task diary into a factual snapshot of merged work, open blockers, verified gates, and next actions.
+- Repository branch lifecycle now explicitly keeps only `main` plus active pull-request branches; merged source branches are treated as disposable after squash merge.
 
 ### Fixed
 
@@ -65,6 +74,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Corrected Spring Boot 4 MVC test wiring by adding the focused `spring-boot-starter-webmvc-test` test module after the first controller test compile attempt exposed the split test auto-configuration.
 - Corrected the initial web-test dependency updater to operate from the root pnpm workspace after local-directory installation could not resolve the shared workspace protocol package.
 - Removed an unused-variable lint warning from the initial component test rather than accepting warning noise.
+- Corrected `PROJECT_STATE.md` references that still described already-merged PR #7 and the pre-Task-8 repository state as current.
 
 ### Security
 
@@ -72,3 +82,4 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Production database credentials are required through external environment configuration and are not stored in source control.
 - Contract CI and Web CI use read-only repository permissions and verify the lockfile through pnpm's supply-chain policy check during frozen installation.
 - Actuator environment/configuration/metrics endpoints remain unavailable over public HTTP, and request logging defaults are restricted to reduce accidental credential/location leakage.
+- Repository governance now explicitly requires least-privilege Actions, no silent security-check bypasses, Dependency Graph/Dependabot/CodeQL/Dependency Review/secret scanning/push protection/PVR where available, and convergence on immutable full-SHA action pins.

--- a/README.md
+++ b/README.md
@@ -1,121 +1,163 @@
 # Закуп готов / Zakup Gotov
 
-> Recipe-to-cart grocery comparison service for finding the best complete basket across nearby stores.
+> От рецепта или списка продуктов — к честному сравнению полной корзины в доступных магазинах.
 
-**Status:** M0 — Product & Integration Discovery
+[![API CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/api-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/api-ci.yml)
+[![Contract CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/contract-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/contract-ci.yml)
+[![Web CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml)
 
-Zakup Gotov is an early-stage product for turning a recipe, meal plan, or manual grocery list into a location-aware comparison of complete grocery baskets.
+**Status:** M0 — Product & Integration Discovery · **pre-release**
 
-The product is intentionally focused on the **whole basket**, not isolated “cheapest item” search:
+Zakup Gotov — сервис, который должен превращать рецепт, недельное меню или обычный список покупок в сравнение **полной корзины** по магазинам с учётом местоположения, актуальности цены, наличия и полноты сопоставления.
+
+Проект намеренно не маскирует неизвестность: пока реальные retailer-интеграции не доказаны в M0B, интерфейс не выдаёт сравнение магазинов за готовую функцию.
+
+## Зачем проект
+
+Большинство сравнений отвечает на вопрос «где дешевле конкретный товар?». Zakup Gotov ориентирован на более практичный вопрос:
+
+> **Где выгоднее и реально возможно купить всю нужную корзину?**
 
 ```text
-recipe / meal plan / grocery list
-        ↓
-shopping requirements
-        ↓
-location + retailer context
-        ↓
-product matching
-        ↓
-current price + availability
-        ↓
-package / quantity optimization
-        ↓
-complete basket comparison
+рецепт / меню / список продуктов
+              ↓
+     shopping requirements
+              ↓
+      location + retailer
+              ↓
+       product matching
+              ↓
+   price + availability + age
+              ↓
+      quantity / package fit
+              ↓
+     complete basket ranking
 ```
 
-## Product promise
+Целевой результат должен явно показывать:
 
-Choose what you want to cook or buy. Zakup Gotov should help answer:
+- какие магазины способны закрыть весь список;
+- итоговую стоимость корзины, а не отдельных SKU;
+- отсутствующие и неоднозначно сопоставленные позиции;
+- свежесть цены и наличия;
+- разницу между удобством одной корзины и минимальной ценой нескольких магазинов.
 
-- Which nearby retailer can fulfill the whole list?
-- What will the basket actually cost?
-- Which items are missing or uncertain?
-- How fresh are the prices and availability signals?
-- Is one-store convenience better than splitting the basket?
+## Текущее состояние
 
-The project will not hide incomplete matches or silently treat stale prices as current.
+Сейчас реализована и автоматически проверяется платформенная основа:
 
-## Current focus
+- Java 25 + Spring Boot 4.1 API;
+- PostgreSQL 18 + Flyway + jOOQ;
+- Spring Modulith architecture verification;
+- OpenAPI 3.1 как источник клиентского контракта;
+- генерируемый TypeScript API client;
+- Next.js 16 / React 19 responsive web shell;
+- Testcontainers с настоящим PostgreSQL;
+- Vitest + Testing Library + Playwright desktop/mobile;
+- безопасный Actuator health/readiness baseline;
+- воспроизводимый `./scripts/verify.sh`.
 
-The first milestone is **not** a full recipe application. M0 exists to prove the hardest assumption first: that at least two target retailers can provide sufficiently reliable, location-specific product, price, and availability data through technically and legally acceptable integration paths.
+**Ещё не реализованы:** retailer integrations, shopping-list domain, recipes, matching, basket optimization, auth и native mobile. Это запланированные этапы, а не скрытые незавершённые функции.
 
-M0 is split into:
+Фактический статус всегда фиксируется в [`docs/PROJECT_STATE.md`](docs/PROJECT_STATE.md).
 
-- **M0A — Platform Foundation:** executable monorepo, API/web foundations, database, contracts, observability, CI/security, and repository governance.
-- **M0B — Retailer Feasibility:** provider research, legal/technical evidence, probe harness, fixtures, and at least two proven retailer integrations.
+## Быстрый старт для разработки
 
-See:
-
-- [Project state](docs/PROJECT_STATE.md)
-- [Roadmap](docs/ROADMAP.md)
-- [Development](docs/DEVELOPMENT.md)
-- [Engineering policy](docs/ENGINEERING.md)
-- [Observability](docs/OBSERVABILITY.md)
-- [Foundation design](docs/superpowers/specs/2026-08-09-zakup-gotov-foundation-design.md)
-- [M0A implementation plan](docs/superpowers/plans/2026-08-09-m0a-platform-foundation.md)
-- [ADR-0001: Platform stack](docs/adr/0001-platform-stack.md)
-- [Changelog](CHANGELOG.md)
-
-## Approved technical foundation
-
-The approved baseline is:
-
-- **Backend:** Java 25 LTS, Spring Boot 4.1, Spring MVC, Virtual Threads, Spring Modulith
-- **Database:** PostgreSQL 18
-- **Persistence:** Flyway + jOOQ
-- **API:** REST/JSON + OpenAPI 3.1.x
-- **Web:** Next.js 16, React, TypeScript
-- **Future mobile:** Expo + React Native + TypeScript
-- **Testing:** JUnit 5, Testcontainers, Modulith tests, Vitest, Testing Library, Playwright
-- **Observability:** Micrometer/Actuator with OpenTelemetry-compatible telemetry
-- **Repository/CI:** GitHub Actions and GitHub-native security tooling
-
-The architecture was approved on 2026-08-09 and is recorded in accepted ADR-0001.
-
-## Development
-
-The supported developer workflow is documented in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md). With the pinned Java 25 / Node 24.18.1 / pnpm 11.4.0 toolchains and Docker running, the primary local verification entrypoint is:
+Требуются Java 25, Node.js 24.18.1, pnpm 11.4.0 и запущенный Docker.
 
 ```bash
+git clone https://github.com/True-Ruslan/zakup-gotov.git
+cd zakup-gotov
+pnpm install --frozen-lockfile
 ./scripts/verify.sh
 ```
 
-The command intentionally fails rather than silently skipping Testcontainers, generated-contract drift, type checks, tests, or production builds.
+Команда не пропускает молча недоступный Docker/Testcontainers, drift сгенерированного OpenAPI-клиента, type checks, tests или production builds.
 
-Responsive Playwright browser tests are an explicit additional gate; see the development guide for the Chromium setup and command.
+Полная настройка окружения, focused-команды и Playwright: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
 
-## Engineering principles
+> Готовый `docker compose` релиз без локальной сборки — утверждённое направление release engineering и будет добавлен отдельным этапом после repository baseline.
 
-1. **TDD by default.** Executable behavior follows RED -> GREEN -> REFACTOR, with the expected failure observed before production implementation.
-2. **Evidence before claims.** A change is complete only with fresh automated verification appropriate to that change.
-3. **Automation first.** Repeated manual verification is automation debt; deterministic CI should cover everything reasonably automatable.
-4. **Documentation is repository truth.** State, roadmap, ADRs, implementation plans, and changelog stay synchronized with actual work.
-5. **Clean Git history.** Short-lived branches, cohesive commits, small PRs, required checks, and squash-only target history.
-6. **Modular monolith first.** Preserve cheap refactoring while enforcing module boundaries.
-7. **Retailers are adapters.** External provider behavior must not leak into the product domain.
-8. **Freshness is data.** A comparable offer includes source, retailer context, availability, and observation time.
-9. **Uncertainty is visible.** Ambiguous matching and incomplete baskets are explicit states.
-10. **YAGNI infrastructure.** No Kafka, Kubernetes, Redis, Elasticsearch, vector DB, or microservices until evidence justifies them.
+## Архитектура
 
-Full rules: [docs/ENGINEERING.md](docs/ENGINEERING.md).
+```text
+┌──────────────────────┐          ┌──────────────────────┐
+│      Next.js Web     │          │  Future Expo Mobile  │
+└──────────┬───────────┘          └──────────┬───────────┘
+           └──────────────┬───────────────────┘
+                          │ OpenAPI
+                          ▼
+              ┌──────────────────────┐
+              │ Spring Boot / Java 25│
+              │   Modular Monolith   │
+              └──────────┬───────────┘
+                         │
+              ┌──────────▼───────────┐
+              │ PostgreSQL 18 / jOOQ │
+              └──────────────────────┘
+                         │
+              provider adapter boundary
+                         │
+          ┌──────────────┼──────────────┐
+          ▼              ▼              ▼
+       retailer A     retailer B     retailer ...
+```
+
+Основной путь retailer-интеграций — backend provider adapters. Client-side integration допускается только как осознанное исключение, если конкретный публичный API не требует секретов, разрешает CORS/browser use или действительно зависит от пользовательской browser-session.
+
+Архитектурные решения: [`docs/adr/`](docs/adr/) и [`docs/superpowers/specs/`](docs/superpowers/specs/).
+
+## Инженерный контракт
+
+Проект следует строгой политике из [`docs/ENGINEERING.md`](docs/ENGINEERING.md):
+
+- TDD: RED → проверка правильной причины → GREEN → regression → refactor;
+- evidence before claims;
+- automation first — повторяемая ручная проверка считается automation debt;
+- реальные PostgreSQL integration tests вместо H2-подмены;
+- provider fixtures/contracts вместо live retailer-зависимости обычного CI;
+- короткие ветки, небольшие PR, squash-only target history;
+- `PROJECT_STATE`, roadmap, ADR/spec/plan и changelog обновляются вместе с реальностью проекта.
+
+## Документация
+
+| Что нужно понять | Документ |
+|---|---|
+| Текущее фактическое состояние | [`PROJECT_STATE.md`](docs/PROJECT_STATE.md) |
+| Что делаем дальше | [`ROADMAP.md`](docs/ROADMAP.md) |
+| Карта всей документации | [`docs/README.md`](docs/README.md) |
+| Разработка и локальная проверка | [`DEVELOPMENT.md`](docs/DEVELOPMENT.md) |
+| Инженерные правила | [`ENGINEERING.md`](docs/ENGINEERING.md) |
+| Repository governance | [`REPOSITORY_GOVERNANCE.md`](docs/REPOSITORY_GOVERNANCE.md) |
+| Observability / privacy rules | [`OBSERVABILITY.md`](docs/OBSERVABILITY.md) |
+| История заметных изменений | [`CHANGELOG.md`](CHANGELOG.md) |
+| Участие в разработке | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Сообщение об уязвимостях | [`SECURITY.md`](SECURITY.md) |
+| Code of Conduct | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
 
 ## Roadmap
 
-- **M0:** Product & Integration Discovery
-- **M1:** Shopping Core
-- **M2:** Recipes
-- **M3:** Weekly Planning
-- **M4:** Basket Optimization
-- **M5:** Productization
-- **M6:** Native Mobile
+- **M0A — Platform Foundation:** завершаем security/governance/release-ready repository baseline.
+- **M0B — Retailer Feasibility:** доказываем минимум две технически и юридически приемлемые интеграции.
+- **M1 — Shopping Core**
+- **M2 — Recipes**
+- **M3 — Weekly Planning**
+- **M4 — Basket Optimization**
+- **M5 — Productization**
+- **M6 — Native Mobile**
 
-Details: [docs/ROADMAP.md](docs/ROADMAP.md).
+Подробные scope и exit criteria: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+## Security
+
+Не публикуйте credentials, provider tokens, точные пользовательские адреса, приватные endpoints или чувствительные provider payloads в issues, logs, fixtures и screenshots.
+
+Уязвимости **не следует** отправлять публичным issue. Порядок disclosure: [`SECURITY.md`](SECURITY.md).
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md), [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md), and [docs/ENGINEERING.md](docs/ENGINEERING.md) before proposing substantial changes. Security vulnerabilities must not be reported through public issues; see [SECURITY.md](SECURITY.md).
+Перед существенным изменением прочитайте [`CONTRIBUTING.md`](CONTRIBUTING.md), [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) и [`docs/ENGINEERING.md`](docs/ENGINEERING.md).
 
 ## License
 
-This repository is public, but no open-source license has been selected yet. Unless and until a license is added, no additional license grant should be assumed.
+Репозиторий публичный, но open-source license пока не выбран. До появления `LICENSE` не следует предполагать дополнительное разрешение на использование, распространение или создание производных работ.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -4,92 +4,130 @@ Updated: 2026-08-09
 
 ## Project
 
-**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is: choose what to cook or buy, provide a location, and compare complete grocery baskets across supported nearby retailers using current price and availability data.
+**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is to turn a recipe, meal plan, or grocery list into a location-aware comparison of complete baskets using current retailer price and availability data.
 
-Repository: `True-Ruslan/zakup-gotov`
-Visibility: Public
-Current phase: **M0 — Product & Integration Discovery**
-Current execution stage: **M0A — Platform Foundation**
-Current task: **Task 6 — Observability and safe operational defaults**
+Repository: `True-Ruslan/zakup-gotov`  
+Visibility: Public  
+Current phase: **M0 — Product & Integration Discovery**  
+Current execution stage: **M0A — Platform Foundation**  
+Current focus: **repository hygiene, security/governance completion, then release engineering design implementation**
 
 ## Product status
 
-The project has a verified API, persistence baseline, contract/generated client, responsive web shell, and now a constrained operational-health surface. Retailer comparison itself is still intentionally unavailable until M0B proves real integrations.
+The platform foundation is executable and automatically verified, but the core retailer-comparison product is **not implemented yet**. The current web surface intentionally presents project status rather than fake store cards, prices, or comparison behavior.
 
-## Completed M0A work
+No retailer integration is considered supported until M0B proves it with acceptable technical/legal evidence and reproducible fixture/contract tests.
 
-- PR #1: approved product/architecture/engineering foundation, squash-merged.
-- PR #2 / Task 1: Java/Node/pnpm toolchains, monorepo workspace hygiene, ADR-0002, squash-merged.
-- PR #3 / Task 2: Java 25 + Spring Boot 4.1 API bootstrap, Maven Wrapper, architecture/context tests, API CI, squash-merged.
-- PR #4 / Task 3: PostgreSQL 18 + Flyway + jOOQ + Testcontainers persistence baseline, squash-merged.
-- PR #5 / Task 4: OpenAPI contract, tested system endpoint, generated TypeScript API client, Contract CI, squash-merged.
-- PR #6 / Task 5: responsive Next.js web shell with component + desktop/mobile browser tests and Web CI, squash-merged.
+## Completed and merged foundation work
 
-## Task 6 TDD evidence
+- PR #1 — product, architecture, engineering, security, contribution, state/roadmap, and planning foundation.
+- PR #2 / M0A Task 1 — Java/Node/pnpm toolchains and monorepo conventions.
+- PR #3 / Task 2 — Java 25 + Spring Boot 4.1 API bootstrap, Maven Wrapper, architecture/context verification, API CI.
+- PR #4 / Task 3 — PostgreSQL 18 + Flyway + jOOQ + real Testcontainers persistence baseline.
+- PR #5 / Task 4 — OpenAPI 3.1 contract, tested system endpoint, generated TypeScript client, Contract CI.
+- PR #6 / Task 5 — Next.js 16 / React 19 responsive web shell, component tests, desktop/mobile Playwright, Web CI.
+- PR #7 / Task 6 — constrained Actuator health/readiness surface, executable exposure guard, observability/privacy rules.
+- PR #9 / Task 8 — reproducible `./scripts/verify.sh`, `docs/DEVELOPMENT.md`, and verified clean-runner developer workflow.
 
-- A new `ActuatorSecurityTest` was written before changing production management configuration.
-- The test requires `/actuator/health`, `/actuator/info`, `/actuator/health/liveness`, and `/actuator/health/readiness` to be available while `/actuator/env`, `/actuator/configprops`, and `/actuator/metrics` remain HTTP-unavailable.
-- **Valid RED:** API CI run `31309354018`, job `93234641102` started the full Java 25/PostgreSQL 18.4 application and showed `/actuator/health` already returning `200 UP`, but `/actuator/info` returning `404`; the suite ended `Tests run: 5, Failures: 1` and `BUILD FAILURE` for exactly that expected contract gap.
-- Production configuration was then changed minimally: HTTP exposure only `health,info`, health probes enabled, health details/components hidden, and Spring MVC request-detail logging explicitly disabled.
-- `docs/OBSERVABILITY.md` documents vendor-neutral metric/trace vocabulary, low-cardinality rules, liveness/readiness semantics, and logging/redaction constraints for future provider work.
-- **GREEN:** API CI run `31309422819`, job `93234803394` shows `Exposing 2 endpoints beneath base path '/actuator'`, `ActuatorSecurityTest` PASS, total `5/5` tests PASS, and `BUILD SUCCESS`.
-- Sensitive management endpoints remain inaccessible because the executable test asserts their HTTP 404 behavior.
+Task 8 was completed before Task 7 because Task 7 is externally blocked by a GitHub repository security setting; independent verified work was not held back artificially.
 
-## Operational baseline
+## Verified platform baseline
 
-Public management HTTP surface:
+### Backend
+
+- Java 25;
+- Spring Boot 4.1;
+- Spring MVC + Virtual Threads;
+- Spring Modulith architecture verification;
+- PostgreSQL 18;
+- Flyway;
+- jOOQ;
+- Testcontainers with real PostgreSQL 18.4 in integration tests.
+
+### Contracts and clients
+
+- OpenAPI 3.1 source contract;
+- generated `@zakup-gotov/api-client`;
+- generated-schema drift gate;
+- strict TypeScript typechecking.
+
+### Web
+
+- Next.js 16.2;
+- React 19.2;
+- TypeScript;
+- Vitest + Testing Library;
+- Playwright production-browser coverage for desktop and mobile viewports.
+
+### Operations
+
+Public management HTTP surface is intentionally limited to:
 
 - `/actuator/health`;
 - `/actuator/health/liveness`;
 - `/actuator/health/readiness`;
 - `/actuator/info`.
 
-Explicitly not exposed over HTTP:
-
-- `/actuator/env`;
-- `/actuator/configprops`;
-- `/actuator/metrics`;
-- other management endpoints unless a future security review and test intentionally adds them.
-
-Request-detail logging is disabled. Raw provider payloads, credentials, authorization headers, tokens, precise user addresses, and arbitrary user input are not acceptable telemetry labels/log content by default.
-
-Reserved M0B/M1 metric vocabulary is documented in `docs/OBSERVABILITY.md`, including provider latency/errors/offer age, matching confidence, basket completeness, and basket compute duration.
+Environment, configuration-properties, and metrics Actuator endpoints remain HTTP-inaccessible. Request-detail logging is disabled by default. Provider credentials, raw payloads, authorization material, precise user addresses, and arbitrary user input must not become telemetry labels/log content by default.
 
 ## Current automated gates
 
-- `API CI`: Java 25, Maven Wrapper/Maven 3.9.16, PostgreSQL/Testcontainers, backend tests.
-- `Contract CI`: exact Node/pnpm, frozen install, generated OpenAPI drift check, strict TypeScript, Vitest, package build.
-- `Web CI`: frozen install, shared client build, lint, strict TypeScript, component tests, production build, desktop/mobile Playwright E2E.
+Merged and active on `main`:
+
+- **API CI** — Java 25, pinned Maven Wrapper/Maven 3.9.16, backend tests, PostgreSQL/Testcontainers;
+- **Contract CI** — exact Node/pnpm, frozen install, OpenAPI generation drift, typecheck, Vitest, build;
+- **Web CI** — frozen install, shared client build, lint, typecheck, component tests, production build;
+- **Web E2E** — Playwright against the production-built web app on desktop/mobile Chromium profiles;
+- local/clean-runner **`./scripts/verify.sh`** — unified backend/contract/web verification.
+
+PR #8 adds permanent CodeQL, Dependency Review, and Dependabot configuration. CodeQL has already passed for Java and JavaScript/TypeScript. Dependency Review is intentionally still red because GitHub reports Dependency Graph as unavailable/disabled for this repository; the workflow is not weakened to hide that configuration defect.
+
+## Current repository work
+
+- `chore/repository-hygiene` — public README/documentation cleanup, branch/workflow audit, repository-governance policy, support routing, and approved governance/release design documentation.
+- PR #8 / `ci/m0a-security-gates` — open and blocked only by repository Dependency Graph/security configuration.
+- Historical merged branches are safe to delete; future merged PR branches should be removed automatically through repository settings.
+
+No obsolete one-off generator/scaffold workflow remains on `main`; only recurring CI workflows are kept permanently.
 
 ## Approved engineering policy
 
-The project follows `docs/ENGINEERING.md`: TDD, evidence-before-claims, automation-first verification, clean Git/PR discipline, continuous changelog maintenance, and documentation synchronized with repository reality.
+[`ENGINEERING.md`](ENGINEERING.md) is mandatory repository policy:
 
-## Current repository state
+- TDD for executable behavior;
+- evidence before completion claims;
+- automation-first verification;
+- real integration dependencies when practical and deterministic;
+- short-lived branches and small PRs;
+- documentation/changelog synchronized with repository reality;
+- no silent security/test bypasses;
+- no retailer live calls in normal deterministic CI.
 
-- `main` contains completed M0A Tasks 1-5.
-- PR #7 contains verified Task 6 operational-observability work and is green pending the final documentation/current-head CI gate and squash merge.
-- Broader repository security/automation work remains Task 7: CodeQL, Dependency Review, Dependabot, and consolidation of required CI/security gates.
-- M0A plan: `docs/superpowers/plans/2026-08-09-m0a-platform-foundation.md`.
-- Execution mode is Inline Execution because independent subagent dispatch is not exposed in this chat; task/review gates remain mandatory.
-- No license decision has been made.
-- No external retailer integration has been proven yet.
+## Approved next platform direction
+
+Repository governance and release engineering direction is approved and documented in:
+
+- [`REPOSITORY_GOVERNANCE.md`](REPOSITORY_GOVERNANCE.md);
+- [`superpowers/specs/2026-08-09-repository-governance-and-release-design.md`](superpowers/specs/2026-08-09-repository-governance-and-release-design.md).
+
+The intended release experience is a ready Docker Compose bundle using prebuilt `web` and `api` GHCR images plus PostgreSQL, with multi-platform images, exact-bundle smoke tests, vulnerability scanning, SBOM, provenance/attestations, and immutable digests. This is **approved design, not implemented functionality yet**.
 
 ## Current critical unknowns
 
-1. Which Russian retailers expose a technically stable and legally acceptable path to location-specific catalog, price, and availability data?
-2. Can at least two providers be supported with sufficient freshness and reliability for a useful basket comparison?
-3. What address/location precision must be retained versus used transiently?
-4. How should delivery fees/minimum order constraints be obtained and normalized per retailer?
-5. What baseline matching accuracy is achievable with deterministic normalization/ranking before AI-assisted matching is justified?
+1. Which target retailers expose a technically stable and legally acceptable path to location-specific catalog, price, and availability data?
+2. Can at least two providers achieve useful basket coverage with acceptable freshness/reliability?
+3. What location precision must be used transiently and what, if anything, may be persisted?
+4. How can delivery fees/minimum order constraints be obtained and normalized per retailer?
+5. What deterministic product-matching quality is achievable before any AI-assisted stage is justified?
 
 ## Immediate next work
 
-1. Merge verified PR #7 / M0A Task 6.
-2. Execute Task 7 from updated `main`: add CodeQL, Dependency Review, Dependabot, and complete repository CI/security gates.
-3. Then establish one-command developer verification and reproducible development documentation in Task 8.
-4. Retailer-specific implementation waits for verified M0A and a separate M0B plan.
+1. Complete and merge repository-hygiene documentation after CI verification.
+2. Enable/verify required GitHub security settings so PR #8 Dependency Review becomes genuinely green, then merge PR #8.
+3. Activate repository merge/ruleset/security governance using the exact proven check names.
+4. Write and execute the implementation plan for the approved Docker/GHCR release-engineering design.
+5. Run final M0A verification and hand off to a separately planned M0B Retailer Feasibility phase.
 
 ## Definition of M0 success
 
-M0 is complete only when evidence shows that at least two retailer integrations can support a repeatable comparison flow for one supported city/location context, with automated fixtures/tests and documented legal/technical constraints.
+M0 is complete only when evidence proves at least two retailer integrations can support a repeatable location-specific comparison flow with reproducible fixtures/tests and documented technical/legal/freshness constraints.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# Documentation index
+
+This directory is the durable documentation entry point for Zakup Gotov. Documents have explicit responsibilities so plans, decisions, current state, and historical changes do not get mixed together.
+
+## Start here
+
+| Purpose | Document |
+|---|---|
+| Current factual state | [`PROJECT_STATE.md`](PROJECT_STATE.md) |
+| Product and engineering roadmap | [`ROADMAP.md`](ROADMAP.md) |
+| Local setup and verification | [`DEVELOPMENT.md`](DEVELOPMENT.md) |
+| Mandatory engineering policy | [`ENGINEERING.md`](ENGINEERING.md) |
+| Repository governance and security controls | [`REPOSITORY_GOVERNANCE.md`](REPOSITORY_GOVERNANCE.md) |
+| Operational telemetry and privacy baseline | [`OBSERVABILITY.md`](OBSERVABILITY.md) |
+
+Repository-level contributor/security/history files live at the root:
+
+- [`../README.md`](../README.md) — public project overview;
+- [`../CHANGELOG.md`](../CHANGELOG.md) — notable changes that actually happened;
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow;
+- [`../SECURITY.md`](../SECURITY.md) — vulnerability reporting and security policy;
+- [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) — collaboration expectations.
+
+## Architectural decisions
+
+Durable decisions live in [`adr/`](adr/).
+
+Current accepted foundation decisions include:
+
+- [`adr/0001-platform-stack.md`](adr/0001-platform-stack.md) — long-term platform stack;
+- [`adr/0002-build-tooling.md`](adr/0002-build-tooling.md) — repository build/toolchain conventions.
+
+An ADR records **why a durable decision was made**. It should not be used as a task tracker or current-state file.
+
+## Specifications
+
+Approved product/technical designs live in [`superpowers/specs/`](superpowers/specs/).
+
+Specifications define intended behavior and boundaries before implementation. Once approved, implementation should follow them or explicitly supersede them with a new decision.
+
+## Implementation plans
+
+Executable task breakdowns live in [`superpowers/plans/`](superpowers/plans/).
+
+Plans describe **how an approved specification will be implemented**. Completion claims still depend on current automated verification and `PROJECT_STATE.md`, not merely checked boxes in an old plan.
+
+## Documentation rules
+
+The repository follows these rules:
+
+1. `PROJECT_STATE.md` describes repository reality now.
+2. `ROADMAP.md` describes future milestones and exit criteria.
+3. ADRs describe durable architectural decisions.
+4. Specifications describe approved designs.
+5. Plans describe implementation sequencing.
+6. `CHANGELOG.md` records notable changes that actually happened.
+7. A PR that changes one of these truths updates the relevant document in the same PR.
+
+Stale documentation is treated as a defect. See [`ENGINEERING.md`](ENGINEERING.md) for the complete policy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Durable decisions live in [`adr/`](adr/).
 Current accepted foundation decisions include:
 
 - [`adr/0001-platform-stack.md`](adr/0001-platform-stack.md) — long-term platform stack;
-- [`adr/0002-build-tooling.md`](adr/0002-build-tooling.md) — repository build/toolchain conventions.
+- [`adr/0002-build-and-workspace-tooling.md`](adr/0002-build-and-workspace-tooling.md) — repository build/toolchain conventions.
 
 An ADR records **why a durable decision was made**. It should not be used as a task tracker or current-state file.
 

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -1,0 +1,131 @@
+# Repository Governance
+
+This document defines the intended GitHub repository controls for `True-Ruslan/zakup-gotov`. Git-tracked configuration and GitHub repository settings are both part of the engineering baseline.
+
+## Principles
+
+1. `main` is reviewed repository truth, not a development branch.
+2. Functional work happens in short-lived branches and merges through pull requests.
+3. Required checks are based on real successful check names, never guessed strings.
+4. Security checks are not disabled merely to make a pull request green.
+5. Repository settings should minimize accidental privilege, irreversible history changes, and supply-chain risk.
+6. Rules remain practical for a single-maintainer project; controls that require a second human are introduced only when another maintainer exists.
+
+## Merge policy
+
+Target repository settings:
+
+- squash merge: enabled;
+- merge commits: disabled;
+- rebase merge: disabled;
+- automatic head-branch deletion after merge: enabled;
+- auto-merge: enabled;
+- update-branch button: enabled;
+- default branch: `main`.
+
+This gives a linear target history while preserving rich development history in pull requests.
+
+## `main` ruleset
+
+Target rules for `main`:
+
+- changes require a pull request;
+- linear history is required;
+- force pushes are blocked;
+- branch deletion is blocked;
+- unresolved review conversations block merge;
+- required status checks must pass;
+- no mandatory second-human approval while the project has one maintainer;
+- administrators should normally follow the same rules rather than silently bypass them.
+
+Required checks are activated only after they have completed successfully at least once in the repository. Current/target check families are:
+
+- `API CI`;
+- `Contract CI`;
+- `Web CI`;
+- `Web E2E`;
+- CodeQL Java;
+- CodeQL JavaScript/TypeScript;
+- `Dependency Review` once GitHub Dependency Graph is operational;
+- future container/release checks after their workflows are proven.
+
+## Branch lifecycle
+
+Long-lived branches are avoided. Normally the repository should contain:
+
+- `main`;
+- active pull-request branches only.
+
+After a pull request is squash-merged, its source branch should be deleted automatically. Historical context remains in the pull request and target history.
+
+## GitHub Actions policy
+
+Permanent workflows must solve a recurring repository need. One-off generators/scaffold workflows are deleted immediately after the generated artifact is committed and independently verified.
+
+Default workflow permissions should be read-only. A workflow receives write permissions only for the smallest explicit capability needed by that workflow.
+
+Third-party and GitHub-owned actions should ultimately be pinned by full commit SHA in permanent security-sensitive workflows. Dependabot for `github-actions` keeps those pins reviewable and current.
+
+Do not grant workflows permission to approve pull requests.
+
+## Security features
+
+Target security baseline for this public repository:
+
+- Dependency Graph;
+- Dependabot alerts;
+- Dependabot security updates;
+- Dependabot version updates;
+- CodeQL code scanning;
+- Dependency Review on pull requests;
+- secret scanning;
+- push protection;
+- Private Vulnerability Reporting;
+- GitHub Security Advisories for coordinated fixes.
+
+A known security gate that cannot execute because a repository setting is disabled is a repository defect, not a reason to weaken the workflow.
+
+## Issues and community files
+
+The repository tracks:
+
+- structured bug reports;
+- structured feature requests;
+- public contribution rules;
+- security disclosure policy;
+- Code of Conduct;
+- CODEOWNERS;
+- pull request quality template.
+
+Security vulnerabilities must not be filed as public issues.
+
+GitHub Discussions, Wiki, Projects, sponsorship/funding, and CITATION metadata are intentionally not enabled merely to maximize feature count. They should be enabled only when the project has a real workflow that benefits from them.
+
+## License
+
+Repository visibility and software licensing are separate decisions. The repository is public but currently has no open-source license. A license will be added only after the project owner deliberately chooses the intended reuse/distribution model.
+
+## Releases and packages
+
+The approved next release-engineering direction is:
+
+- versioned GitHub Releases;
+- prebuilt `api` and `web` OCI images published to GitHub Container Registry;
+- multi-platform `linux/amd64` and `linux/arm64` images;
+- a release Compose bundle that starts `web + api + PostgreSQL` without local builds;
+- release verification against the exact container set that users will run;
+- vulnerability scanning, SBOM, provenance/attestation, and immutable image digests;
+- prereleases do not update the stable `latest` tag.
+
+This design is specified separately before implementation and is not considered implemented merely because it is documented here.
+
+## Audit cadence
+
+Repository governance should be reviewed when any of the following changes:
+
+- a new required workflow/check is introduced;
+- another maintainer joins;
+- releases begin;
+- secrets/provider credentials are introduced;
+- GitHub changes available security controls;
+- a security incident or CI bypass reveals a policy gap.

--- a/docs/superpowers/specs/2026-08-09-repository-governance-and-release-design.md
+++ b/docs/superpowers/specs/2026-08-09-repository-governance-and-release-design.md
@@ -1,0 +1,232 @@
+# Repository Governance and Release Engineering Design
+
+**Status:** Approved
+**Approved:** 2026-08-09
+
+## Purpose
+
+Define the durable repository-governance, supply-chain-security, container-packaging, and release-distribution model for Zakup Gotov before release engineering is implemented.
+
+This specification complements the platform foundation. It does not itself make a release or claim container support exists.
+
+## Goals
+
+- keep the public repository understandable, auditable, and difficult to modify accidentally;
+- use GitHub-native security controls where they provide concrete value;
+- keep permanent GitHub Actions minimal, reproducible, and least-privileged;
+- make every future application release directly testable without requiring users to install Java, Node.js, pnpm, Maven, or PostgreSQL;
+- publish the exact container artifacts that CI has verified;
+- support both common x86-64 hosts and ARM64/Apple-Silicon Docker hosts;
+- preserve an architecture that can later serve web, Android, and iOS clients without moving retailer secrets or core integration logic into clients.
+
+## Non-goals
+
+- Kubernetes or another orchestrator;
+- microservices;
+- a separate external container registry;
+- continuous deployment to production infrastructure;
+- making every GitHub feature active regardless of need;
+- moving retailer integration logic to browsers merely to avoid backend work.
+
+## Repository governance
+
+`main` is protected repository truth.
+
+Target policy:
+
+- pull-request-only changes;
+- squash-only merge policy;
+- linear history;
+- automatic deletion of merged source branches;
+- blocked force pushes and deletion of `main`;
+- required resolution of review conversations;
+- required automated checks based on check names observed successfully in real runs;
+- no mandatory second-human approval while there is only one maintainer;
+- no silent security-check bypasses.
+
+Only `main` and active PR branches should normally exist.
+
+## GitHub Actions security
+
+Permanent workflows must:
+
+- default to `contents: read` or narrower permissions;
+- request write permissions explicitly and only for the required job/action;
+- avoid persistent credentials when they are unnecessary;
+- use reproducible/frozen dependency resolution;
+- converge on full-commit-SHA action pinning for immutable action code;
+- remain covered by Dependabot GitHub Actions updates;
+- never gain pull-request approval permission by default.
+
+One-off scaffolding/generation workflows must be removed immediately after their output is committed and independently verified.
+
+## GitHub security baseline
+
+Enable all repository controls that materially reduce risk:
+
+- Dependency Graph;
+- Dependabot alerts;
+- Dependabot security updates;
+- Dependabot version updates;
+- CodeQL for Java and JavaScript/TypeScript;
+- Dependency Review;
+- secret scanning;
+- push protection;
+- Private Vulnerability Reporting;
+- GitHub Security Advisories.
+
+A check blocked by repository configuration is treated as an actionable repository defect. It must not be made conditional merely to obtain a green PR.
+
+## Release unit
+
+A release is a tested application bundle composed of three services:
+
+```text
+web -> api -> PostgreSQL
+```
+
+The user-facing release experience is one Docker Compose project, not one oversized physical container.
+
+The web and API images are built in CI and published to GHCR. PostgreSQL uses an official version-pinned upstream image with a persistent named volume.
+
+## Release images
+
+Publish:
+
+```text
+ghcr.io/true-ruslan/zakup-gotov-api:<version>
+ghcr.io/true-ruslan/zakup-gotov-web:<version>
+```
+
+Each application image must support:
+
+- `linux/amd64`;
+- `linux/arm64`.
+
+Stable releases may additionally update `latest`. Prereleases must never move `latest`.
+
+Every published release remains addressable by immutable OCI digest even when convenient semantic tags exist.
+
+## Release trigger
+
+The authoritative stable/prerelease packaging flow is triggered by a published GitHub Release, not by arbitrary pushes or unreviewed tags.
+
+A separate explicitly manual workflow may build/test snapshot images for maintainers when a full versioned release is unnecessary.
+
+## Release verification sequence
+
+A release workflow performs, in order:
+
+1. verify release/tag/version consistency;
+2. run the complete repository verification baseline;
+3. run responsive browser verification;
+4. run GitHub-native security/dependency gates required for release;
+5. build API and web images;
+6. scan built images for actionable vulnerabilities;
+7. produce SBOM and build provenance/attestation;
+8. publish multi-platform images to GHCR;
+9. resolve immutable image digests;
+10. generate a release-specific Compose file pinned to those digests;
+11. start the exact Compose bundle in CI;
+12. wait for PostgreSQL and API readiness rather than only process start;
+13. smoke-test API and web through their released container boundaries;
+14. attach the tested Compose bundle and relevant verification metadata to the GitHub Release.
+
+An image that merely builds is not release-ready.
+
+## Compose contract
+
+The release Compose file must:
+
+- require no local source build;
+- contain no committed real secrets;
+- use a persistent PostgreSQL volume;
+- declare explicit health/readiness dependencies;
+- expose a predictable local web port;
+- wire web to API through the Compose network/runtime configuration;
+- use application images by immutable digest for a specific release bundle;
+- document clean start, stop, update, and data-removal commands.
+
+Expected user flow:
+
+```bash
+docker compose -f compose.release.yaml pull
+docker compose -f compose.release.yaml up -d
+```
+
+The exact file name/ports may be refined during implementation without changing the architectural contract.
+
+## Supply-chain evidence
+
+For release application images, produce and retain:
+
+- OCI digest;
+- SBOM;
+- provenance/build attestation;
+- vulnerability-scan result;
+- source repository/commit identity;
+- tested release Compose bundle.
+
+Security exceptions must be explicit, narrow, time-bounded where possible, and documented. Global ignore lists are not acceptable as a default strategy.
+
+## Client/backend retailer-integration policy
+
+The authoritative retailer-integration path remains backend-side:
+
+```text
+Web / Mobile -> Zakup Gotov API -> GroceryProvider -> retailer
+```
+
+Reasons:
+
+- credentials and partner tokens remain server-side;
+- normalization/rate limiting/retry/freshness policies remain centralized;
+- web and future mobile clients share the same product behavior;
+- fixture/contract testing remains deterministic;
+- retailer-specific response models do not leak into client code.
+
+A client-side provider path is permitted only as an explicit provider-specific exception when all relevant conditions are satisfied, such as:
+
+- no secret or privileged credential is required;
+- browser/mobile direct use is permitted by the provider;
+- CORS or equivalent platform access is supported;
+- the interaction genuinely depends on a user-owned browser/session context;
+- privacy/security implications are documented;
+- the provider still conforms to a clear product-domain contract rather than spreading retailer-specific logic through UI code.
+
+M0B must evaluate integration feasibility per retailer rather than assuming one transport model applies to all providers.
+
+## Test philosophy
+
+Release engineering follows the existing project policy:
+
+- executable behavior is developed test-first when a meaningful behavioral RED/GREEN cycle exists;
+- configuration is validated by automated execution rather than YAML inspection alone;
+- Dockerfiles and Compose definitions must be exercised by CI;
+- release smoke tests run against the exact built/published artifact set;
+- repeated manual release acceptance is automation debt;
+- manual checks remain only for genuinely non-deterministic or visual concerns that cannot be automated reliably.
+
+## Documentation contract
+
+When release engineering is implemented, update together:
+
+- `README.md` quick start;
+- `docs/DEVELOPMENT.md` developer/container workflows;
+- `docs/REPOSITORY_GOVERNANCE.md` required checks/settings;
+- `SECURITY.md` supply-chain/security support policy;
+- `docs/PROJECT_STATE.md` factual completion state;
+- `CHANGELOG.md` under `[Unreleased]` and later versioned release sections;
+- release/runbook documentation.
+
+## Acceptance criteria
+
+This design is implemented only when evidence proves that:
+
+- repository protections/security features are actually active or documented as platform-limited;
+- permanent CI is least-privileged and security checks are green;
+- a versioned release can publish verified multi-platform API/web images;
+- an external user can start the complete application from a release Compose bundle without building source;
+- CI starts and tests the exact released Compose bundle;
+- artifacts carry digest, SBOM, vulnerability result, and provenance/attestation evidence;
+- stable and prerelease tagging semantics cannot accidentally replace one another.


### PR DESCRIPTION
## Problem

The repository foundation is strong, but the public entry points and repository metadata/documentation need a hygiene pass before release-engineering work. `PROJECT_STATE.md` also still described already-merged work as pending, and historical merged branches remain on the remote.

## Solution

- restructure README around product value, honest implementation status, CI badges, quick verification, architecture, security, and a compact documentation map;
- add `docs/README.md` as the documentation index;
- add `docs/REPOSITORY_GOVERNANCE.md` for merge/branch/Actions/security/release-governance policy;
- add `.github/SUPPORT.md` and route the issue chooser to support/security guidance;
- record the already approved repository-governance + Docker/GHCR release design as an Approved specification;
- rewrite `PROJECT_STATE.md` as a durable factual snapshot rather than a stale per-task diary;
- synchronize `CHANGELOG.md`;
- audit branches/workflows and document the exact cleanup/settings that must be performed through repository-admin APIs.

## Repository audit findings

- permanent `main` workflows are only API CI, Contract CI, and Web CI; prior one-off generator/scaffold workflows had already been deleted after use, so no recurring workflow is being removed merely for cosmetic reasons;
- remote branches currently include historical merged branches plus active work; only `main`, active PR branches, and this hygiene branch should remain after cleanup;
- PR #8 security gates remains intentionally blocked by GitHub reporting Dependency Graph unavailable/disabled; this PR does not weaken that check.

## Verification

This PR changes documentation/community metadata only. Before merge, links/files are reviewed against repository contents and the branch/base diff will be checked for unrelated application changes. Existing application CI remains authoritative for executable code; no application behavior is changed.

## Security / privacy

No credentials, private endpoints, provider payloads, or user data are introduced. Governance documentation strengthens least-privilege Actions, security-feature expectations, and confidential vulnerability routing.

## Scope / non-goals

This PR does not implement release Docker images, GHCR publishing, rulesets, repository admin settings, retailer integrations, or client-side provider execution. Those remain separate verified steps.