### PR TITLE
ci: harden recurring repository gates

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -2,33 +2,34 @@ name: API CI
 
 on:
   pull_request:
-    paths:
-      - "apps/api/**"
-      - ".github/workflows/api-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "apps/api/**"
-      - ".github/workflows/api-ci.yml"
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify:
     name: API CI
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: apps/api
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Java 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "25"
@@ -44,5 +45,5 @@ jobs:
           java -version 2>&1 | grep -Eq 'version "25([.\"])'
           ./mvnw --version | grep -F 'Apache Maven 3.9.16'
 
-      - name: Run API tests
-        run: ./mvnw --batch-mode --no-transfer-progress test
+      - name: Run API verification
+        run: ./mvnw --batch-mode --no-transfer-progress verify

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -2,39 +2,30 @@ name: Contract CI
 
 on:
   pull_request:
-    paths:
-      - "openapi/**"
-      - "packages/api-client/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - ".nvmrc"
-      - ".github/workflows/contract-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "openapi/**"
-      - "packages/api-client/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - ".nvmrc"
-      - ".github/workflows/contract-ci.yml"
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify:
     name: Contract CI
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,27 +2,9 @@ name: Web CI
 
 on:
   pull_request:
-    paths:
-      - "apps/web/**"
-      - "packages/api-client/**"
-      - "openapi/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - ".nvmrc"
-      - ".github/workflows/web-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "apps/web/**"
-      - "packages/api-client/**"
-      - "openapi/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - ".nvmrc"
-      - ".github/workflows/web-ci.yml"
 
 permissions:
   contents: read
@@ -30,16 +12,23 @@ permissions:
 env:
   NEXT_TELEMETRY_DISABLED: "1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     name: Web CI
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
 
@@ -56,7 +45,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore Next.js build cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: apps/web/.next/cache
           key: ${{ runner.os }}-next-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**', 'apps/web/next.config.*', 'apps/web/postcss.config.*', 'apps/web/tsconfig.json') }}
@@ -82,12 +71,15 @@ jobs:
     name: Web E2E
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
 
@@ -98,7 +90,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore Next.js build cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: apps/web/.next/cache
           key: ${{ runner.os }}-next-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**', 'apps/web/next.config.*', 'apps/web/postcss.config.*', 'apps/web/tsconfig.json') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - `docs/REPOSITORY_GOVERNANCE.md` defining merge, branch, Actions, security-feature, and future release-governance policy.
 - `.github/SUPPORT.md` routing bugs, proposals, contributions, and confidential security reports to appropriate channels.
 - Approved repository-governance and Docker/GHCR release-engineering specification, including multi-platform images, Compose distribution, supply-chain evidence, and backend-first provider policy.
+- Repository-hardening implementation plan covering deterministic required checks, immutable Actions, GitHub-native security, rulesets, branch cleanup, and social-preview handoff.
 
 ### Changed
 
@@ -67,6 +68,9 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Public README was reorganized around product value, honest implementation status, CI visibility, quick verification, architecture, security, and a compact documentation map.
 - `PROJECT_STATE.md` was converted from a stale task diary into a factual snapshot of merged work, open blockers, verified gates, and next actions.
 - Repository branch lifecycle now explicitly keeps only `main` plus active pull-request branches; merged source branches are treated as disposable after squash merge.
+- API CI, Contract CI, Web CI, and Web E2E now run predictably on every pull request so future required-check rules cannot deadlock on path-filtered workflows.
+- API CI now runs Maven `verify` instead of only `test`, aligning the required backend gate with packaged-build verification.
+- Recurring workflows now cancel superseded runs for the same PR/ref and have finite job timeouts.
 
 ### Fixed
 
@@ -75,6 +79,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Corrected the initial web-test dependency updater to operate from the root pnpm workspace after local-directory installation could not resolve the shared workspace protocol package.
 - Removed an unused-variable lint warning from the initial component test rather than accepting warning noise.
 - Corrected `PROJECT_STATE.md` references that still described already-merged PR #7 and the pre-Task-8 repository state as current.
+- Removed the future protected-branch deadlock risk caused by path-filtered required-check candidates.
 
 ### Security
 
@@ -82,4 +87,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Production database credentials are required through external environment configuration and are not stored in source control.
 - Contract CI and Web CI use read-only repository permissions and verify the lockfile through pnpm's supply-chain policy check during frozen installation.
 - Actuator environment/configuration/metrics endpoints remain unavailable over public HTTP, and request logging defaults are restricted to reduce accidental credential/location leakage.
-- Repository governance now explicitly requires least-privilege Actions, no silent security-check bypasses, Dependency Graph/Dependabot/CodeQL/Dependency Review/secret scanning/push protection/PVR where available, and convergence on immutable full-SHA action pins.
+- Repository governance now explicitly requires least-privilege Actions, no silent security-check bypasses, Dependency Graph/Dependabot/CodeQL/Dependency Review/secret scanning/push protection/PVR where available, and immutable full-SHA action pins.
+- Permanent API/Contract/Web Actions are pinned to full commit SHAs verified from successful repository runs instead of mutable major tags.
+- Read-only checkout steps disable persisted Git credentials after source retrieval.
+- PR #8 CodeQL and Dependency Review workflows were likewise hardened with full-SHA pins, non-persisted checkout credentials, concurrency control, and finite timeouts while preserving the real Dependency Graph blocker.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A — Platform Foundation**  
-Current focus: **repository hygiene, security/governance completion, then release engineering design implementation**
+Current focus: **repository CI/security hardening and GitHub governance before release-engineering implementation**
 
 ## Product status
 
@@ -28,6 +28,7 @@ No retailer integration is considered supported until M0B proves it with accepta
 - PR #6 / Task 5 — Next.js 16 / React 19 responsive web shell, component tests, desktop/mobile Playwright, Web CI.
 - PR #7 / Task 6 — constrained Actuator health/readiness surface, executable exposure guard, observability/privacy rules.
 - PR #9 / Task 8 — reproducible `./scripts/verify.sh`, `docs/DEVELOPMENT.md`, and verified clean-runner developer workflow.
+- PR #10 — public README/documentation index, repository-governance policy, support routing, branch/workflow audit, factual state cleanup, and approved governance/release design.
 
 Task 8 was completed before Task 7 because Task 7 is externally blocked by a GitHub repository security setting; independent verified work was not held back artificially.
 
@@ -72,7 +73,7 @@ Environment, configuration-properties, and metrics Actuator endpoints remain HTT
 
 ## Current automated gates
 
-Merged and active on `main`:
+Merged baseline:
 
 - **API CI** — Java 25, pinned Maven Wrapper/Maven 3.9.16, backend tests, PostgreSQL/Testcontainers;
 - **Contract CI** — exact Node/pnpm, frozen install, OpenAPI generation drift, typecheck, Vitest, build;
@@ -80,15 +81,35 @@ Merged and active on `main`:
 - **Web E2E** — Playwright against the production-built web app on desktop/mobile Chromium profiles;
 - local/clean-runner **`./scripts/verify.sh`** — unified backend/contract/web verification.
 
-PR #8 adds permanent CodeQL, Dependency Review, and Dependabot configuration. CodeQL has already passed for Java and JavaScript/TypeScript. Dependency Review is intentionally still red because GitHub reports Dependency Graph as unavailable/disabled for this repository; the workflow is not weakened to hide that configuration defect.
+PR #11 (`ci/repository-hardening`) hardens these recurring checks before they become ruleset requirements:
 
-## Current repository work
+- removes PR path filters so all four required-check candidates are emitted on every pull request;
+- pins permanent checkout/setup/cache Actions to full commit SHA verified from actual repository runs;
+- sets `persist-credentials: false` on read-only checkouts;
+- adds finite job timeouts and cancellation of superseded runs;
+- upgrades API CI from Maven `test` to Maven `verify`.
 
-- `chore/repository-hygiene` — public README/documentation cleanup, branch/workflow audit, repository-governance policy, support routing, and approved governance/release design documentation.
-- PR #8 / `ci/m0a-security-gates` — open and blocked only by repository Dependency Graph/security configuration.
+Initial PR #11 verification is GREEN:
+
+- API CI run `31312678179`: Java 25.0.3, Maven 3.9.16, PostgreSQL 18.4/Testcontainers, `5/5` tests, packaged JAR, `BUILD SUCCESS`;
+- Contract CI run `31312678120`: generated contract drift/typecheck/test/build GREEN;
+- Web CI run `31312678133`: Web CI GREEN and Web E2E GREEN.
+
+Logs explicitly confirm full-SHA action resolution and `persist-credentials: false`. A final current-head run is required after this documentation synchronization before PR #11 can merge.
+
+## Security gates in progress
+
+PR #8 (`ci/m0a-security-gates`) adds permanent CodeQL, Dependency Review, and Dependabot configuration.
+
+- CodeQL previously passed for Java and JavaScript/TypeScript.
+- CodeQL and Dependency Review workflows have now also been hardened with immutable action SHAs, non-persisted checkout credentials, concurrency, and finite timeouts.
+- Dependency Review remains intentionally blocked because GitHub reports Dependency Graph as unavailable/disabled for this repository. The check is not weakened or skipped to hide that configuration defect.
+
+## Repository hygiene
+
+- No obsolete one-off generator/scaffold workflow remains on `main`; only recurring CI workflows are kept permanently.
 - Historical merged branches are safe to delete; future merged PR branches should be removed automatically through repository settings.
-
-No obsolete one-off generator/scaffold workflow remains on `main`; only recurring CI workflows are kept permanently.
+- The desired branch steady state is `main` plus active pull-request branches only.
 
 ## Approved engineering policy
 
@@ -108,7 +129,8 @@ No obsolete one-off generator/scaffold workflow remains on `main`; only recurrin
 Repository governance and release engineering direction is approved and documented in:
 
 - [`REPOSITORY_GOVERNANCE.md`](REPOSITORY_GOVERNANCE.md);
-- [`superpowers/specs/2026-08-09-repository-governance-and-release-design.md`](superpowers/specs/2026-08-09-repository-governance-and-release-design.md).
+- [`superpowers/specs/2026-08-09-repository-governance-and-release-design.md`](superpowers/specs/2026-08-09-repository-governance-and-release-design.md);
+- [`superpowers/plans/2026-08-09-repository-hardening.md`](superpowers/plans/2026-08-09-repository-hardening.md).
 
 The intended release experience is a ready Docker Compose bundle using prebuilt `web` and `api` GHCR images plus PostgreSQL, with multi-platform images, exact-bundle smoke tests, vulnerability scanning, SBOM, provenance/attestations, and immutable digests. This is **approved design, not implemented functionality yet**.
 
@@ -122,11 +144,12 @@ The intended release experience is a ready Docker Compose bundle using prebuilt 
 
 ## Immediate next work
 
-1. Complete and merge repository-hygiene documentation after CI verification.
-2. Enable/verify required GitHub security settings so PR #8 Dependency Review becomes genuinely green, then merge PR #8.
-3. Activate repository merge/ruleset/security governance using the exact proven check names.
-4. Write and execute the implementation plan for the approved Docker/GHCR release-engineering design.
-5. Run final M0A verification and hand off to a separately planned M0B Retailer Feasibility phase.
+1. Complete final current-head verification and merge PR #11.
+2. Enable/verify GitHub Dependency Graph and security settings so PR #8 Dependency Review becomes genuinely green, then merge PR #8.
+3. Activate repository merge/ruleset/Actions/security governance using the exact proven check names and remove historical merged branches.
+4. Generate and upload the repository Social Preview asset.
+5. Write and execute the separate implementation plan for the approved Docker/GHCR release-engineering subsystem.
+6. Run final M0A verification and hand off to a separately planned M0B Retailer Feasibility phase.
 
 ## Definition of M0 success
 

--- a/docs/superpowers/plans/2026-08-09-repository-hardening.md
+++ b/docs/superpowers/plans/2026-08-09-repository-hardening.md
@@ -1,0 +1,191 @@
+# Repository Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GitHub Actions and repository governance safe enough to become enforced `main` gates without creating missing-check deadlocks or weakening existing verification.
+
+**Architecture:** Keep existing API, Contract, Web, and Web E2E checks as independent recurring gates, but make their PR presence deterministic and their action dependencies immutable. Complete GitHub-native security gates separately in PR #8, then activate repository-admin settings/rulesets only after every required check name has been observed green.
+
+**Tech Stack:** GitHub Actions, GitHub Rulesets, GitHub Advanced Security features available to public repositories, Dependabot, CodeQL, Dependency Review, `gh api` for repository-admin settings not exposed by the connected GitHub app.
+
+## Global Constraints
+
+- Do not weaken a failing security check merely to obtain GREEN.
+- Permanent actions are pinned to full commit SHA; comments retain the human-readable major tag.
+- Permanent verification workflows use read-only token permissions unless a job has a documented write requirement.
+- `actions/checkout` does not persist credentials in read-only workflows.
+- Required PR checks must be emitted predictably on every pull request before a ruleset requires them.
+- Normal CI remains deterministic and never performs live retailer requests.
+- Documentation and `[Unreleased]` changelog stay synchronized with actual repository state.
+
+---
+
+### Task 1: Harden recurring CI and make required-check presence deterministic
+
+**Files:**
+- Modify: `.github/workflows/api-ci.yml`
+- Modify: `.github/workflows/contract-ci.yml`
+- Modify: `.github/workflows/web-ci.yml`
+- Modify: `docs/PROJECT_STATE.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces stable PR checks: `API CI`, `Contract CI`, `Web CI`, `Web E2E`.
+- Uses immutable action SHAs observed from actual successful repository runs.
+
+- [ ] **Step 1: Remove PR path filters from the three recurring workflows**
+
+Every pull request must emit the same check names before these checks become ruleset requirements. Push-to-main execution may also remain unconditional for simplicity and repository-wide regression confidence at the current project size.
+
+- [ ] **Step 2: Pin permanent actions by full commit SHA**
+
+Use the SHAs verified from actual GitHub Actions runs:
+
+```text
+actions/checkout@v6    d23441a48e516b6c34aea4fa41551a30e30af803
+actions/setup-java@v5  b6effb05e454b25005698d916606bdc6ffcbf961
+actions/setup-node@v6  249970729cb0ef3589644e2896645e5dc5ba9c38
+actions/cache@v5       caa296126883cff596d87d8935842f9db880ef25
+```
+
+Workflow syntax should retain comments such as `# v6` so Dependabot/reviewers can identify the intended release line.
+
+- [ ] **Step 3: Disable persisted checkout credentials**
+
+For every read-only checkout:
+
+```yaml
+with:
+  persist-credentials: false
+```
+
+- [ ] **Step 4: Strengthen runtime behavior**
+
+Add a workflow-level `concurrency` group that cancels superseded runs for the same PR/ref and finite job `timeout-minutes`. Change API CI from Maven `test` to `verify` so its required check matches the repository's one-command verification semantics.
+
+- [ ] **Step 5: Open a draft PR and observe all four checks**
+
+Expected: the documentation/workflow PR itself emits `API CI`, `Contract CI`, `Web CI`, and `Web E2E`, proving no required-check deadlock exists for non-application changes.
+
+- [ ] **Step 6: Inspect actual logs**
+
+Expected: action downloads resolve to exactly the pinned SHAs, checkout shows `persist-credentials: false`, backend uses Java 25/PostgreSQL Testcontainers and Maven `verify`, and all four checks finish GREEN.
+
+- [ ] **Step 7: Synchronize state/changelog and squash-merge**
+
+Only merge after the current PR head has all four checks green.
+
+---
+
+### Task 2: Harden PR #8 security workflows and complete GitHub-native security gates
+
+**Files (branch `ci/m0a-security-gates` / PR #8):**
+- Modify: `.github/workflows/codeql.yml`
+- Modify: `.github/workflows/dependency-review.yml`
+- Modify: `.github/dependabot.yml` only if validation reveals a concrete issue
+- Modify: `docs/PROJECT_STATE.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces stable checks: `CodeQL / Java`, `CodeQL / JavaScript-TypeScript`, `Dependency Review`.
+
+- [ ] **Step 1: Pin security workflow actions to verified full SHAs**
+
+Use repository-run evidence:
+
+```text
+actions/checkout@v6                d23441a48e516b6c34aea4fa41551a30e30af803
+github/codeql-action@v4            5595ccaf912efad79be6eef63a5619ff05969be3
+actions/dependency-review-action@v4 2031cfc080254a8a887f58cffee85186f0e49e48
+```
+
+Set checkout `persist-credentials: false`.
+
+- [ ] **Step 2: Enable repository Dependency Graph/security prerequisites through repository-admin settings**
+
+Do not change the workflow to skip. Re-run the existing failed Dependency Review job only after the repository setting is enabled.
+
+- [ ] **Step 3: Verify security checks on the current PR head**
+
+Expected: CodeQL Java GREEN, CodeQL JavaScript/TypeScript GREEN, Dependency Review GREEN.
+
+- [ ] **Step 4: Synchronize docs/changelog and squash-merge PR #8**
+
+Task is incomplete while Dependency Review is red for any reason.
+
+---
+
+### Task 3: Activate repository-admin governance after exact checks are proven
+
+**Files:**
+- Modify documentation only if observed GitHub behavior differs from `docs/REPOSITORY_GOVERNANCE.md`.
+
+**Interfaces:**
+- Consumes exact successful check names from Tasks 1-2.
+- Produces merge policy, Actions default permissions, security toggles, topics, automatic branch cleanup, and an active `main` ruleset.
+
+- [ ] **Step 1: Configure repository metadata and merge policy with `gh api`**
+
+Target: issues on, wiki/projects off until needed, squash-only, auto-merge on, delete merged branches, update-branch support, concise repository description/topics.
+
+- [ ] **Step 2: Set Actions token defaults**
+
+Set `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`.
+
+- [ ] **Step 3: Enable security features**
+
+Enable Dependabot alerts/security updates, secret scanning, push protection, and Private Vulnerability Reporting where GitHub accepts them for the public repository. Dependency Graph must be operational because Dependency Review has already proven the dependency.
+
+- [ ] **Step 4: Create active `main` ruleset**
+
+Require pull requests, linear history, resolved conversations, block deletion/non-fast-forward, and require the exact seven proven checks:
+
+```text
+API CI
+Contract CI
+Web CI
+Web E2E
+CodeQL / Java
+CodeQL / JavaScript-TypeScript
+Dependency Review
+```
+
+Do not require a second-human approval while the repository has one maintainer.
+
+- [ ] **Step 5: Delete historical merged branches**
+
+Keep only `main` plus active pull-request branches. Verify the branch list afterwards.
+
+- [ ] **Step 6: Re-open a harmless docs PR or use the next real PR to prove ruleset behavior**
+
+Expected: direct merge cannot bypass required checks, all required checks appear, and squash merge remains possible after GREEN.
+
+---
+
+### Task 4: Prepare social-preview handoff
+
+**Files:**
+- No repository source file is required unless the owner chooses to retain brand assets under `docs/assets/` later.
+
+**Interfaces:**
+- Produces a GitHub Social Preview asset and exact manual upload path because GitHub does not expose this setting through the connected repository toolset.
+
+- [ ] **Step 1: Generate a simple product mark/social-preview asset**
+
+Design direction: grocery basket + check/price signal, minimal geometry, no small text, high contrast, readable when reduced, neutral modern consumer-tech character.
+
+- [ ] **Step 2: Owner uploads it in GitHub repository Settings → General → Social preview**
+
+Do not claim the preview is configured until GitHub shows it on the repository page/share preview.
+
+---
+
+## Self-review results
+
+- **Spec coverage:** repository hygiene, least-privilege Actions, immutable pins, deterministic required checks, GitHub-native security, ruleset/merge policy, branch lifecycle, and social-preview handoff are covered. Docker/GHCR release implementation is intentionally a separate plan because it is an independent executable subsystem.
+- **Placeholder scan:** no TODO/TBD implementation placeholders remain.
+- **Check consistency:** required-check names match existing workflow job names and observed CodeQL/Dependency Review job names.
+
+## Completion gate
+
+Repository hardening is complete only when recurring CI and security workflows are green with immutable action pins, GitHub security/admin settings are active, `main` ruleset protects the exact proven checks without path-filter deadlocks, merged branches are cleaned, and repository state/changelog describe the observed result rather than the intended configuration.


### PR DESCRIPTION
## Problem

The repository is about to enforce required status checks on `main`, but the recurring workflows were path-filtered. Requiring those checks would deadlock unrelated/documentation PRs because GitHub would wait for checks that never ran. Permanent actions also used mutable major tags and checkout persisted credentials even though these workflows are read-only.

## Solution

- make API CI, Contract CI, Web CI, and Web E2E run predictably on every pull request and `main` push;
- pin checkout/setup/cache actions to full commit SHA observed from successful repository runs;
- set `persist-credentials: false` on all read-only checkout steps;
- add finite job timeouts and concurrency cancellation for superseded PR/ref runs;
- strengthen API CI from Maven `test` to Maven `verify`;
- record the complete hardening sequence in `docs/superpowers/plans/2026-08-09-repository-hardening.md`;
- synchronize `PROJECT_STATE.md` and `CHANGELOG.md`.

## Verification evidence

### Initial GREEN

- API CI run `31312678179`: Java 25.0.3, Maven 3.9.16, PostgreSQL 18.4/Testcontainers, `5/5` tests, packaged JAR, `BUILD SUCCESS`.
- Contract CI run `31312678120`: generated schema drift, typecheck, Vitest, and package build all GREEN.
- Web CI run `31312678133`: Web CI GREEN and Web E2E GREEN.

The PR itself is CI/docs-only, so these runs prove the removed path filters emit all future required-check candidates even for non-application changes.

Actual logs confirm action downloads resolve to the exact pinned SHAs and checkout receives `persist-credentials: false`.

### Final current-head GREEN

After state/changelog synchronization on head `681ce645ac40a64af0e075780e7ae93b40f7bcff`:

- API CI run `31312813577` — success;
- Contract CI run `31312813583` — success;
- Web CI run `31312813580` — `Web CI` success and `Web E2E` success.

## Security

All permanent workflows remain `contents: read`; no new secret/write permission is introduced. Full-SHA action pinning follows GitHub immutable-action guidance, and checkout credentials are removed immediately after source retrieval.

## Scope / non-goals

This PR does not yet activate the `main` ruleset or repository-admin security toggles. Those occur only after PR #8 Dependency Review is genuinely green and all exact check names are proven.