### PR TITLE
feat(release): publish verified versioned container releases

### DIFF
--- a/.github/workflows/release-contract-ci.yml
+++ b/.github/workflows/release-contract-ci.yml
@@ -24,5 +24,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Parse release workflow YAML
+        run: ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' .github/workflows/release.yml
+
       - name: Verify release semantics
         run: python3 -m unittest discover -s scripts/release -p 'test_*.py' -v

--- a/.github/workflows/release-contract-ci.yml
+++ b/.github/workflows/release-contract-ci.yml
@@ -25,7 +25,9 @@ jobs:
           persist-credentials: false
 
       - name: Parse release workflow YAML
-        run: ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' .github/workflows/release.yml
+        run: |
+          ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' \
+            .github/workflows/release.yml
 
       - name: Verify release semantics
         run: python3 -m unittest discover -s scripts/release -p 'test_*.py' -v

--- a/.github/workflows/release-contract-ci.yml
+++ b/.github/workflows/release-contract-ci.yml
@@ -1,0 +1,28 @@
+name: Release Contract CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Release Contract CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify release semantics
+        run: python3 -m unittest discover -s scripts/release -p 'test_*.py' -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,24 +291,24 @@ jobs:
       - name: Verify staging candidate bundle
         run: bash scripts/release/verify-published-release.sh dist/compose.candidate.yaml
 
-      - name: Promote verified digests to release version
+      - name: Copy verified digests into final packages
         run: |
           set -euo pipefail
 
           docker buildx imagetools create \
-            --tag "${{ steps.release.outputs.api_image }}:${{ steps.release.outputs.version_tag }}" \
-            --metadata-file dist/api-promotion.json \
+            --tag "${{ steps.release.outputs.api_verified_candidate }}" \
+            --metadata-file dist/api-final-copy.json \
             "${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}"
 
           docker buildx imagetools create \
-            --tag "${{ steps.release.outputs.web_image }}:${{ steps.release.outputs.version_tag }}" \
-            --metadata-file dist/web-promotion.json \
+            --tag "${{ steps.release.outputs.web_verified_candidate }}" \
+            --metadata-file dist/web-final-copy.json \
             "${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}"
 
-          test "$(jq -r '."containerimage.descriptor".digest' dist/api-promotion.json)" = "${{ steps.api-build.outputs.digest }}"
-          test "$(jq -r '."containerimage.descriptor".digest' dist/web-promotion.json)" = "${{ steps.web-build.outputs.digest }}"
+          test "$(jq -r '."containerimage.descriptor".digest' dist/api-final-copy.json)" = "${{ steps.api-build.outputs.digest }}"
+          test "$(jq -r '."containerimage.descriptor".digest' dist/web-final-copy.json)" = "${{ steps.web-build.outputs.digest }}"
 
-      - name: Render digest-pinned release Compose
+      - name: Render digest-pinned final-package Compose
         run: |
           set -euo pipefail
           python3 scripts/release/release_contract.py render-compose \
@@ -317,7 +317,7 @@ jobs:
             --api-ref "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}" \
             --web-ref "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
 
-      - name: Verify exact promoted release bundle
+      - name: Verify exact final-package candidate bundle
         run: bash scripts/release/verify-published-release.sh dist/compose.release.yaml
 
       - name: Attest final API provenance
@@ -333,6 +333,23 @@ jobs:
           subject-name: ${{ steps.release.outputs.web_image }}
           subject-digest: ${{ steps.web-build.outputs.digest }}
           push-to-registry: true
+
+      - name: Promote verified final digests to release version
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.api_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/api-promotion.json \
+            "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}"
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.web_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/web-promotion.json \
+            "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
+
+          test "$(jq -r '."containerimage.descriptor".digest' dist/api-promotion.json)" = "${{ steps.api-build.outputs.digest }}"
+          test "$(jq -r '."containerimage.descriptor".digest' dist/web-promotion.json)" = "${{ steps.web-build.outputs.digest }}"
 
       - name: Promote stable release to latest
         if: steps.release.outputs.publish_latest == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,396 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  DOCKER_BUILDKIT: "1"
+
+jobs:
+  verify:
+    name: Release / Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Validate release metadata
+        run: |
+          set -euo pipefail
+          python3 scripts/release/release_contract.py metadata \
+            --tag "${{ github.event.release.tag_name }}" \
+            --prerelease "${{ github.event.release.prerelease }}" \
+            --commit-sha "${GITHUB_SHA}" \
+            --owner "${{ github.repository_owner }}" \
+            --repository "${{ github.event.repository.name }}"
+
+      - name: Require release commit on main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Set up Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install pinned pnpm
+        run: npm install --global pnpm@11.4.0
+
+      - name: Verify pinned toolchain
+        run: |
+          set -euo pipefail
+          java -version
+          node --version
+          pnpm --version
+          test "$(node --version)" = "v24.18.1"
+          test "$(pnpm --version)" = "11.4.0"
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+
+      - name: Run repository verification
+        run: ./scripts/verify.sh
+
+      - name: Install Chromium
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Build shared API client
+        run: pnpm --filter @zakup-gotov/api-client build
+
+      - name: Build production web app
+        run: NEXT_TELEMETRY_DISABLED=1 pnpm --filter web build
+
+      - name: Run responsive browser tests
+        run: pnpm --filter web test:e2e
+
+      - name: Verify production container bundle
+        run: ./scripts/verify-release-bundle.sh
+
+  publish:
+    name: Release / Publish
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve release metadata
+        id: release
+        run: |
+          set -euo pipefail
+          python3 scripts/release/release_contract.py metadata \
+            --tag "${{ github.event.release.tag_name }}" \
+            --prerelease "${{ github.event.release.prerelease }}" \
+            --commit-sha "${GITHUB_SHA}" \
+            --owner "${{ github.repository_owner }}" \
+            --repository "${{ github.event.repository.name }}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          image: tonistiigi/binfmt@sha256:465d3fdd28d0f2b871ba4b4ec98bd183292e96167f00d9fd40bd249f8632d705
+          platforms: arm64
+          cache-image: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: |
+            image=moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
+
+      - name: Prepare release evidence directory
+        run: mkdir -p dist
+
+      - name: Build and push API candidate
+        id: api-build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.release.outputs.api_candidate }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=release-api
+          cache-to: type=gha,mode=max,scope=release-api
+
+      - name: Build and push web candidate
+        id: web-build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.release.outputs.web_candidate }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=release-web
+          cache-to: type=gha,mode=max,scope=release-web
+
+      - name: Scan API candidate for HIGH/CRITICAL vulnerabilities on amd64
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          format: json
+          output: dist/api-amd64-vulnerabilities.json
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          scanners: vuln
+
+      - name: Scan API candidate for HIGH/CRITICAL vulnerabilities on arm64
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          format: json
+          output: dist/api-arm64-vulnerabilities.json
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          scanners: vuln
+
+      - name: Scan web candidate for HIGH/CRITICAL vulnerabilities on amd64
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          format: json
+          output: dist/web-amd64-vulnerabilities.json
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          scanners: vuln
+
+      - name: Scan web candidate for HIGH/CRITICAL vulnerabilities on arm64
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          format: json
+          output: dist/web-arm64-vulnerabilities.json
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          scanners: vuln
+
+      - name: Generate API amd64 SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          format: spdx-json
+          output: dist/api-amd64-sbom.spdx.json
+          exit-code: "0"
+
+      - name: Generate API arm64 SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          format: spdx-json
+          output: dist/api-arm64-sbom.spdx.json
+          exit-code: "0"
+
+      - name: Generate web amd64 SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/amd64
+        with:
+          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          format: spdx-json
+          output: dist/web-amd64-sbom.spdx.json
+          exit-code: "0"
+
+      - name: Generate web arm64 SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          format: spdx-json
+          output: dist/web-arm64-sbom.spdx.json
+          exit-code: "0"
+
+      - name: Render digest-pinned release Compose
+        run: |
+          set -euo pipefail
+          python3 scripts/release/release_contract.py render-compose \
+            --input compose.release.yaml \
+            --output dist/compose.release.yaml \
+            --api-ref "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}" \
+            --web-ref "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
+
+      - name: Verify exact published candidate bundle
+        run: bash scripts/release/verify-published-release.sh dist/compose.release.yaml
+
+      - name: Attest API candidate provenance
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ steps.release.outputs.api_image }}
+          subject-digest: ${{ steps.api-build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest web candidate provenance
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ steps.release.outputs.web_image }}
+          subject-digest: ${{ steps.web-build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Promote verified digests to release version
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.api_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/api-promotion.json \
+            "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}"
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.web_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/web-promotion.json \
+            "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
+
+          test "$(jq -r '."containerimage.descriptor".digest' dist/api-promotion.json)" = "${{ steps.api-build.outputs.digest }}"
+          test "$(jq -r '."containerimage.descriptor".digest' dist/web-promotion.json)" = "${{ steps.web-build.outputs.digest }}"
+
+      - name: Promote stable release to latest
+        if: steps.release.outputs.publish_latest == 'true'
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.api_image }}:latest" \
+            "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}"
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.web_image }}:latest" \
+            "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
+
+      - name: Capture published manifests
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect \
+            "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}" \
+            --raw > dist/api-manifest.json
+          docker buildx imagetools inspect \
+            "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}" \
+            --raw > dist/web-manifest.json
+
+          for manifest in dist/api-manifest.json dist/web-manifest.json; do
+            jq -e '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length >= 1' "$manifest" >/dev/null
+            jq -e '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length >= 1' "$manifest" >/dev/null
+          done
+
+      - name: Write release verification metadata
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg version "${{ steps.release.outputs.version }}" \
+            --arg source_sha "${GITHUB_SHA}" \
+            --arg stable "${{ steps.release.outputs.stable }}" \
+            --arg api_image "${{ steps.release.outputs.api_image }}" \
+            --arg api_digest "${{ steps.api-build.outputs.digest }}" \
+            --arg web_image "${{ steps.release.outputs.web_image }}" \
+            --arg web_digest "${{ steps.web-build.outputs.digest }}" \
+            --arg workflow_run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              version: $version,
+              source_sha: $source_sha,
+              stable: ($stable == "true"),
+              platforms: ["linux/amd64", "linux/arm64"],
+              vulnerability_gate: "CRITICAL,HIGH",
+              api: {image: $api_image, digest: $api_digest},
+              web: {image: $web_image, digest: $web_digest},
+              workflow_run: $workflow_run
+            }' > dist/release-verification.json
+
+          sha256sum \
+            dist/compose.release.yaml \
+            dist/release-verification.json \
+            dist/api-manifest.json \
+            dist/web-manifest.json \
+            dist/*-vulnerabilities.json \
+            dist/*-sbom.spdx.json \
+            > dist/SHA256SUMS
+
+      - name: Attach verified release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/compose.release.yaml \
+            dist/release-verification.json \
+            dist/SHA256SUMS \
+            dist/api-manifest.json \
+            dist/web-manifest.json \
+            dist/*-vulnerabilities.json \
+            dist/*-sbom.spdx.json \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}
           format: json
           output: dist/api-amd64-vulnerabilities.json
           severity: CRITICAL,HIGH
@@ -196,7 +196,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/arm64
         with:
-          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}
           format: json
           output: dist/api-arm64-vulnerabilities.json
           severity: CRITICAL,HIGH
@@ -210,7 +210,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: json
           output: dist/web-amd64-vulnerabilities.json
           severity: CRITICAL,HIGH
@@ -224,7 +224,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/arm64
         with:
-          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: json
           output: dist/web-arm64-vulnerabilities.json
           severity: CRITICAL,HIGH
@@ -238,7 +238,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}
           format: spdx-json
           output: dist/api-amd64-sbom.spdx.json
           exit-code: "0"
@@ -250,7 +250,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/arm64
         with:
-          image-ref: ${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}
           format: spdx-json
           output: dist/api-arm64-sbom.spdx.json
           exit-code: "0"
@@ -262,7 +262,7 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: spdx-json
           output: dist/web-amd64-sbom.spdx.json
           exit-code: "0"
@@ -274,10 +274,39 @@ jobs:
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/arm64
         with:
-          image-ref: ${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}
+          image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: spdx-json
           output: dist/web-arm64-sbom.spdx.json
           exit-code: "0"
+
+      - name: Render staging candidate Compose
+        run: |
+          set -euo pipefail
+          python3 scripts/release/release_contract.py render-compose \
+            --input compose.release.yaml \
+            --output dist/compose.candidate.yaml \
+            --api-ref "${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}" \
+            --web-ref "${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}"
+
+      - name: Verify staging candidate bundle
+        run: bash scripts/release/verify-published-release.sh dist/compose.candidate.yaml
+
+      - name: Promote verified digests to release version
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.api_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/api-promotion.json \
+            "${{ steps.release.outputs.api_staging_image }}@${{ steps.api-build.outputs.digest }}"
+
+          docker buildx imagetools create \
+            --tag "${{ steps.release.outputs.web_image }}:${{ steps.release.outputs.version_tag }}" \
+            --metadata-file dist/web-promotion.json \
+            "${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}"
+
+          test "$(jq -r '."containerimage.descriptor".digest' dist/api-promotion.json)" = "${{ steps.api-build.outputs.digest }}"
+          test "$(jq -r '."containerimage.descriptor".digest' dist/web-promotion.json)" = "${{ steps.web-build.outputs.digest }}"
 
       - name: Render digest-pinned release Compose
         run: |
@@ -288,39 +317,22 @@ jobs:
             --api-ref "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}" \
             --web-ref "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
 
-      - name: Verify exact published candidate bundle
+      - name: Verify exact promoted release bundle
         run: bash scripts/release/verify-published-release.sh dist/compose.release.yaml
 
-      - name: Attest API candidate provenance
+      - name: Attest final API provenance
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ steps.release.outputs.api_image }}
           subject-digest: ${{ steps.api-build.outputs.digest }}
           push-to-registry: true
 
-      - name: Attest web candidate provenance
+      - name: Attest final web provenance
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ steps.release.outputs.web_image }}
           subject-digest: ${{ steps.web-build.outputs.digest }}
           push-to-registry: true
-
-      - name: Promote verified digests to release version
-        run: |
-          set -euo pipefail
-
-          docker buildx imagetools create \
-            --tag "${{ steps.release.outputs.api_image }}:${{ steps.release.outputs.version_tag }}" \
-            --metadata-file dist/api-promotion.json \
-            "${{ steps.release.outputs.api_image }}@${{ steps.api-build.outputs.digest }}"
-
-          docker buildx imagetools create \
-            --tag "${{ steps.release.outputs.web_image }}:${{ steps.release.outputs.version_tag }}" \
-            --metadata-file dist/web-promotion.json \
-            "${{ steps.release.outputs.web_image }}@${{ steps.web-build.outputs.digest }}"
-
-          test "$(jq -r '."containerimage.descriptor".digest' dist/api-promotion.json)" = "${{ steps.api-build.outputs.digest }}"
-          test "$(jq -r '."containerimage.descriptor".digest' dist/web-promotion.json)" = "${{ steps.web-build.outputs.digest }}"
 
       - name: Promote stable release to latest
         if: steps.release.outputs.publish_latest == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,10 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Production multi-stage Docker images for the Java API and Next.js standalone web runtime, both running as non-root users.
 - `compose.release.yaml` no-source-build production topology for PostgreSQL 18.4 → API → web with persistent database storage and health/readiness dependencies.
 - `Release Bundle CI` and `./scripts/verify-release-bundle.sh`, which build both application images, start the complete container topology, wait for health, smoke-test API/web boundaries, and emit Compose diagnostics on failure.
-- `docs/RELEASES.md` documenting the verified container bundle and explicitly separating it from the still-pending versioned GHCR publication workflow.
+- `docs/RELEASES.md` documenting the verified container bundle and explicitly separating it from the versioned GHCR publication workflow.
+- `Release Contract CI` and `scripts/release/release_contract.py`, providing read-only PR verification for strict SemVer/prerelease rules, lower-case GHCR names, digest-only release Compose rendering, immutable release dependencies, and release-workflow trust ordering.
+- `scripts/release/verify-published-release.sh`, which rejects mutable/local-build release Compose files and smoke-tests the exact digest-pinned images pulled from the registry.
+- Versioned `release: published` workflow implementing source verification, `linux/amd64` + `linux/arm64` GHCR candidate builds, per-platform Trivy vulnerability gates and SPDX SBOMs, exact-digest Compose smoke verification, GitHub attestations, no-rebuild digest promotion, stable-only `latest`, manifest verification, checksums, and GitHub Release evidence assets.
 
 ### Changed
 
@@ -87,6 +90,9 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Next.js production output now uses standalone mode with monorepo tracing configured so the runtime image contains only the server/runtime artifacts needed by the web container.
 - The release Compose topology publishes only the web port by default; API and PostgreSQL remain on the internal Compose network, while web health verifies real API reachability through runtime `API_BASE_URL`.
 - Container-bundle verification is a distinct gate from source/unit/build verification so a healthy source build cannot mask broken Docker/Compose behavior.
+- Versioned release publication now uses candidate image digests as the security boundary: scan, SBOM, exact-bundle smoke verification, and attestation happen before version-tag promotion, and promotion copies the verified image index without rebuild.
+- Stable and prerelease semantics are explicit: a GitHub prerelease must use a SemVer prerelease tag and can never update `latest`; stable releases may update `latest` only after the same verification path succeeds.
+- Release verification is intentionally split between read-only PR contract tests and the write-capable release-event workflow so package/OIDC permissions are never granted to ordinary pull-request CI.
 
 ### Fixed
 
@@ -119,4 +125,6 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Default GitHub Actions workflow token permissions are read-only and workflows cannot approve pull requests.
 - No dependency update was allowed to weaken the pnpm minimum-release-age policy, required status checks, CodeQL, Dependency Review, contract generation, linting, or browser verification in order to become mergeable.
 - Application container runtimes use non-root users, Compose requires the database password at runtime instead of committing one, and only the web service is host-published by default.
-- `Release Bundle CI` remains read-only; future GHCR/package and attestation write permissions are reserved for a separate versioned release workflow rather than broadening ordinary pull-request CI.
+- `Release Bundle CI` and `Release Contract CI` remain read-only; package and OIDC write permissions exist only on the downstream release-publish job after read-only release verification succeeds.
+- Release Docker/GitHub Actions are pinned to full commit SHAs, and the QEMU binfmt and BuildKit helper images are additionally pinned by digest to avoid mutable helper-image drift.
+- Both target image architectures are scanned for `HIGH` and `CRITICAL` vulnerabilities before version promotion, and release consumers are bound to immutable application-image digests through the attached Compose asset.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,22 @@ The repository uses GitHub-native Dependency Review, Dependabot, secret scanning
 
 Production container topology is exercised by `Release Bundle CI` with read-only repository permissions. The release Compose file requires externally supplied application-image references and a database password; it contains no real committed secret and publishes only the web service to the host by default.
 
-Versioned public release publishing is intentionally a separate trust boundary. When implemented, only that release workflow may receive the narrowly required package/attestation write permissions. It must produce immutable application-image digests, vulnerability-scan results, SBOM, source/build provenance or equivalent attestations, and a tested release-specific Compose bundle before a release is considered consumable.
+Versioned publishing is a separate trust boundary:
 
-Do not weaken required checks, dependency freshness policy, vulnerability thresholds, or image verification merely to make a release publish. Any security exception must be explicit, narrow, justified, and reviewable.
+- ordinary pull-request and source-verification workflows remain read-only;
+- `Release / Verify` remains read-only and reruns source, browser, and container verification for the tagged commit;
+- only `Release / Publish`, after verification succeeds, receives the narrowly scoped `contents: write`, `packages: write`, `attestations: write`, and `id-token: write` permissions needed for release publication;
+- Docker/GitHub Actions in the release path use immutable full commit SHAs;
+- QEMU binfmt and BuildKit helper images are pinned by digest rather than mutable helper tags;
+- candidate application images are built before public version-tag promotion;
+- both `linux/amd64` and `linux/arm64` variants are scanned for `HIGH` and `CRITICAL` vulnerabilities before promotion;
+- the exact candidate digests are rendered into Compose and smoke-tested before promotion;
+- version tags are created from the already verified digests without rebuild;
+- prereleases are contractually prevented from updating `latest`;
+- BuildKit/GitHub provenance and SBOM/scan evidence are retained with the release.
+
+The versioned workflow is implemented and statically/TDD verified in pull-request CI, but its registry/OIDC behavior is not considered proven until the first real published prerelease succeeds.
+
+GHCR publication does not by itself prove anonymous public pull access. Package visibility must be verified explicitly after first publication before documentation promises a publicly consumable image.
+
+Do not weaken required checks, dependency freshness policy, vulnerability thresholds, image verification, provenance/attestation requirements, or exact-digest smoke tests merely to make a release publish. Any security exception must be explicit, narrow, justified, and reviewable.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A — Platform Foundation**  
-Current focus: **finish versioned GHCR/supply-chain release publishing and final M0A verification, then enter M0B retailer feasibility**
+Current focus: **runtime-validate the versioned release pipeline with a prerelease, finish repository/release gates, then enter M0B retailer feasibility**
 
 ## Product status
 
@@ -18,7 +18,7 @@ The platform foundation is executable and automatically verified. The core retai
 
 No retailer integration is considered supported until M0B proves it with acceptable technical/legal evidence and reproducible fixture/contract tests.
 
-## Completed and merged foundation work
+## Completed foundation work
 
 - PR #1 — product, architecture, engineering, security, contribution, state/roadmap, and planning foundation.
 - PR #2 / M0A Task 1 — Java/Node/pnpm toolchains and monorepo conventions.
@@ -37,6 +37,7 @@ No retailer integration is considered supported until M0B proves it with accepta
 - PR #23 — consolidated `actions/setup-node` 7.0.0 and `dependency-review-action` 5.0.0 maintenance with corrected immutable-pin annotations and full CI/security verification.
 - PR #15 — CI-verified web dependency maintenance to Next.js 16.3.0, React/React DOM 19.2.8, and `eslint-config-next` 16.3.0.
 - PR #25 — production API/web Docker images, Next.js standalone runtime, PostgreSQL 18.4-compatible no-source-build Compose topology, and executable `Release Bundle CI` smoke verification.
+- PR #26 — versioned-release contract and release workflow implementation: strict SemVer/prerelease semantics, multi-platform GHCR candidates, per-platform vulnerability scans/SBOMs, immutable digest rendering, exact-published-bundle smoke verification, attestations, no-rebuild promotion, release assets, and stable-only `latest` policy. The workflow implementation is PR-verified but still requires its first real `release: published` runtime execution after merge.
 
 ## Verified platform baseline
 
@@ -83,28 +84,29 @@ Production container baseline:
 - separate multi-stage API and web Dockerfiles;
 - non-root runtime users for both application images;
 - `compose.release.yaml` contains no local source `build:` directives;
-- PostgreSQL 18.4 uses a persistent named volume at the PostgreSQL 18-compatible `/var/lib/postgresql` path;
+- PostgreSQL 18.4 uses a persistent named volume at `/var/lib/postgresql`;
 - PostgreSQL health gates API startup, API readiness gates web startup;
 - web health verifies both its own HTTP surface and API reachability over `API_BASE_URL` on the Compose network;
 - only the web service publishes a host port by default; API remains internal to the Compose network;
 - failures in release-bundle verification automatically emit Compose status/log diagnostics before cleanup.
 
-## Automated gates on `main`
+## Automated verification
 
-- **API CI** — Java 25, pinned Maven Wrapper/Maven 3.9.16, PostgreSQL/Testcontainers, backend tests, packaged JAR via Maven `verify`;
-- **Contract CI** — exact Node/pnpm, frozen install, OpenAPI generation drift, typecheck, Vitest, build;
-- **Web CI** — frozen install, shared client build, lint, typecheck, component tests, production build;
-- **Web E2E** — Playwright against the production-built web app on desktop/mobile Chromium profiles;
+PR/main checks currently available:
+
+- **API CI**;
+- **Contract CI**;
+- **Web CI**;
+- **Web E2E**;
 - **CodeQL / Java**;
 - **CodeQL / JavaScript-TypeScript**;
 - **Dependency Review**;
-- **Release Bundle CI** — builds production API/web images, validates Compose, starts PostgreSQL → API → web, waits for health/readiness, smoke-tests API inside its container boundary and the public web surface;
-- local/clean-runner **`./scripts/verify.sh`** — unified backend/contract/web verification;
-- local/CI **`./scripts/verify-release-bundle.sh`** — exact production-container topology verification.
+- **Release Bundle CI** — builds production API/web images and smoke-tests the complete PostgreSQL → API → web topology;
+- **Release Contract CI** — read-only verification of release SemVer/prerelease semantics, digest-only Compose rendering, immutable action/helper pins, release-workflow YAML syntax, and build/scan/smoke/attest/promotion ordering;
+- local/clean-runner **`./scripts/verify.sh`**;
+- local/CI **`./scripts/verify-release-bundle.sh`**.
 
-Recurring CI Actions are pinned to immutable full commit SHAs where introduced by the project, use non-persisted checkout credentials for read-only jobs, have finite timeouts, and cancel superseded PR/ref runs. The current maintenance baseline includes `actions/cache` 6.1.0, `actions/checkout` 7.0.1, `actions/setup-node` 7.0.0, and `dependency-review-action` 5.0.0.
-
-`Release Bundle CI` is proven green but is not yet independently verified as part of the `main` required-check ruleset. The currently verified ruleset still enforces the original seven CI/security checks.
+The currently independently verified `main` ruleset still enforces the original seven CI/security checks. `Release Bundle CI` and `Release Contract CI` are proven check candidates but are not yet independently verified as required ruleset checks.
 
 ## Repository governance and security state
 
@@ -114,55 +116,65 @@ Verified repository-admin baseline:
 - auto-merge and update-branch enabled;
 - merged source branches are deleted automatically;
 - only `main` plus active PR branches are retained;
-- `main` merge protection actively requires the seven previously proven CI/security checks, and stale/missing required checks block merge;
+- stale/missing required checks block `main` merge;
 - default workflow token permissions are read-only and Actions cannot approve pull requests;
 - Dependency Graph enabled and SBOM endpoint available;
 - Dependabot alerts/security updates enabled;
 - secret scanning enabled;
 - secret scanning push protection enabled;
 - private vulnerability reporting enabled;
-- CodeQL and Dependency Review are operational and green after Dependency Graph enablement.
+- CodeQL and Dependency Review operational.
 
-Required-check enforcement was exercised during dependency maintenance rather than inferred from configuration: direct merge attempts were rejected until the candidate was refreshed against current `main` and all required checks had passed. `Release Bundle CI` should be added to the ruleset only after its successful check name is applied and the resulting repository setting is independently verified.
+The versioned release workflow intentionally separates permissions:
+
+- `Release / Verify` uses read-only repository access;
+- only `Release / Publish`, after verification, receives `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
+- ordinary PR CI never receives registry-publish or OIDC release permissions;
+- Docker/GitHub Actions are pinned to full commit SHAs;
+- QEMU binfmt and BuildKit helper images used by release publishing are also digest-pinned.
 
 ## Dependency maintenance state
 
 The first Dependabot maintenance cycle was intentionally triaged rather than blindly merged:
 
-- compatible Actions updates were verified and merged through PRs #19, #20, and #23;
-- compatible Next.js/React maintenance was refreshed against current `main`, passed the full required gate including production Web E2E, and merged through PR #15;
-- the older Next.js 16.2.11 PR #13 was closed as superseded after `main` advanced to 16.3.0;
-- TypeScript 7.0.2 remains intentionally deferred because CI proved `openapi-typescript` 7.13.0 is incompatible with it;
-- ESLint 10 remains intentionally deferred because the current web lint configuration fails under that major line;
-- `@types/node` 26 remains intentionally deferred while the repository runtime is pinned to Node 24.
+- compatible Actions updates were verified and merged;
+- compatible Next.js/React maintenance was refreshed against current `main` and passed full CI including production Web E2E;
+- TypeScript 7.0.2 remains deferred because `openapi-typescript` 7.13.0 is incompatible with it;
+- ESLint 10 remains deferred because the current web lint configuration fails under that major line;
+- `@types/node` 26 remains deferred while the repository runtime is pinned to Node 24.
 
 No required test, supply-chain, or security gate was weakened to make an automated dependency update pass.
 
 ## Release-engineering state
 
-The first release-engineering slice is now executable and verified:
+### Runtime-proven
 
-- Dockerfiles are exercised by CI rather than reviewed statically;
-- the no-source-build Compose topology is exercised end-to-end;
-- a TDD RED run failed on the intentionally missing API Dockerfile before implementation;
-- the first implementation run exposed the PostgreSQL 18 data-layout change and failed because the volume used the pre-18 path;
-- the Compose volume was corrected to `/var/lib/postgresql` according to the PostgreSQL 18 image layout;
-- subsequent runs proved PostgreSQL, API, and web become healthy in dependency order;
-- final GREEN keeps API internal to Compose while web health proves actual web → API network connectivity.
+- production API/web Docker images build successfully;
+- PostgreSQL 18.4 → API → web Compose startup is automated and green;
+- API remains internal while web is host-published;
+- exact local production topology smoke verification is green;
+- PostgreSQL 18 volume-layout compatibility is covered by real Compose execution.
 
-This does **not** yet satisfy the complete public release design. Still pending:
+### Implemented and PR-verified, awaiting first release event
 
-- published GitHub Release trigger;
-- GHCR publication;
-- `linux/amd64` + `linux/arm64` application images;
-- vulnerability scanning of release images;
-- SBOM and provenance/attestation evidence;
-- immutable digest resolution;
-- generated release-specific Compose pinned to application-image digests;
-- smoke verification of the exact published artifact set;
-- release asset attachment and stable/prerelease `latest` semantics.
+- authoritative trigger: published GitHub Release;
+- release commit must be contained in `main`;
+- strict SemVer + GitHub prerelease flag validation;
+- prereleases never move `latest`;
+- multi-platform `linux/amd64` + `linux/arm64` API/web candidate indexes;
+- BuildKit provenance and SBOM attestations;
+- per-platform `HIGH`/`CRITICAL` Trivy vulnerability gates;
+- per-platform SPDX JSON SBOM release evidence;
+- release-specific Compose rendered from exact GHCR digests;
+- authenticated pull and smoke test of the exact published candidate digests;
+- GitHub provenance attestations pushed for the verified image digests;
+- no-rebuild digest promotion via `docker buildx imagetools create`;
+- manifest verification for amd64/arm64;
+- release verification JSON, manifests, scans, SBOMs, checksums, and digest-pinned Compose attached as GitHub Release assets.
 
-See [`RELEASES.md`](RELEASES.md) for the current verified boundary.
+A real `release: published` run is still required before these publishing claims move from implementation evidence to runtime evidence. GHCR package visibility must also be checked after first publication; a public source repository alone is not treated as proof of anonymous image pullability.
+
+See [`RELEASES.md`](RELEASES.md).
 
 ## Approved engineering policy
 
@@ -187,10 +199,11 @@ See [`RELEASES.md`](RELEASES.md) for the current verified boundary.
 
 ## Immediate next work
 
-1. Implement the versioned GitHub Release → GHCR publishing subsystem with multi-platform API/web images, vulnerability scanning, SBOM/provenance/attestations, immutable digest resolution, release-specific Compose generation, exact-published-bundle smoke tests, release assets, and stable/prerelease semantics.
-2. Add the proven `Release Bundle CI` check to the `main` ruleset and independently verify the ruleset change; verify any narrowly scoped release-workflow permissions without broadening the default read-only Actions baseline.
-3. Run final M0A verification across repository checks and the exact distributable published Compose bundle.
-4. Hand off to a separately planned M0B Retailer Feasibility phase.
+1. Merge the versioned-release implementation only after final PR verification/change review.
+2. Publish a first **prerelease** (not stable) to exercise the real release workflow; verify multi-platform GHCR digests, scans, attestations, attached evidence, exact digest-pinned Compose smoke test, and confirm that `latest` is untouched.
+3. Verify GHCR package visibility and make the intended public-consumption policy explicit; do not claim anonymous availability before it is proven.
+4. Add `Release Bundle CI` and `Release Contract CI` to the `main` ruleset when the settings API/UI change can be applied and independently verified.
+5. Run final M0A verification, then hand off to separately planned M0B Retailer Feasibility.
 
 ## Definition of M0 success
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,10 +1,10 @@
 # Releases
 
-Zakup Gotov is still **pre-release**. This document separates the container bundle that is already verified in CI from the versioned GHCR release pipeline that is still being implemented.
+Zakup Gotov is still **pre-release**. The production container topology is already exercised in normal CI; the versioned GHCR publishing workflow is now implemented but is not considered runtime-proven until a real published prerelease completes successfully.
 
 ## Verified container bundle
 
-The repository now has an executable production-container baseline:
+The repository has an executable production-container baseline:
 
 - `apps/api/Dockerfile` builds the Spring Boot API and runs it as a non-root user;
 - `apps/web/Dockerfile` builds the Next.js standalone server and runs it as a non-root user;
@@ -16,28 +16,75 @@ The repository now has an executable production-container baseline:
 - `Release Bundle CI` builds both application images, starts the complete bundle, waits for health, smoke-tests API readiness inside the API container, and verifies the public web page;
 - failing bundle verification prints Compose status and logs before cleanup.
 
-This proves the production container topology and startup contract. It does **not** mean a versioned public release is available yet.
-
-## Local release-bundle verification
-
-Prerequisite: a running Docker daemon with Docker Compose v2.
-
-Run the same executable contract as CI:
+Run the same executable contract locally with a running Docker daemon and Docker Compose v2:
 
 ```bash
 ./scripts/verify-release-bundle.sh
 ```
 
-The script builds disposable local images named `zakup-gotov-api:ci` and `zakup-gotov-web:ci`, starts the Compose project with a test-only password, verifies it, and removes its containers and disposable test volume on exit.
+## Versioned release contract
 
-To use custom local image names:
+The repository now contains two separate layers for versioned releases.
 
-```bash
-API_IMAGE=my-api:test \
-WEB_IMAGE=my-web:test \
-POSTGRES_PASSWORD='local-only-password' \
-./scripts/verify-release-bundle.sh
+### Read-only release contract
+
+`Release Contract CI` runs on ordinary pull requests with only `contents: read`. It verifies:
+
+- strict release tags in the form `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-prerelease`;
+- consistency between SemVer prerelease state and the GitHub Release `prerelease` flag;
+- prereleases can never publish the `latest` tag;
+- repository-scoped GHCR image names are normalized to lowercase;
+- application images in a release-specific Compose file must be GHCR references pinned by `sha256` digest;
+- the release workflow uses immutable full-SHA action pins;
+- QEMU and BuildKit helper images are themselves digest-pinned;
+- candidate build, vulnerability scan, exact-bundle smoke verification, attestation, promotion, and release-asset upload remain in the approved trust order;
+- `release.yml` remains syntactically parseable YAML.
+
+This makes the most security-sensitive release semantics reviewable without granting package or OIDC write permissions to pull-request CI.
+
+### Published-release workflow
+
+`.github/workflows/release.yml` is triggered only by a **published GitHub Release**. It has two jobs with distinct trust boundaries.
+
+`Release / Verify` remains read-only and requires the tagged commit to be contained in `main`. It reruns the repository verification, responsive production-browser tests, and the production container-bundle smoke test.
+
+Only after that succeeds, `Release / Publish` receives narrowly scoped release permissions and performs this sequence:
+
+1. validate release metadata and derive lowercase GHCR package names;
+2. authenticate to GHCR with the workflow token;
+3. build and push candidate API/web image indexes for `linux/amd64` and `linux/arm64`;
+4. generate BuildKit provenance and SBOM attestations during the build;
+5. scan both target platforms of both application images for `HIGH` and `CRITICAL` vulnerabilities;
+6. generate per-platform SPDX JSON SBOM files as release evidence;
+7. render `compose.release.yaml` with the exact candidate image digests;
+8. pull and smoke-test that exact published digest-pinned bundle;
+9. create GitHub provenance attestations for the verified image digests and push them to the registry;
+10. promote the **same digests without rebuild** to the version tag;
+11. move `latest` only when the release is stable;
+12. verify the promoted manifests contain both target Linux architectures;
+13. attach the digest-pinned Compose file, manifests, vulnerability reports, SBOMs, verification metadata, and checksums to the GitHub Release.
+
+Docker Actions are pinned to immutable commit SHAs. The QEMU binfmt helper image and BuildKit daemon image are also pinned by digest so the release builder does not silently inherit mutable `latest`/`buildx-stable-1` dependencies.
+
+## Release status and first validation
+
+The workflow implementation itself is covered by normal PR CI, but GitHub does not execute a `release: published` workflow during a pull request. Therefore the first real end-to-end validation must be a prerelease after this implementation is merged.
+
+The intended first validation release is a prerelease such as:
+
+```text
+v0.1.0-rc.1
 ```
+
+It must remain marked as a GitHub prerelease. A successful prerelease must **not** create or move `latest`.
+
+Do not create a stable release until at least one prerelease has exercised the complete workflow successfully and its attached evidence has been inspected.
+
+## GHCR visibility
+
+Package publication and package visibility are separate concerns. The first GHCR publication may not be anonymously pullable merely because the source repository is public. After the first real prerelease, verify the API and web package visibility explicitly before calling the release publicly consumable.
+
+Until that verification is complete, documentation may state that GHCR publication exists, but must not promise anonymous public pulls.
 
 ## Manual local start
 
@@ -61,7 +108,7 @@ docker compose -f compose.release.yaml up -d --wait
 
 Open `http://localhost:3000`.
 
-The API remains internal to the Compose network in this bundle. The web container reaches it through `API_BASE_URL=http://api:8080`.
+The API remains internal to the Compose network. The web container reaches it through `API_BASE_URL=http://api:8080`.
 
 Stop containers while retaining database data:
 
@@ -76,19 +123,3 @@ docker compose -f compose.release.yaml down --volumes
 ```
 
 Never commit a real database password or a populated local `.env` file.
-
-## Versioned release contract — not implemented yet
-
-The next release-engineering slice must complete the approved public-release contract:
-
-1. trigger authoritative packaging from a published GitHub Release;
-2. build and publish `linux/amd64` and `linux/arm64` API/web images to GHCR;
-3. scan the application images for actionable vulnerabilities;
-4. produce SBOM and provenance/attestation evidence;
-5. resolve immutable OCI digests;
-6. generate a release-specific Compose file pinned to those application digests;
-7. start and smoke-test that exact published bundle in CI;
-8. attach the tested Compose file and verification metadata to the GitHub Release;
-9. allow stable releases to move `latest` while ensuring prereleases never do.
-
-Until those steps are implemented and verified, do not describe the repository as having a consumable versioned release.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,6 +1,6 @@
 # Releases
 
-Zakup Gotov is still **pre-release**. The production container topology is already exercised in normal CI; the versioned GHCR publishing workflow is now implemented but is not considered runtime-proven until a real published prerelease completes successfully.
+Zakup Gotov is still **pre-release**. The production container topology is already exercised in normal CI; the versioned GHCR publishing workflow is implemented but is not considered runtime-proven until a real published prerelease completes successfully.
 
 ## Verified container bundle
 
@@ -24,7 +24,7 @@ Run the same executable contract locally with a running Docker daemon and Docker
 
 ## Versioned release contract
 
-The repository now contains two separate layers for versioned releases.
+The repository contains two separate verification layers for versioned releases.
 
 ### Read-only release contract
 
@@ -34,35 +34,40 @@ The repository now contains two separate layers for versioned releases.
 - consistency between SemVer prerelease state and the GitHub Release `prerelease` flag;
 - prereleases can never publish the `latest` tag;
 - repository-scoped GHCR image names are normalized to lowercase;
+- unverified candidates use separate `*-staging-api` / `*-staging-web` package names rather than final package names;
+- final-package pre-version copies use deterministic `verified-<source-sha>` tags;
 - application images in a release-specific Compose file must be GHCR references pinned by `sha256` digest;
 - the release workflow uses immutable full-SHA action pins;
 - QEMU and BuildKit helper images are themselves digest-pinned;
-- candidate build, vulnerability scan, exact-bundle smoke verification, attestation, promotion, and release-asset upload remain in the approved trust order;
+- build, scan, staging smoke, final-package copy, final-package smoke, attestation, version promotion, optional `latest`, and release-asset upload remain in the approved trust order;
 - `release.yml` remains syntactically parseable YAML.
 
-This makes the most security-sensitive release semantics reviewable without granting package or OIDC write permissions to pull-request CI.
+This keeps security-sensitive release semantics testable without granting package or OIDC write permissions to pull-request CI.
 
 ### Published-release workflow
 
 `.github/workflows/release.yml` is triggered only by a **published GitHub Release**. It has two jobs with distinct trust boundaries.
 
-`Release / Verify` remains read-only and requires the tagged commit to be contained in `main`. It reruns the repository verification, responsive production-browser tests, and the production container-bundle smoke test.
+`Release / Verify` remains read-only and requires the tagged commit to be contained in `main`. It reruns repository verification, responsive production-browser tests, and the production container-bundle smoke test.
 
 Only after that succeeds, `Release / Publish` receives narrowly scoped release permissions and performs this sequence:
 
-1. validate release metadata and derive lowercase GHCR package names;
+1. validate release metadata and derive lowercase final/staging GHCR package names;
 2. authenticate to GHCR with the workflow token;
-3. build and push candidate API/web image indexes for `linux/amd64` and `linux/arm64`;
+3. build and push candidate API/web image indexes for `linux/amd64` and `linux/arm64` into dedicated staging packages;
 4. generate BuildKit provenance and SBOM attestations during the build;
-5. scan both target platforms of both application images for `HIGH` and `CRITICAL` vulnerabilities;
+5. scan both target platforms of both staging images for `HIGH` and `CRITICAL` vulnerabilities;
 6. generate per-platform SPDX JSON SBOM files as release evidence;
-7. render `compose.release.yaml` with the exact candidate image digests;
-8. pull and smoke-test that exact published digest-pinned bundle;
-9. create GitHub provenance attestations for the verified image digests and push them to the registry;
-10. promote the **same digests without rebuild** to the version tag;
-11. move `latest` only when the release is stable;
-12. verify the promoted manifests contain both target Linux architectures;
-13. attach the digest-pinned Compose file, manifests, vulnerability reports, SBOMs, verification metadata, and checksums to the GitHub Release.
+7. render a temporary Compose file with the exact staging image digests and smoke-test that registry-pulled bundle;
+8. copy those verified indexes **without rebuild** into the final API/web packages under `verified-<source-sha>` tags and require the copied digest to remain identical;
+9. render the release Compose file using the final package names with those exact digests and smoke-test the final-package bundle;
+10. create GitHub provenance attestations for the final-package image digests;
+11. only now create the SemVer version tags from the already verified final-package digests, again without rebuild;
+12. move `latest` only when the release is stable;
+13. verify the final manifests contain both target Linux architectures;
+14. attach the digest-pinned Compose file, manifests, vulnerability reports, SBOMs, verification metadata, and checksums to the GitHub Release.
+
+The staging packages are intentionally separate from the final packages so an unverified candidate is never placed in a future public release package. Staging packages must remain private. Final package visibility is a separate product/distribution setting and is verified independently after first publication.
 
 Docker Actions are pinned to immutable commit SHAs. The QEMU binfmt helper image and BuildKit daemon image are also pinned by digest so the release builder does not silently inherit mutable `latest`/`buildx-stable-1` dependencies.
 
@@ -82,9 +87,13 @@ Do not create a stable release until at least one prerelease has exercised the c
 
 ## GHCR visibility
 
-Package publication and package visibility are separate concerns. The first GHCR publication may not be anonymously pullable merely because the source repository is public. After the first real prerelease, verify the API and web package visibility explicitly before calling the release publicly consumable.
+Package publication and package visibility are separate concerns.
 
-Until that verification is complete, documentation may state that GHCR publication exists, but must not promise anonymous public pulls.
+- staging packages are an internal release-engineering boundary and must remain private;
+- final API/web packages may be made public only as a deliberate distribution decision;
+- a public source repository is not treated as proof that a newly created GHCR package is anonymously pullable.
+
+After the first real prerelease, verify both staging-package privacy and final-package visibility explicitly. Until final-package visibility is proven, documentation must not promise anonymous public pulls.
 
 ## Manual local start
 

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -38,7 +38,7 @@ Target rules for `main`:
 - no mandatory second-human approval while the project has one maintainer;
 - administrators should normally follow the same rules rather than silently bypass them.
 
-Required checks are activated only after they have completed successfully at least once in the repository. The currently enforced baseline is:
+Required checks are activated only after they have completed successfully at least once in the repository. The currently independently verified enforced baseline is:
 
 - `API CI`;
 - `Contract CI`;
@@ -48,7 +48,12 @@ Required checks are activated only after they have completed successfully at lea
 - CodeQL JavaScript/TypeScript;
 - `Dependency Review`.
 
-`Release Bundle CI` is now a **proven successful check candidate**: it builds the production API/web images and executes the full PostgreSQL → API → web Compose topology. It should be added to `main` required checks once the repository ruleset is updated and that setting is independently verified. Until then, documentation must not describe it as already enforced by the ruleset.
+Additional proven candidates:
+
+- `Release Bundle CI` — builds the production API/web images and executes the full PostgreSQL → API → web Compose topology;
+- `Release Contract CI` — verifies version/prerelease semantics, digest-only release Compose rendering, immutable release dependencies, release-workflow syntax, and security/promotion ordering without write permissions.
+
+These candidates should be added to `main` required checks only when the ruleset change can be applied and independently verified. Documentation must not describe them as already enforced until then.
 
 ## Branch lifecycle
 
@@ -63,13 +68,20 @@ After a pull request is squash-merged, its source branch should be deleted autom
 
 Permanent workflows must solve a recurring repository need. One-off generators/scaffold workflows are deleted immediately after the generated artifact is committed and independently verified.
 
-Default workflow permissions should be read-only. A workflow receives write permissions only for the smallest explicit capability needed by that workflow.
+Default workflow permissions remain read-only. A workflow receives write permissions only for the smallest explicit capability needed by that workflow.
 
-Third-party and GitHub-owned actions should ultimately be pinned by full commit SHA in permanent security-sensitive workflows. Dependabot for `github-actions` keeps those pins reviewable and current.
+Third-party and GitHub-owned actions in permanent security-sensitive workflows are pinned by full commit SHA. Mutable helper images used by security-sensitive release actions should also be pinned by digest where supported.
 
 Do not grant workflows permission to approve pull requests.
 
-`Release Bundle CI` follows the normal read-only workflow baseline. Future versioned publishing is a separate workflow boundary and may receive package/attestation write permissions only where publishing actually requires them; those permissions must not be moved into ordinary PR CI.
+Release boundaries:
+
+- `Release Bundle CI` is ordinary read-only PR/main verification;
+- `Release Contract CI` is ordinary read-only PR/main verification;
+- `.github/workflows/release.yml` runs only for a published GitHub Release;
+- its `Release / Verify` job remains `contents: read`;
+- only the downstream `Release / Publish` job may receive `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
+- package/OIDC write permissions must never be copied into ordinary PR CI.
 
 ## Security features
 
@@ -110,7 +122,7 @@ Repository visibility and software licensing are separate decisions. The reposit
 
 ## Releases and packages
 
-The production container topology is now implemented and verified in PR CI:
+Runtime-proven production container baseline:
 
 - separate production `api` and `web` images;
 - Next.js standalone runtime;
@@ -120,17 +132,24 @@ The production container topology is now implemented and verified in PR CI:
 - API kept internal to the Compose network while the web port is host-published;
 - automated exact-topology startup/smoke verification with failure diagnostics.
 
-The remaining approved versioned release-engineering direction is:
+Implemented versioned publishing contract:
 
-- versioned GitHub Releases;
-- prebuilt `api` and `web` OCI images published to GitHub Container Registry;
-- multi-platform `linux/amd64` and `linux/arm64` images;
-- a release-specific Compose asset pinned to immutable application-image digests;
-- release verification against the exact published container set that users will run;
-- vulnerability scanning, SBOM, provenance/attestation, and immutable image digests;
-- prereleases do not update the stable `latest` tag.
+- published GitHub Release is the authoritative trigger;
+- tagged source must belong to `main` history;
+- strict SemVer and GitHub prerelease-state consistency are enforced;
+- prebuilt `api` and `web` OCI indexes target `linux/amd64` and `linux/arm64`;
+- candidate image digests are scanned on both target platforms before promotion;
+- per-platform SPDX SBOM evidence is generated;
+- BuildKit provenance/SBOM and GitHub provenance attestations are created for exact image digests;
+- release-specific Compose is pinned to immutable application-image digests;
+- that exact published digest set is pulled and smoke-tested before promotion;
+- promotion copies the verified image indexes without rebuild;
+- stable releases may update `latest`; prereleases never do;
+- Compose, manifests, scans, SBOMs, verification metadata, and checksums are attached to the GitHub Release.
 
-The local/CI container baseline must not be confused with a consumable public release: GHCR publication and release-specific supply-chain evidence remain incomplete until a separately verified release workflow lands.
+This release-event path must be exercised by a real prerelease before it is considered runtime-proven. A stable release should not be used for first validation.
+
+GHCR package visibility must be independently checked after first publication. Public repository visibility is not treated as evidence that new package images are anonymously pullable.
 
 ## Audit cadence
 

--- a/scripts/release/release_contract.py
+++ b/scripts/release/release_contract.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import pathlib
+import re
+from typing import TextIO
+
+
+SEMVER_TAG_RE = re.compile(
+    r"^v(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+GHCR_DIGEST_REF_RE = re.compile(
+    r"^ghcr\.io/"
+    r"[a-z0-9][a-z0-9._-]*"
+    r"(?:/[a-z0-9][a-z0-9._-]*)+"
+    r"@sha256:[0-9a-f]{64}$"
+)
+
+API_IMAGE_TOKEN = "image: ${API_IMAGE:?API_IMAGE must be set}"
+WEB_IMAGE_TOKEN = "image: ${WEB_IMAGE:?WEB_IMAGE must be set}"
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleaseMetadata:
+    version: str
+    stable: bool
+    version_tag: str
+    candidate_tag: str
+    publish_latest: bool
+
+
+def _validate_prerelease_identifiers(prerelease: str | None) -> None:
+    if prerelease is None:
+        return
+
+    for identifier in prerelease.split("."):
+        if identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0"):
+            raise ValueError(
+                "numeric SemVer prerelease identifiers must not contain leading zeroes"
+            )
+
+
+def parse_release(tag: str, *, prerelease: bool, commit_sha: str) -> ReleaseMetadata:
+    match = SEMVER_TAG_RE.fullmatch(tag)
+    if match is None:
+        raise ValueError(
+            "release tag must match vMAJOR.MINOR.PATCH or "
+            "vMAJOR.MINOR.PATCH-prerelease without build metadata"
+        )
+
+    prerelease_text = match.group(4)
+    _validate_prerelease_identifiers(prerelease_text)
+
+    tag_is_prerelease = prerelease_text is not None
+    if prerelease != tag_is_prerelease:
+        raise ValueError("GitHub prerelease flag must match the SemVer prerelease state")
+
+    if COMMIT_SHA_RE.fullmatch(commit_sha) is None:
+        raise ValueError("commit SHA must be a full lowercase 40-character SHA-1")
+
+    version = tag.removeprefix("v")
+    stable = not tag_is_prerelease
+    return ReleaseMetadata(
+        version=version,
+        stable=stable,
+        version_tag=version,
+        candidate_tag=f"candidate-{commit_sha}",
+        publish_latest=stable,
+    )
+
+
+def build_image_names(owner: str, repository: str) -> tuple[str, str]:
+    owner_slug = owner.strip().lower()
+    repository_slug = repository.strip().lower()
+
+    slug_re = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+    if slug_re.fullmatch(owner_slug) is None:
+        raise ValueError("repository owner cannot be represented safely in a GHCR name")
+    if slug_re.fullmatch(repository_slug) is None:
+        raise ValueError("repository name cannot be represented safely in a GHCR name")
+
+    prefix = f"ghcr.io/{owner_slug}/{repository_slug}"
+    return f"{prefix}-api", f"{prefix}-web"
+
+
+def _validate_digest_ref(ref: str) -> None:
+    if GHCR_DIGEST_REF_RE.fullmatch(ref) is None:
+        raise ValueError(
+            "release application image reference must be a lowercase GHCR "
+            "reference pinned by sha256 digest"
+        )
+
+
+def render_release_compose(source: str, *, api_ref: str, web_ref: str) -> str:
+    _validate_digest_ref(api_ref)
+    _validate_digest_ref(web_ref)
+
+    if source.count(API_IMAGE_TOKEN) != 1 or source.count(WEB_IMAGE_TOKEN) != 1:
+        raise ValueError(
+            "compose release source must contain exactly one API_IMAGE and one "
+            "WEB_IMAGE token"
+        )
+
+    rendered = source.replace(API_IMAGE_TOKEN, f"image: {api_ref}")
+    rendered = rendered.replace(WEB_IMAGE_TOKEN, f"image: {web_ref}")
+    return rendered
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def _append_github_output(path: pathlib.Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        _write_key_values(output, values)
+
+
+def _write_key_values(output: TextIO, values: dict[str, str]) -> None:
+    for key, value in values.items():
+        if "\n" in value or "\r" in value:
+            raise ValueError(f"multi-line GitHub output is not supported for {key}")
+        print(f"{key}={value}", file=output)
+
+
+def _metadata_command(args: argparse.Namespace) -> None:
+    metadata = parse_release(
+        args.tag,
+        prerelease=args.prerelease,
+        commit_sha=args.commit_sha,
+    )
+    api_image, web_image = build_image_names(args.owner, args.repository)
+
+    values = {
+        "version": metadata.version,
+        "stable": str(metadata.stable).lower(),
+        "version_tag": metadata.version_tag,
+        "candidate_tag": metadata.candidate_tag,
+        "publish_latest": str(metadata.publish_latest).lower(),
+        "api_image": api_image,
+        "web_image": web_image,
+        "api_candidate": f"{api_image}:{metadata.candidate_tag}",
+        "web_candidate": f"{web_image}:{metadata.candidate_tag}",
+    }
+
+    if args.github_output is not None:
+        _append_github_output(args.github_output, values)
+    else:
+        _write_key_values(output=__import__("sys").stdout, values=values)
+
+
+def _render_compose_command(args: argparse.Namespace) -> None:
+    source = args.input.read_text(encoding="utf-8")
+    rendered = render_release_compose(
+        source,
+        api_ref=args.api_ref,
+        web_ref=args.web_ref,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Zakup Gotov release contract helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    metadata = subparsers.add_parser("metadata", help="validate release metadata")
+    metadata.add_argument("--tag", required=True)
+    metadata.add_argument("--prerelease", required=True, type=_parse_bool)
+    metadata.add_argument("--commit-sha", required=True)
+    metadata.add_argument("--owner", required=True)
+    metadata.add_argument("--repository", required=True)
+    metadata.add_argument("--github-output", type=pathlib.Path)
+    metadata.set_defaults(func=_metadata_command)
+
+    render = subparsers.add_parser(
+        "render-compose", help="render immutable release Compose asset"
+    )
+    render.add_argument("--input", required=True, type=pathlib.Path)
+    render.add_argument("--output", required=True, type=pathlib.Path)
+    render.add_argument("--api-ref", required=True)
+    render.add_argument("--web-ref", required=True)
+    render.set_defaults(func=_render_compose_command)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/release_contract.py
+++ b/scripts/release/release_contract.py
@@ -21,6 +21,7 @@ GHCR_DIGEST_REF_RE = re.compile(
     r"(?:/[a-z0-9][a-z0-9._-]*)+"
     r"@sha256:[0-9a-f]{64}$"
 )
+GHCR_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
 API_IMAGE_TOKEN = "image: ${API_IMAGE:?API_IMAGE must be set}"
 WEB_IMAGE_TOKEN = "image: ${WEB_IMAGE:?WEB_IMAGE must be set}"
@@ -75,18 +76,26 @@ def parse_release(tag: str, *, prerelease: bool, commit_sha: str) -> ReleaseMeta
     )
 
 
-def build_image_names(owner: str, repository: str) -> tuple[str, str]:
+def _build_image_prefix(owner: str, repository: str) -> str:
     owner_slug = owner.strip().lower()
     repository_slug = repository.strip().lower()
 
-    slug_re = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
-    if slug_re.fullmatch(owner_slug) is None:
+    if GHCR_SLUG_RE.fullmatch(owner_slug) is None:
         raise ValueError("repository owner cannot be represented safely in a GHCR name")
-    if slug_re.fullmatch(repository_slug) is None:
+    if GHCR_SLUG_RE.fullmatch(repository_slug) is None:
         raise ValueError("repository name cannot be represented safely in a GHCR name")
 
-    prefix = f"ghcr.io/{owner_slug}/{repository_slug}"
+    return f"ghcr.io/{owner_slug}/{repository_slug}"
+
+
+def build_image_names(owner: str, repository: str) -> tuple[str, str]:
+    prefix = _build_image_prefix(owner, repository)
     return f"{prefix}-api", f"{prefix}-web"
+
+
+def build_staging_image_names(owner: str, repository: str) -> tuple[str, str]:
+    prefix = _build_image_prefix(owner, repository)
+    return f"{prefix}-staging-api", f"{prefix}-staging-web"
 
 
 def _validate_digest_ref(ref: str) -> None:
@@ -140,6 +149,9 @@ def _metadata_command(args: argparse.Namespace) -> None:
         commit_sha=args.commit_sha,
     )
     api_image, web_image = build_image_names(args.owner, args.repository)
+    api_staging_image, web_staging_image = build_staging_image_names(
+        args.owner, args.repository
+    )
 
     values = {
         "version": metadata.version,
@@ -149,8 +161,10 @@ def _metadata_command(args: argparse.Namespace) -> None:
         "publish_latest": str(metadata.publish_latest).lower(),
         "api_image": api_image,
         "web_image": web_image,
-        "api_candidate": f"{api_image}:{metadata.candidate_tag}",
-        "web_candidate": f"{web_image}:{metadata.candidate_tag}",
+        "api_staging_image": api_staging_image,
+        "web_staging_image": web_staging_image,
+        "api_candidate": f"{api_staging_image}:{metadata.candidate_tag}",
+        "web_candidate": f"{web_staging_image}:{metadata.candidate_tag}",
     }
 
     if args.github_output is not None:

--- a/scripts/release/release_contract.py
+++ b/scripts/release/release_contract.py
@@ -33,6 +33,7 @@ class ReleaseMetadata:
     stable: bool
     version_tag: str
     candidate_tag: str
+    verified_tag: str
     publish_latest: bool
 
 
@@ -72,6 +73,7 @@ def parse_release(tag: str, *, prerelease: bool, commit_sha: str) -> ReleaseMeta
         stable=stable,
         version_tag=version,
         candidate_tag=f"candidate-{commit_sha}",
+        verified_tag=f"verified-{commit_sha}",
         publish_latest=stable,
     )
 
@@ -158,6 +160,7 @@ def _metadata_command(args: argparse.Namespace) -> None:
         "stable": str(metadata.stable).lower(),
         "version_tag": metadata.version_tag,
         "candidate_tag": metadata.candidate_tag,
+        "verified_tag": metadata.verified_tag,
         "publish_latest": str(metadata.publish_latest).lower(),
         "api_image": api_image,
         "web_image": web_image,
@@ -165,6 +168,8 @@ def _metadata_command(args: argparse.Namespace) -> None:
         "web_staging_image": web_staging_image,
         "api_candidate": f"{api_staging_image}:{metadata.candidate_tag}",
         "web_candidate": f"{web_staging_image}:{metadata.candidate_tag}",
+        "api_verified_candidate": f"{api_image}:{metadata.verified_tag}",
+        "web_verified_candidate": f"{web_image}:{metadata.verified_tag}",
     }
 
     if args.github_output is not None:

--- a/scripts/release/test_release_contract.py
+++ b/scripts/release/test_release_contract.py
@@ -107,8 +107,12 @@ class ComposeRenderTest(unittest.TestCase):
 
 
 class PublishingWorkflowContractTest(unittest.TestCase):
+    @staticmethod
+    def _workflow() -> str:
+        return (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
     def test_release_workflow_preserves_supply_chain_boundary(self):
-        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        workflow = self._workflow()
 
         required_fragments = (
             "release:\n    types: [published]",
@@ -134,13 +138,54 @@ class PublishingWorkflowContractTest(unittest.TestCase):
                 self.assertIn(fragment, workflow)
 
     def test_release_workflow_does_not_use_mutable_action_tags(self):
-        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        workflow = self._workflow()
 
         for line in workflow.splitlines():
             stripped = line.strip()
             if stripped.startswith("uses:"):
                 with self.subTest(line=stripped):
                     self.assertRegex(stripped, r"@[0-9a-f]{40}(?:\s+#.*)?$")
+
+    def test_release_workflow_pins_qemu_and_buildkit_helper_images(self):
+        workflow = self._workflow()
+
+        self.assertRegex(
+            workflow,
+            r"image: tonistiigi/binfmt@sha256:[0-9a-f]{64}",
+        )
+        self.assertRegex(
+            workflow,
+            r"image=moby/buildkit@sha256:[0-9a-f]{64}",
+        )
+        self.assertNotIn("tonistiigi/binfmt:latest", workflow)
+        self.assertNotIn("moby/buildkit:buildx-stable-1", workflow)
+
+    def test_verification_and_security_gates_precede_promotion(self):
+        workflow = self._workflow()
+
+        build_position = workflow.index("Build and push API candidate")
+        scan_position = workflow.index(
+            "Scan API candidate for HIGH/CRITICAL vulnerabilities on amd64"
+        )
+        smoke_position = workflow.index("Verify exact published candidate bundle")
+        attest_position = workflow.index("Attest API candidate provenance")
+        promote_position = workflow.index("Promote verified digests to release version")
+        latest_position = workflow.index("Promote stable release to latest")
+        upload_position = workflow.index("Attach verified release assets")
+
+        self.assertLess(build_position, scan_position)
+        self.assertLess(scan_position, smoke_position)
+        self.assertLess(smoke_position, attest_position)
+        self.assertLess(attest_position, promote_position)
+        self.assertLess(promote_position, latest_position)
+        self.assertLess(latest_position, upload_position)
+
+    def test_latest_promotion_is_explicitly_conditional(self):
+        workflow = self._workflow()
+        latest_section = workflow[workflow.index("Promote stable release to latest") :]
+
+        self.assertIn("if: steps.release.outputs.publish_latest == 'true'", latest_section)
+        self.assertIn(":latest", latest_section)
 
 
 if __name__ == "__main__":

--- a/scripts/release/test_release_contract.py
+++ b/scripts/release/test_release_contract.py
@@ -1,0 +1,110 @@
+import pathlib
+import unittest
+
+from release_contract import (
+    ReleaseMetadata,
+    build_image_names,
+    parse_release,
+    render_release_compose,
+)
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ReleaseMetadataTest(unittest.TestCase):
+    def test_stable_release_may_publish_latest(self):
+        metadata = parse_release("v1.2.3", prerelease=False, commit_sha="a" * 40)
+
+        self.assertEqual(
+            metadata,
+            ReleaseMetadata(
+                version="1.2.3",
+                stable=True,
+                version_tag="1.2.3",
+                candidate_tag=f"candidate-{'a' * 40}",
+                publish_latest=True,
+            ),
+        )
+
+    def test_prerelease_never_publishes_latest(self):
+        metadata = parse_release(
+            "v1.2.3-rc.1", prerelease=True, commit_sha="b" * 40
+        )
+
+        self.assertEqual(metadata.version, "1.2.3-rc.1")
+        self.assertFalse(metadata.stable)
+        self.assertFalse(metadata.publish_latest)
+
+    def test_release_flag_must_match_semver_prerelease_state(self):
+        with self.assertRaisesRegex(ValueError, "prerelease flag"):
+            parse_release("v1.2.3-rc.1", prerelease=False, commit_sha="c" * 40)
+
+        with self.assertRaisesRegex(ValueError, "prerelease flag"):
+            parse_release("v1.2.3", prerelease=True, commit_sha="c" * 40)
+
+    def test_invalid_or_ambiguous_release_tags_are_rejected(self):
+        invalid_tags = (
+            "1.2.3",
+            "v1.2",
+            "v01.2.3",
+            "v1.02.3",
+            "v1.2.03",
+            "v1.2.3+build.1",
+            "v1.2.3-01",
+            "v1.2.3-",
+        )
+
+        for tag in invalid_tags:
+            with self.subTest(tag=tag):
+                with self.assertRaises(ValueError):
+                    parse_release(tag, prerelease=False, commit_sha="d" * 40)
+
+    def test_commit_sha_must_be_full_lowercase_sha1(self):
+        for sha in ("abc", "A" * 40, "g" * 40):
+            with self.subTest(sha=sha):
+                with self.assertRaisesRegex(ValueError, "commit SHA"):
+                    parse_release("v1.2.3", prerelease=False, commit_sha=sha)
+
+
+class ImageNameTest(unittest.TestCase):
+    def test_ghcr_image_names_are_lowercase_and_repo_scoped(self):
+        api, web = build_image_names("True-Ruslan", "zakup-gotov")
+
+        self.assertEqual(api, "ghcr.io/true-ruslan/zakup-gotov-api")
+        self.assertEqual(web, "ghcr.io/true-ruslan/zakup-gotov-web")
+
+
+class ComposeRenderTest(unittest.TestCase):
+    def test_release_compose_pins_both_application_images_by_digest(self):
+        source = (ROOT / "compose.release.yaml").read_text(encoding="utf-8")
+        api_ref = f"ghcr.io/true-ruslan/zakup-gotov-api@sha256:{'1' * 64}"
+        web_ref = f"ghcr.io/true-ruslan/zakup-gotov-web@sha256:{'2' * 64}"
+
+        rendered = render_release_compose(source, api_ref=api_ref, web_ref=web_ref)
+
+        self.assertIn(f"image: {api_ref}", rendered)
+        self.assertIn(f"image: {web_ref}", rendered)
+        self.assertNotIn("${API_IMAGE", rendered)
+        self.assertNotIn("${WEB_IMAGE", rendered)
+        self.assertIn("${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}", rendered)
+        self.assertNotIn("build:", rendered)
+
+    def test_release_compose_rejects_mutable_or_malformed_image_refs(self):
+        source = (ROOT / "compose.release.yaml").read_text(encoding="utf-8")
+        valid = f"ghcr.io/true-ruslan/zakup-gotov-api@sha256:{'1' * 64}"
+        invalid = (
+            "ghcr.io/true-ruslan/zakup-gotov-api:1.2.3",
+            "docker.io/library/alpine@sha256:" + "1" * 64,
+            "ghcr.io/True-Ruslan/zakup-gotov-api@sha256:" + "1" * 64,
+            "ghcr.io/true-ruslan/zakup-gotov-api@sha256:abc",
+        )
+
+        for ref in invalid:
+            with self.subTest(ref=ref):
+                with self.assertRaises(ValueError):
+                    render_release_compose(source, api_ref=ref, web_ref=valid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_release_contract.py
+++ b/scripts/release/test_release_contract.py
@@ -24,6 +24,7 @@ class ReleaseMetadataTest(unittest.TestCase):
                 stable=True,
                 version_tag="1.2.3",
                 candidate_tag=f"candidate-{'a' * 40}",
+                verified_tag=f"verified-{'a' * 40}",
                 publish_latest=True,
             ),
         )
@@ -169,26 +170,28 @@ class PublishingWorkflowContractTest(unittest.TestCase):
         self.assertNotIn("tonistiigi/binfmt:latest", workflow)
         self.assertNotIn("moby/buildkit:buildx-stable-1", workflow)
 
-    def test_verification_and_security_gates_precede_final_publication(self):
+    def test_verification_and_security_gates_precede_version_publication(self):
         workflow = self._workflow()
 
         build_position = workflow.index("Build and push API candidate")
         scan_position = workflow.index(
             "Scan API candidate for HIGH/CRITICAL vulnerabilities on amd64"
         )
-        candidate_smoke_position = workflow.index("Verify staging candidate bundle")
-        promote_position = workflow.index("Promote verified digests to release version")
-        final_smoke_position = workflow.index("Verify exact promoted release bundle")
+        staging_smoke_position = workflow.index("Verify staging candidate bundle")
+        copy_position = workflow.index("Copy verified digests into final packages")
+        final_smoke_position = workflow.index("Verify exact final-package candidate bundle")
         attest_position = workflow.index("Attest final API provenance")
+        version_position = workflow.index("Promote verified final digests to release version")
         latest_position = workflow.index("Promote stable release to latest")
         upload_position = workflow.index("Attach verified release assets")
 
         self.assertLess(build_position, scan_position)
-        self.assertLess(scan_position, candidate_smoke_position)
-        self.assertLess(candidate_smoke_position, promote_position)
-        self.assertLess(promote_position, final_smoke_position)
+        self.assertLess(scan_position, staging_smoke_position)
+        self.assertLess(staging_smoke_position, copy_position)
+        self.assertLess(copy_position, final_smoke_position)
         self.assertLess(final_smoke_position, attest_position)
-        self.assertLess(attest_position, latest_position)
+        self.assertLess(attest_position, version_position)
+        self.assertLess(version_position, latest_position)
         self.assertLess(latest_position, upload_position)
 
     def test_latest_promotion_is_explicitly_conditional(self):
@@ -205,6 +208,8 @@ class PublishingWorkflowContractTest(unittest.TestCase):
         self.assertIn("steps.release.outputs.web_candidate", workflow)
         self.assertIn("steps.release.outputs.api_staging_image", workflow)
         self.assertIn("steps.release.outputs.web_staging_image", workflow)
+        self.assertIn("steps.release.outputs.api_verified_candidate", workflow)
+        self.assertIn("steps.release.outputs.web_verified_candidate", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/release/test_release_contract.py
+++ b/scripts/release/test_release_contract.py
@@ -106,5 +106,42 @@ class ComposeRenderTest(unittest.TestCase):
                     render_release_compose(source, api_ref=ref, web_ref=valid)
 
 
+class PublishingWorkflowContractTest(unittest.TestCase):
+    def test_release_workflow_preserves_supply_chain_boundary(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+        required_fragments = (
+            "release:\n    types: [published]",
+            "permissions:\n  contents: read",
+            "packages: write",
+            "attestations: write",
+            "id-token: write",
+            "linux/amd64,linux/arm64",
+            "provenance: mode=max",
+            "sbom: true",
+            "severity: CRITICAL,HIGH",
+            "TRIVY_PLATFORM: linux/amd64",
+            "TRIVY_PLATFORM: linux/arm64",
+            "docker buildx imagetools create",
+            "publish_latest",
+            "render-compose",
+            "verify-published-release.sh",
+            "gh release upload",
+        )
+
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, workflow)
+
+    def test_release_workflow_does_not_use_mutable_action_tags(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+        for line in workflow.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("uses:"):
+                with self.subTest(line=stripped):
+                    self.assertRegex(stripped, r"@[0-9a-f]{40}(?:\s+#.*)?$")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/release/test_release_contract.py
+++ b/scripts/release/test_release_contract.py
@@ -4,6 +4,7 @@ import unittest
 from release_contract import (
     ReleaseMetadata,
     build_image_names,
+    build_staging_image_names,
     parse_release,
     render_release_compose,
 )
@@ -73,6 +74,14 @@ class ImageNameTest(unittest.TestCase):
 
         self.assertEqual(api, "ghcr.io/true-ruslan/zakup-gotov-api")
         self.assertEqual(web, "ghcr.io/true-ruslan/zakup-gotov-web")
+
+    def test_unverified_candidates_use_separate_staging_packages(self):
+        api, web = build_staging_image_names("True-Ruslan", "zakup-gotov")
+
+        self.assertEqual(api, "ghcr.io/true-ruslan/zakup-gotov-staging-api")
+        self.assertEqual(web, "ghcr.io/true-ruslan/zakup-gotov-staging-web")
+        self.assertNotEqual(api, build_image_names("True-Ruslan", "zakup-gotov")[0])
+        self.assertNotEqual(web, build_image_names("True-Ruslan", "zakup-gotov")[1])
 
 
 class ComposeRenderTest(unittest.TestCase):
@@ -160,24 +169,26 @@ class PublishingWorkflowContractTest(unittest.TestCase):
         self.assertNotIn("tonistiigi/binfmt:latest", workflow)
         self.assertNotIn("moby/buildkit:buildx-stable-1", workflow)
 
-    def test_verification_and_security_gates_precede_promotion(self):
+    def test_verification_and_security_gates_precede_final_publication(self):
         workflow = self._workflow()
 
         build_position = workflow.index("Build and push API candidate")
         scan_position = workflow.index(
             "Scan API candidate for HIGH/CRITICAL vulnerabilities on amd64"
         )
-        smoke_position = workflow.index("Verify exact published candidate bundle")
-        attest_position = workflow.index("Attest API candidate provenance")
+        candidate_smoke_position = workflow.index("Verify staging candidate bundle")
         promote_position = workflow.index("Promote verified digests to release version")
+        final_smoke_position = workflow.index("Verify exact promoted release bundle")
+        attest_position = workflow.index("Attest final API provenance")
         latest_position = workflow.index("Promote stable release to latest")
         upload_position = workflow.index("Attach verified release assets")
 
         self.assertLess(build_position, scan_position)
-        self.assertLess(scan_position, smoke_position)
-        self.assertLess(smoke_position, attest_position)
-        self.assertLess(attest_position, promote_position)
-        self.assertLess(promote_position, latest_position)
+        self.assertLess(scan_position, candidate_smoke_position)
+        self.assertLess(candidate_smoke_position, promote_position)
+        self.assertLess(promote_position, final_smoke_position)
+        self.assertLess(final_smoke_position, attest_position)
+        self.assertLess(attest_position, latest_position)
         self.assertLess(latest_position, upload_position)
 
     def test_latest_promotion_is_explicitly_conditional(self):
@@ -186,6 +197,14 @@ class PublishingWorkflowContractTest(unittest.TestCase):
 
         self.assertIn("if: steps.release.outputs.publish_latest == 'true'", latest_section)
         self.assertIn(":latest", latest_section)
+
+    def test_candidate_builds_use_staging_packages_not_final_packages(self):
+        workflow = self._workflow()
+
+        self.assertIn("steps.release.outputs.api_candidate", workflow)
+        self.assertIn("steps.release.outputs.web_candidate", workflow)
+        self.assertIn("steps.release.outputs.api_staging_image", workflow)
+        self.assertIn("steps.release.outputs.web_staging_image", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/release/verify-published-release.sh
+++ b/scripts/release/verify-published-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <release-compose-file>" >&2
+  exit 2
+fi
+
+COMPOSE_FILE="$1"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "release compose file does not exist: $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if grep -Eq '^[[:space:]]*build:' "$COMPOSE_FILE"; then
+  echo "published release compose must not contain build directives" >&2
+  exit 1
+fi
+
+if grep -Eq '\$\{(API_IMAGE|WEB_IMAGE)' "$COMPOSE_FILE"; then
+  echo "published release compose must pin application images directly" >&2
+  exit 1
+fi
+
+mapfile -t application_refs < <(
+  grep -E '^[[:space:]]+image: ghcr\.io/.+@sha256:[0-9a-f]{64}$' "$COMPOSE_FILE" \
+    | sed -E 's/^[[:space:]]+image:[[:space:]]+//'
+)
+
+if [[ ${#application_refs[@]} -ne 2 ]]; then
+  echo "published release compose must contain exactly two digest-pinned GHCR application images" >&2
+  exit 1
+fi
+
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-release-smoke-password}"
+WEB_PORT="${WEB_PORT:-3000}"
+export POSTGRES_PASSWORD WEB_PORT
+
+cleanup() {
+  local status=$?
+
+  if (( status != 0 )); then
+    echo "published release verification failed; collecting compose diagnostics" >&2
+    docker compose -f "$COMPOSE_FILE" ps --all || true
+    docker compose -f "$COMPOSE_FILE" logs --no-color || true
+  fi
+
+  docker compose -f "$COMPOSE_FILE" down --volumes --remove-orphans >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" config >/dev/null
+docker compose -f "$COMPOSE_FILE" pull
+docker compose -f "$COMPOSE_FILE" up --detach --wait --wait-timeout 180
+
+docker compose -f "$COMPOSE_FILE" exec -T api \
+  curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health/readiness \
+  | grep -q '"status":"UP"'
+
+curl --fail --silent --show-error "http://127.0.0.1:${WEB_PORT}/" | grep -q 'Закуп готов'


### PR DESCRIPTION
## Goal

Complete the versioned M0A release-engineering contract on top of the runtime-proven production container topology from #25.

## Implemented

- read-only `Release Contract CI` for release SemVer/prerelease semantics and release-workflow trust-boundary checks;
- strict `vMAJOR.MINOR.PATCH[-prerelease]` validation and consistency with the GitHub Release prerelease flag;
- deterministic lowercase GHCR naming;
- separate private staging package namespace for unverified candidates;
- multi-platform `linux/amd64` + `linux/arm64` staging builds;
- BuildKit provenance/SBOM generation;
- per-platform HIGH/CRITICAL Trivy gates and SPDX JSON SBOM evidence;
- exact staging digest-pinned Compose smoke test;
- no-rebuild cross-package copy into final packages under deterministic `verified-<source-sha>` tags;
- exact final-package digest-pinned Compose smoke test before SemVer publication;
- GitHub provenance attestations for final package digests;
- SemVer promotion only after final-package verification;
- stable-only `latest`; prereleases cannot move `latest`;
- release manifest/platform verification, verification metadata, checksums, vulnerability reports, SBOMs and digest-pinned Compose release assets;
- immutable full-SHA Action pins plus digest-pinned QEMU binfmt and BuildKit helper images;
- synchronized release/security/governance/state/changelog documentation.

## TDD evidence

1. **RED #1** — `Release Contract CI` run `31320052949` failed exactly because `release_contract` did not exist (`ModuleNotFoundError`).
2. Implemented the smallest release metadata/digest-Compose contract; the same tests became GREEN.
3. **RED #2** — expanded tests required the production `.github/workflows/release.yml`; run `31320343830` failed because that workflow did not yet exist.
4. Implemented the release workflow and made the expanded contract GREEN.
5. Review discovered mutable helper-image defaults; QEMU binfmt and BuildKit daemon images were pinned by digest and made part of the PR contract.
6. Review discovered that candidates in a future public final GHCR package could expose unverified images. Tests were tightened first; candidates were moved into dedicated staging packages.
7. Review discovered that a SemVer OCI tag could be created before the cross-package final copy had been smoke-tested. Tests were tightened first; final packages now receive only `verified-<sha>` before final-package smoke, attestation, and subsequent SemVer promotion.
8. `Release Contract CI` itself temporarily disappeared after an invalid one-line YAML parser command; this was treated as a real regression, fixed using a YAML block scalar, and the check was required to reappear and pass.

## Final verification

Final reviewed head: `b184186a078d0f70fcbca29d88aa3ef78184957f`.

On that exact head:

- API CI — PASS;
- Contract CI — PASS;
- Web CI — PASS;
- Web E2E — PASS;
- CodeQL / Java — PASS;
- CodeQL / JavaScript-TypeScript — PASS;
- Dependency Review — PASS;
- Release Bundle CI — PASS;
- Release Contract CI — PASS, including YAML parse + release semantics/trust-order tests.

## Runtime-evidence boundary

The production container topology is already runtime-proven by #25 and `Release Bundle CI`.

The `release: published` registry/OIDC path cannot execute from a pull request and is therefore **implemented and PR-verified, not yet runtime-proven**. After merge, the required next step is a real GitHub **prerelease** (not stable), e.g. `v0.1.0-rc.1`, followed by inspection of GHCR manifests/digests, scans/SBOMs/attestations, attached assets, package visibility, and confirmation that `latest` remains untouched.