### PR TITLE
docs: synchronize rc2 container-security state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - `scripts/release/verify-published-release.sh`, which rejects mutable/local-build release Compose files and smoke-tests the exact digest-pinned images pulled from the registry.
 - Versioned `release: published` workflow implementing source verification, `linux/amd64` + `linux/arm64` GHCR candidate builds, per-platform Trivy vulnerability gates and SPDX SBOMs, exact-digest Compose smoke verification, GitHub attestations, no-rebuild digest promotion, stable-only `latest`, manifest verification, checksums, and GitHub Release evidence assets.
 - Clean-checkout regression coverage that requires both release helper shell scripts to retain executable Git modes.
+- Read-only `Container Security CI` for pull requests, `main`, and daily scheduled runs; it builds the exact production API/web Dockerfiles with fresh bases and fails closed on Trivy `HIGH`/`CRITICAL` vulnerabilities before a GitHub Release is created.
 
 ### Changed
 
@@ -95,6 +96,8 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Stable and prerelease semantics are explicit: a GitHub prerelease must use a SemVer prerelease tag and can never update `latest`; stable releases may update `latest` only after the same verification path succeeds.
 - Release verification is intentionally split between read-only PR contract tests and the write-capable release-event workflow so package/OIDC permissions are never granted to ordinary pull-request CI.
 - The first real prerelease, `v0.1.0-rc.1`, exercised the actual `release: published` trigger and proved release metadata/main-ancestry checks, the full source verification suite, production web build, and 4/4 Playwright tests before stopping at the release-helper mode defect; `Release / Publish` was skipped, so no GHCR publication evidence is attributed to rc.1.
+- `v0.1.0-rc.2` proved the corrected `Release / Verify` path end to end, started `Release / Publish`, authenticated to GHCR, and built/pushed both multi-platform staging image indexes before the first Trivy gate intentionally stopped publication on a HIGH API dependency finding.
+- The final Next.js production runtime moved from full Node 24 Bookworm-slim to distroless Node 24 Debian 13/non-root, removing shell/package-manager runtime requirements while preserving the Node 24.18.1 build toolchain and verified standalone-server behavior.
 
 ### Fixed
 
@@ -110,6 +113,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Corrected the release PostgreSQL volume from the pre-18 `/var/lib/postgresql/data` mount to the PostgreSQL 18-compatible `/var/lib/postgresql` mount after the first real Compose run exposed the upstream data-layout change.
 - Release-bundle failures now print Compose service state and logs before cleanup instead of losing the root-cause evidence during teardown.
 - Preserved executable Git modes for `scripts/verify-release-bundle.sh` and `scripts/release/verify-published-release.sh` after `v0.1.0-rc.1` failed with `Permission denied` / exit 126 on a clean GitHub Actions checkout; a TDD regression test now rejects mode `100644` for either release helper.
+- Updated pgJDBC from `42.7.11` to `42.7.12` after `v0.1.0-rc.2` and the TDD PR security gate reproduced `CVE-2026-54291` (`HIGH`) in the API production image.
 
 ### Security
 
@@ -128,6 +132,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Default GitHub Actions workflow token permissions are read-only and workflows cannot approve pull requests.
 - No dependency update was allowed to weaken the pnpm minimum-release-age policy, required status checks, CodeQL, Dependency Review, contract generation, linting, or browser verification in order to become mergeable.
 - Application container runtimes use non-root users, Compose requires the database password at runtime instead of committing one, and only the web service is host-published by default.
-- `Release Bundle CI` and `Release Contract CI` remain read-only; package and OIDC write permissions exist only on the downstream release-publish job after read-only release verification succeeds.
+- `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` remain read-only; package and OIDC write permissions exist only on the downstream release-publish job after read-only release verification succeeds.
 - Release Docker/GitHub Actions are pinned to full commit SHAs, and the QEMU binfmt and BuildKit helper images are additionally pinned by digest to avoid mutable helper-image drift.
 - Both target image architectures are scanned for `HIGH` and `CRITICAL` vulnerabilities before version promotion, and release consumers are bound to immutable application-image digests through the attached Compose asset.
+- `v0.1.0-rc.2` demonstrated the release security boundary fail-closed: publication stopped at the first HIGH finding before final-package copy, attestation, SemVer promotion, evidence upload, or any stable `latest` action; remediation used dependency/runtime hardening rather than scanner suppression.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-09
+Updated: 2026-08-10
 
 ## Project
 
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A — Platform Foundation**  
-Current focus: **fix the first prerelease runtime defect, validate the corrected release pipeline with a follow-up prerelease, finish repository/release gates, then enter M0B retailer feasibility**
+Current focus: **complete one end-to-end prerelease publication (`v0.1.0-rc.3`), verify GHCR visibility/promotion evidence, finish repository gates, then enter M0B retailer feasibility**
 
 ## Product status
 
@@ -21,25 +21,14 @@ No retailer integration is considered supported until M0B proves it with accepta
 ## Completed foundation work
 
 - PR #1 — product, architecture, engineering, security, contribution, state/roadmap, and planning foundation.
-- PR #2 / M0A Task 1 — Java/Node/pnpm toolchains and monorepo conventions.
-- PR #3 / Task 2 — Java 25 + Spring Boot 4.1 API bootstrap, Maven Wrapper, architecture/context verification, API CI.
-- PR #4 / Task 3 — PostgreSQL 18 + Flyway + jOOQ + real Testcontainers persistence baseline.
-- PR #5 / Task 4 — OpenAPI 3.1 contract, tested system endpoint, generated TypeScript client, Contract CI.
-- PR #6 / Task 5 — Next.js 16 / React 19 responsive web shell, component tests, desktop/mobile Playwright, Web CI.
-- PR #7 / Task 6 — constrained Actuator health/readiness surface, executable exposure guard, observability/privacy rules.
-- PR #8 / Task 7 — CodeQL, Dependency Review, Dependabot version-update policy, and hardened security workflows.
-- PR #9 / Task 8 — reproducible `./scripts/verify.sh`, `docs/DEVELOPMENT.md`, and verified clean-runner developer workflow.
-- PR #10 — public README/documentation index, repository-governance policy, support routing, branch/workflow audit, and approved governance/release design.
-- PR #11 — unconditional required-check candidates, immutable Action SHAs, non-persisted checkout credentials, finite timeouts/concurrency, and Maven `verify` in API CI.
-- PR #12 — removal of stale `create-next-app` README/ignore boilerplate and centralized monorepo guidance.
-- PR #19 — `actions/cache` 6.1.0 maintenance after a full required-check pass.
-- PR #20 — `actions/checkout` 7.0.1 maintenance after a fresh required-check pass on current `main`.
-- PR #23 — consolidated `actions/setup-node` 7.0.0 and `dependency-review-action` 5.0.0 maintenance with corrected immutable-pin annotations and full CI/security verification.
-- PR #15 — CI-verified web dependency maintenance to Next.js 16.3.0, React/React DOM 19.2.8, and `eslint-config-next` 16.3.0.
-- PR #25 — production API/web Docker images, Next.js standalone runtime, PostgreSQL 18.4-compatible no-source-build Compose topology, and executable `Release Bundle CI` smoke verification.
-- PR #26 — merged versioned-release contract and release workflow implementation: strict SemVer/prerelease semantics, multi-platform GHCR candidates, per-platform vulnerability scans/SBOMs, immutable digest rendering, exact-published-bundle smoke verification, attestations, no-rebuild promotion, release assets, and stable-only `latest` policy.
-- PR #27 — synchronized post-merge release-engineering state before the first real release event.
-- PR #28 — executable-mode regression fix for the release helper scripts, developed TDD-first after `v0.1.0-rc.1` exposed that clean Git checkouts stored the two release helpers as non-executable files.
+- PR #2–#9 — Java/Node/pnpm workspace, Java 25 + Spring Boot API, PostgreSQL 18/Flyway/jOOQ persistence, OpenAPI/client generation, responsive Next.js/React web, constrained Actuator surface, security workflows, and unified verification.
+- PR #10–#12 — repository governance, deterministic required-check candidates, immutable Action pins, and cleanup of generated boilerplate.
+- PR #15/#19/#20/#23 — verified dependency/action maintenance without weakening compatibility or security gates.
+- PR #25 — production API/web Docker images, PostgreSQL 18.4-compatible no-source-build Compose topology, and executable `Release Bundle CI` smoke verification.
+- PR #26 — versioned release contract and staged multi-platform GHCR workflow with vulnerability scans, SBOM/provenance evidence, exact-digest smoke verification, no-rebuild promotion, release assets, and stable-only `latest` policy.
+- PR #27 — synchronized release-engineering state before the first real release event.
+- PR #28 — TDD executable-mode regression fix after `v0.1.0-rc.1` exposed non-executable release helpers on clean checkouts.
+- PR #29 — TDD container-security gate and runtime hardening after `v0.1.0-rc.2`: pgJDBC `42.7.12`, distroless non-root web runtime, and read-only PR/main/daily HIGH/CRITICAL image scanning.
 
 ## Verified platform baseline
 
@@ -52,27 +41,32 @@ No retailer integration is considered supported until M0B proves it with accepta
 - PostgreSQL 18;
 - Flyway;
 - jOOQ;
+- pgJDBC `42.7.12`;
 - Testcontainers with real PostgreSQL 18.4 in integration tests.
 
 ### Contracts and clients
 
 - OpenAPI 3.1 source contract;
 - generated `@zakup-gotov/api-client`;
+- `openapi-typescript` + `openapi-fetch`;
 - generated-schema drift gate;
 - strict TypeScript typechecking.
 
 ### Web
 
 - Next.js 16.3.0;
-- React 19.2.8;
-- TypeScript 5.x compatibility line;
-- Next.js standalone production-container output;
+- React/React DOM 19.2.8;
+- TypeScript 5.9.3 compatibility line;
+- Node 24.18.1 builder/toolchain;
+- Next.js standalone output;
+- production runtime on `gcr.io/distroless/nodejs24-debian13:nonroot`;
+- no shell or package manager required in the final web runtime;
 - Vitest + Testing Library;
-- Playwright production-browser coverage for desktop and mobile viewports.
+- production Playwright coverage for desktop and mobile viewports.
 
 ### Operations and container topology
 
-Public management HTTP surface is intentionally limited to:
+Public management HTTP surface remains intentionally limited to:
 
 - `/actuator/health`;
 - `/actuator/health/liveness`;
@@ -85,12 +79,13 @@ Production container baseline:
 
 - separate multi-stage API and web Dockerfiles;
 - non-root runtime users for both application images;
+- web runtime is distroless and starts the standalone Next.js server without a shell;
 - `compose.release.yaml` contains no local source `build:` directives;
 - PostgreSQL 18.4 uses a persistent named volume at `/var/lib/postgresql`;
 - PostgreSQL health gates API startup, API readiness gates web startup;
-- web health verifies both its own HTTP surface and API reachability over `API_BASE_URL` on the Compose network;
-- only the web service publishes a host port by default; API remains internal to the Compose network;
-- failures in release-bundle verification automatically emit Compose status/log diagnostics before cleanup.
+- web health verifies both its own HTTP surface and API reachability over `API_BASE_URL`;
+- only web publishes a host port by default; API remains internal;
+- release-bundle failures emit Compose state/log diagnostics before cleanup.
 
 ## Automated verification
 
@@ -103,91 +98,104 @@ PR/main checks currently available:
 - **CodeQL / Java**;
 - **CodeQL / JavaScript-TypeScript**;
 - **Dependency Review**;
-- **Release Bundle CI** — builds production API/web images and smoke-tests the complete PostgreSQL → API → web topology;
-- **Release Contract CI** — read-only verification of release SemVer/prerelease semantics, digest-only Compose rendering, immutable action/helper pins, release-workflow YAML syntax, build/scan/smoke/attest/promotion ordering, and executable release-helper modes in a clean checkout;
-- local/clean-runner **`./scripts/verify.sh`**;
-- local/CI **`./scripts/verify-release-bundle.sh`**.
+- **Release Bundle CI** — builds production API/web images and smoke-tests PostgreSQL → API → web;
+- **Release Contract CI** — read-only verification of SemVer/prerelease semantics, immutable release dependencies, digest-only Compose rendering, workflow syntax and release trust ordering;
+- **Container Security CI** — read-only PR/main/daily build of the exact production API/web Dockerfiles with fresh bases followed by fail-closed Trivy `HIGH`/`CRITICAL` vulnerability scans;
+- local/clean-runner `./scripts/verify.sh`;
+- local/CI `./scripts/verify-release-bundle.sh`.
 
-The currently independently verified `main` ruleset still enforces the original seven CI/security checks. `Release Bundle CI` and `Release Contract CI` are proven check candidates but are not yet independently verified as required ruleset checks.
+PR #29 proved the new security gate TDD-first: the initial workflow failed for both production images, then the same unchanged `CRITICAL,HIGH` / `exit-code: 1` policy passed after root-cause remediation. The final PR head also passed Release Bundle CI, demonstrating that the distroless startup and health-check path works in the real Compose topology.
+
+The independently verified `main` ruleset still enforces the original seven CI/security checks. `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` are proven required-check candidates but are not yet independently verified as enforced ruleset checks.
 
 ## Repository governance and security state
 
 Verified repository-admin baseline:
 
-- squash merge enabled; merge commits and rebase merge disabled;
-- auto-merge and update-branch enabled;
-- merged source branches are deleted automatically;
-- only `main` plus active PR branches are retained;
+- squash merge only;
+- auto-merge/update-branch enabled;
+- merged source branches deleted automatically;
+- steady state is `main` plus active PR branches;
 - stale/missing required checks block `main` merge;
-- default workflow token permissions are read-only and Actions cannot approve pull requests;
-- Dependency Graph enabled and SBOM endpoint available;
-- Dependabot alerts/security updates enabled;
-- secret scanning enabled;
-- secret scanning push protection enabled;
-- private vulnerability reporting enabled;
-- CodeQL and Dependency Review operational.
+- default Actions token permissions are read-only and Actions cannot approve pull requests;
+- Dependency Graph, Dependabot alerts/security updates, secret scanning, push protection, private vulnerability reporting, CodeQL, and Dependency Review are operational.
 
-The versioned release workflow intentionally separates permissions:
+Release permissions remain separated:
 
-- `Release / Verify` uses read-only repository access;
-- only `Release / Publish`, after verification, receives `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
-- ordinary PR CI never receives registry-publish or OIDC release permissions;
-- Docker/GitHub Actions are pinned to full commit SHAs;
-- QEMU binfmt and BuildKit helper images used by release publishing are also digest-pinned.
+- `Release / Verify` is read-only;
+- only downstream `Release / Publish` receives `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
+- ordinary PR CI, including `Container Security CI`, has no package/OIDC write permission;
+- security-sensitive Actions are pinned to full commit SHAs;
+- QEMU binfmt and BuildKit helper images are digest-pinned in the release workflow.
 
-## Dependency maintenance state
-
-The first Dependabot maintenance cycle was intentionally triaged rather than blindly merged:
-
-- compatible Actions updates were verified and merged;
-- compatible Next.js/React maintenance was refreshed against current `main` and passed full CI including production Web E2E;
-- TypeScript 7.0.2 remains deferred because `openapi-typescript` 7.13.0 is incompatible with it;
-- ESLint 10 remains deferred because the current web lint configuration fails under that major line;
-- `@types/node` 26 remains deferred while the repository runtime is pinned to Node 24.
-
-No required test, supply-chain, or security gate was weakened to make an automated dependency update pass.
+No `.trivyignore`, VEX suppression, severity reduction, `ignore-unfixed`, or scanner bypass was introduced to resolve `rc.2`.
 
 ## Release-engineering state
 
-### Runtime-proven
+### Runtime-proven locally and in PR CI
 
-- production API/web Docker images build successfully;
+- production API/web images build successfully;
 - PostgreSQL 18.4 → API → web Compose startup is automated and green;
 - API remains internal while web is host-published;
-- exact local production topology smoke verification is green;
 - PostgreSQL 18 volume-layout compatibility is covered by real Compose execution;
-- the real GitHub `release: published` event fires for a published prerelease and checks out the exact release tag;
-- `v0.1.0-rc.1` proved release metadata validation, the `main` ancestry guard, Java/Node/pnpm setup, full `./scripts/verify.sh`, production web build, and all four responsive Playwright tests on the release-event runner.
+- release helper executable modes are regression-tested;
+- exact production images are scanned before release in ordinary read-only CI;
+- the real GitHub `release: published` event checks out and verifies the exact release source.
 
-### First prerelease runtime finding
+### `v0.1.0-rc.1` — release-helper mode defect
 
-`v0.1.0-rc.1` targeted `d3066258915542c2488d9a3277680b2cc478d611` and was correctly marked as a GitHub prerelease. `Release / Verify` passed every step through production browser tests, then failed before container verification because `scripts/verify-release-bundle.sh` was stored in Git with mode `100644`; the runner therefore returned `Permission denied` / exit 126. `Release / Publish` was skipped, so no GHCR candidate/final images, scans, SBOM release assets, attestations, version OCI tags, or `latest` update can be claimed from rc.1.
+`rc.1` targeted `d3066258915542c2488d9a3277680b2cc478d611`. `Release / Verify` passed release metadata/main-ancestry validation, repository verification, production web build, and all responsive Playwright tests, then failed because `scripts/verify-release-bundle.sh` was stored as mode `100644`. `Release / Publish` never started.
 
-The root cause was independently confirmed from the Git tree: both `scripts/verify-release-bundle.sh` and `scripts/release/verify-published-release.sh` were `100644` while the working `scripts/verify.sh` was `100755`. PR #28 adds a regression test that first failed on both helpers and changes only those two Git tree modes to `100755`, preserving their blob contents.
+PR #28 reproduced the executable-mode problem in a regression test and corrected both release helpers to `100755`.
 
-### Merged release design awaiting successful end-to-end publication
+### `v0.1.0-rc.2` — publish path reached, security gate failed closed
 
-- strict SemVer + GitHub prerelease flag validation;
-- prereleases never move `latest`;
-- unverified multi-platform `linux/amd64` + `linux/arm64` API/web candidates are isolated in staging packages;
-- BuildKit provenance and SBOM attestations;
-- per-platform `HIGH`/`CRITICAL` Trivy vulnerability gates;
-- per-platform SPDX JSON SBOM release evidence;
-- staging candidate and final-package Compose bundles are rendered from exact GHCR digests and smoke-tested in sequence;
-- verified staging digests are copied without rebuild into final packages under deterministic `verified-<source-sha>` tags;
-- GitHub provenance attestations are pushed for the final-package image digests;
-- SemVer tags are created only after final-package smoke verification and attestation;
-- stable `latest` promotion is conditional and unavailable to prereleases;
-- manifest verification for amd64/arm64;
-- release verification JSON, manifests, scans, SBOMs, checksums, and digest-pinned Compose are attached as GitHub Release assets.
+`rc.2` targeted corrected `main` at `184751e164f199fdc5262cf77ea86c931daf59f7`.
 
-A follow-up prerelease from corrected `main` is required before the publishing path moves from implementation evidence to complete runtime evidence. GHCR package visibility must also be checked after first successful publication; a public source repository alone is not treated as proof of anonymous image pullability.
+Proven by the real release event:
+
+- `Release / Verify` completed successfully, including the production container bundle;
+- `Release / Publish` started with its separate write-capable permission boundary;
+- GHCR login, QEMU, and Buildx setup succeeded;
+- both API and web multi-platform staging candidate indexes built and pushed for `linux/amd64` + `linux/arm64`;
+- publication stopped at the first Trivy gate before any final-package/version promotion.
+
+The exact API blocker was `org.postgresql:postgresql 42.7.11`, `CVE-2026-54291` (`HIGH`), fixed in `42.7.12`; the API Ubuntu runtime itself had zero HIGH/CRITICAL findings.
+
+A TDD reproduction moved the same policy into ordinary CI before applying fixes. It additionally showed that the old Node Bookworm-slim web runtime carried 22 Debian HIGH/CRITICAL findings plus 7 npm/runtime-library findings, while the application Next.js/React packages were clean at that threshold. PR #29 therefore updated pgJDBC and replaced only the final web runtime with distroless Node 24 Debian 13/non-root rather than suppressing findings.
+
+Because `rc.2` failed before promotion, it does **not** prove final packages, GitHub provenance attestations, SemVer OCI tags, release evidence assets, or a successful final digest-pinned Compose smoke. No `latest` update is attributed to `rc.2`.
+
+### Merged release design still awaiting complete end-to-end publication
+
+The workflow still requires this sequence:
+
+1. strict SemVer + GitHub prerelease-state validation;
+2. multi-platform staging builds for API/web;
+3. both-platform HIGH/CRITICAL scans and SPDX SBOM evidence;
+4. staging digest-pinned Compose smoke;
+5. no-rebuild copy into final packages under deterministic `verified-<source-sha>` tags;
+6. final-package digest-pinned Compose smoke;
+7. GitHub provenance attestations;
+8. SemVer tag promotion without rebuild;
+9. stable-only optional `latest`;
+10. amd64/arm64 manifest verification and release evidence upload.
+
+A successful `v0.1.0-rc.3` is required before this path can be called fully runtime-proven. GHCR package visibility must then be independently checked: staging must remain private, and final package anonymous/public availability must not be claimed unless explicitly verified.
 
 See [`RELEASES.md`](RELEASES.md).
 
+## Dependency maintenance state
+
+Compatible dependency/Actions maintenance is merged only after full verification. Known incompatible major updates remain intentionally deferred rather than bypassed:
+
+- TypeScript 7.0.2 is incompatible with the current `openapi-typescript 7.13.0` peer range;
+- ESLint 10 breaks the current lint configuration;
+- `@types/node` 26 remains deferred while the toolchain/runtime line is Node 24.
+
 ## Approved engineering policy
 
-[`ENGINEERING.md`](ENGINEERING.md) is mandatory repository policy:
+[`ENGINEERING.md`](ENGINEERING.md) remains mandatory:
 
 - TDD for executable behavior;
 - evidence before completion claims;
@@ -203,16 +211,17 @@ See [`RELEASES.md`](RELEASES.md).
 1. Which target retailers expose a technically stable and legally acceptable path to location-specific catalog, price, and availability data?
 2. Can at least two providers achieve useful basket coverage with acceptable freshness/reliability?
 3. What location precision must be used transiently and what, if anything, may be persisted?
-4. How can delivery fees/minimum order constraints be obtained and normalized per retailer?
-5. What deterministic product-matching quality is achievable before any AI-assisted stage is justified?
+4. How can delivery fees/minimum-order constraints be obtained and normalized per retailer?
+5. What deterministic product-matching quality is achievable before AI assistance is justified?
 
 ## Immediate next work
 
-1. Publish a follow-up **prerelease** from corrected `main` (expected `v0.1.0-rc.2`) and verify both `Release / Verify` and `Release / Publish` end to end.
-2. Verify multi-platform GHCR digests, Trivy gates, SBOMs, attestations, attached evidence, both staging/final exact digest-pinned Compose smoke tests, and confirm that prerelease publication leaves `latest` untouched.
-3. Verify staging packages remain private and verify the intended final GHCR package visibility; do not claim anonymous availability before it is proven.
-4. Add `Release Bundle CI` and `Release Contract CI` to the `main` ruleset when the settings API/UI change can be applied and independently verified.
-5. Run final M0A verification, then hand off to separately planned M0B Retailer Feasibility.
+1. Publish **`v0.1.0-rc.3`** from current verified `main`; do not reuse `rc.1` or `rc.2`.
+2. Require both `Release / Verify` and `Release / Publish` to complete end to end.
+3. Inspect multi-platform digests, Trivy results, SBOMs, attestations, staging/final exact-digest Compose smoke tests, manifests, checksums, and attached release evidence; confirm prerelease publication leaves `latest` untouched.
+4. Verify staging packages remain private and verify the intended final GHCR package visibility independently.
+5. Add `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` to the `main` ruleset when the settings mutation can be applied and independently verified.
+6. Run final M0A verification, then hand off to separately planned M0B Retailer Feasibility.
 
 ## Definition of M0 success
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,126 +1,189 @@
 # Releases
 
-Zakup Gotov is still **pre-release**. The production container topology is exercised in normal CI. The versioned GHCR publishing workflow has now received its first real `release: published` execution, but it is not yet considered end-to-end runtime-proven because `v0.1.0-rc.1` exposed and stopped on a release-helper executable-mode defect before the publish job began.
+Zakup Gotov is still **pre-release**. The production container topology is exercised in normal CI, and two real GitHub prereleases have now exercised progressively more of the versioned GHCR pipeline. The workflow is not yet considered end-to-end runtime-proven: `v0.1.0-rc.1` exposed a clean-checkout executable-mode defect, while `v0.1.0-rc.2` reached multi-platform publishing and then correctly failed closed at the first container vulnerability gate.
 
 ## Verified container bundle
 
 The repository has an executable production-container baseline:
 
 - `apps/api/Dockerfile` builds the Spring Boot API and runs it as a non-root user;
-- `apps/web/Dockerfile` builds the Next.js standalone server and runs it as a non-root user;
+- `apps/web/Dockerfile` builds the Next.js standalone server and runs its final stage on distroless Node 24 Debian 13 as non-root;
+- the final web runtime does not require a shell or package manager;
 - `compose.release.yaml` starts PostgreSQL 18.4, API, and web without Compose `build:` directives;
-- PostgreSQL data is stored in a named volume mounted at the PostgreSQL 18-compatible `/var/lib/postgresql` path;
-- API waits for PostgreSQL health;
-- web waits for API readiness and its healthcheck verifies both its own HTTP surface and the configured API over the Compose network;
-- only the web service is published to the host by default;
-- `Release Bundle CI` builds both application images, starts the complete bundle, waits for health, smoke-tests API readiness inside the API container, and verifies the public web page;
-- failing bundle verification prints Compose status and logs before cleanup.
+- PostgreSQL data uses the PostgreSQL 18-compatible `/var/lib/postgresql` volume path;
+- PostgreSQL health gates API startup, API readiness gates web startup;
+- web health verifies both its own HTTP surface and the configured API over the Compose network;
+- only web is published to the host by default;
+- `Release Bundle CI` builds both application images, starts the complete topology, waits for health, smoke-tests API readiness inside the API container, and verifies the public web page;
+- failing bundle verification prints Compose status/logs before cleanup.
 
-Run the same executable contract locally with a running Docker daemon and Docker Compose v2:
+Run the same contract locally with Docker and Compose v2:
 
 ```bash
 ./scripts/verify-release-bundle.sh
 ```
 
-## Versioned release contract
+## Pre-release container-security gate
 
-The repository contains two separate verification layers for versioned releases.
+`Container Security CI` now runs in ordinary read-only CI on pull requests, `main`, and a daily schedule. It:
+
+1. builds the exact production API and web Dockerfiles with `--pull`;
+2. scans each resulting production image with the same Trivy `vuln` policy used by release publication;
+3. fails on `HIGH` or `CRITICAL` findings (`exit-code: 1`).
+
+It intentionally has only `contents: read`; it cannot publish packages or request OIDC credentials. The release workflow still performs its stronger per-platform scans on both `linux/amd64` and `linux/arm64` staging candidates before promotion.
+
+No `.trivyignore`, `ignore-unfixed`, VEX suppression, severity downgrade, or scanner bypass was added to make this gate green.
+
+## Versioned release contract
 
 ### Read-only release contract
 
-`Release Contract CI` runs on ordinary pull requests with only `contents: read`. It verifies:
+`Release Contract CI` verifies without write permissions:
 
-- strict release tags in the form `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-prerelease`;
-- consistency between SemVer prerelease state and the GitHub Release `prerelease` flag;
-- prereleases can never publish the `latest` tag;
-- repository-scoped GHCR image names are normalized to lowercase;
-- unverified candidates use separate `*-staging-api` / `*-staging-web` package names rather than final package names;
+- strict tags `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-prerelease`;
+- consistency between SemVer prerelease state and the GitHub Release prerelease flag;
+- prereleases can never publish `latest`;
+- normalized lowercase final/staging GHCR package names;
+- unverified candidates remain in separate staging packages;
 - final-package pre-version copies use deterministic `verified-<source-sha>` tags;
-- application images in a release-specific Compose file must be GHCR references pinned by `sha256` digest;
-- release helper shell scripts retain executable modes in a clean Git checkout;
-- the release workflow uses immutable full-SHA action pins;
-- QEMU and BuildKit helper images are themselves digest-pinned;
-- build, scan, staging smoke, final-package copy, final-package smoke, attestation, version promotion, optional `latest`, and release-asset upload remain in the approved trust order;
-- `release.yml` remains syntactically parseable YAML.
-
-This keeps security-sensitive release semantics testable without granting package or OIDC write permissions to pull-request CI.
+- release Compose application references must be GHCR `sha256` digests;
+- release helper scripts retain executable Git modes;
+- release Actions use immutable full-SHA pins;
+- QEMU and BuildKit helper images are digest-pinned;
+- build → scan → staging smoke → final-package copy → final smoke → attestation → version promotion → optional `latest` → evidence upload remains the approved trust order;
+- `release.yml` remains valid YAML.
 
 ### Published-release workflow
 
-`.github/workflows/release.yml` is triggered only by a **published GitHub Release**. It has two jobs with distinct trust boundaries.
+`.github/workflows/release.yml` triggers only for a **published GitHub Release**.
 
-`Release / Verify` remains read-only and requires the tagged commit to be contained in `main`. It reruns repository verification, responsive production-browser tests, and the production container-bundle smoke test.
+`Release / Verify` stays read-only and requires the tagged commit to be contained in `main`. It reruns repository verification, production browser tests, and the production container-bundle smoke test.
 
-Only after that succeeds, `Release / Publish` receives narrowly scoped release permissions and performs this sequence:
+Only after verification succeeds does `Release / Publish` receive `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`. Its intended sequence is:
 
-1. validate release metadata and derive lowercase final/staging GHCR package names;
-2. authenticate to GHCR with the workflow token;
-3. build and push candidate API/web image indexes for `linux/amd64` and `linux/arm64` into dedicated staging packages;
-4. generate BuildKit provenance and SBOM attestations during the build;
-5. scan both target platforms of both staging images for `HIGH` and `CRITICAL` vulnerabilities;
-6. generate per-platform SPDX JSON SBOM files as release evidence;
-7. render a temporary Compose file with the exact staging image digests and smoke-test that registry-pulled bundle;
-8. copy those verified indexes **without rebuild** into the final API/web packages under `verified-<source-sha>` tags and require the copied digest to remain identical;
-9. render the release Compose file using the final package names with those exact digests and smoke-test the final-package bundle;
-10. create GitHub provenance attestations for the final-package image digests;
-11. only now create the SemVer version tags from the already verified final-package digests, again without rebuild;
-12. move `latest` only when the release is stable;
-13. verify the final manifests contain both target Linux architectures;
-14. attach the digest-pinned Compose file, manifests, vulnerability reports, SBOMs, verification metadata, and checksums to the GitHub Release.
+1. validate release metadata and derive final/staging image names;
+2. authenticate to GHCR;
+3. build/push API and web staging indexes for `linux/amd64` and `linux/arm64` with BuildKit provenance/SBOM;
+4. scan both platforms of both staging images for `HIGH`/`CRITICAL` vulnerabilities;
+5. generate per-platform SPDX JSON SBOM evidence;
+6. render and smoke-test a Compose bundle pinned to exact staging digests;
+7. copy verified indexes **without rebuild** into final packages under `verified-<source-sha>`, requiring digest identity;
+8. render and smoke-test a Compose bundle pinned to exact final-package digests;
+9. create GitHub provenance attestations for final digests;
+10. create SemVer tags from the already verified digests, without rebuild;
+11. move `latest` only for stable releases;
+12. verify final manifests contain both target architectures;
+13. attach Compose, manifests, vulnerability reports, SBOMs, verification metadata, and checksums to the GitHub Release.
 
-The staging packages are intentionally separate from the final packages so an unverified candidate is never placed in a future public release package. Staging packages must remain private. Final package visibility is a separate product/distribution setting and is verified independently after first successful publication.
+Staging packages are a private trust boundary. Final package visibility is a separate distribution decision and must be verified independently.
 
-Docker Actions are pinned to immutable commit SHAs. The QEMU binfmt helper image and BuildKit daemon image are also pinned by digest so the release builder does not silently inherit mutable `latest`/`buildx-stable-1` dependencies.
+## Runtime validation 1: `v0.1.0-rc.1`
 
-## First runtime validation: `v0.1.0-rc.1`
+`v0.1.0-rc.1` was published on 2026-08-09 as a GitHub prerelease targeting `d3066258915542c2488d9a3277680b2cc478d611`.
 
-The first real prerelease was published on 2026-08-09 as `v0.1.0-rc.1`, marked as a GitHub prerelease and targeting commit `d3066258915542c2488d9a3277680b2cc478d611`.
+Proven before failure:
 
-The real `release: published` workflow fired and proved the following on the release-event runner:
+- release metadata validation including `publish_latest=false`;
+- release source contained in `main`;
+- Java 25 / Node 24.18.1 / pnpm 11.4.0 setup;
+- complete `./scripts/verify.sh`;
+- production web build;
+- responsive Playwright **4/4**.
 
-- release metadata validation passed, including `publish_latest=false`;
-- the release commit was confirmed to be contained in `main`;
-- Java 25, Node 24.18.1, and pnpm 11.4.0 setup passed;
-- the complete `./scripts/verify.sh` suite passed;
-- production web build passed;
-- responsive Playwright coverage passed **4/4**;
-- the workflow reached production container-bundle verification.
+It then failed before container verification because `scripts/verify-release-bundle.sh` was stored as Git mode `100644`. The later publish helper was found with the same mode. `Release / Publish` was skipped, so no GHCR publication evidence is attributed to rc.1.
 
-The run then failed before executing the bundle because `scripts/verify-release-bundle.sh` was stored in Git as mode `100644`. A clean Linux checkout therefore returned `Permission denied` / exit 126 when the workflow invoked the script directly. The same Git-tree audit found `scripts/release/verify-published-release.sh` was also `100644`, so the later publish smoke would have had the same defect.
+PR #28 added a regression test that was observed RED against the old modes, then changed both helpers to `100755` without changing their script contents.
 
-`Release / Publish` was skipped because `Release / Verify` failed. Therefore rc.1 produced **no verified GHCR publication path evidence**: no candidate/final application images, release vulnerability reports, release SBOM assets, final-package attestations, SemVer OCI tags, or `latest` update are claimed from that run.
+## Runtime validation 2: `v0.1.0-rc.2`
 
-The fix is intentionally at the source rather than in the workflow command: both release helpers are stored as `100755`, and `Release Contract CI` now has a clean-checkout regression test for their executable modes. The test was observed RED against the old `100644` modes before the mode-only fix made it GREEN.
+`v0.1.0-rc.2` was published from corrected `main` at `184751e164f199fdc5262cf77ea86c931daf59f7`.
 
-## Next validation
+This run advanced the proof boundary substantially:
 
-The next runtime validation must be a **new prerelease** from corrected `main`; do not rerun rc.1 because its immutable tag points at the defective source commit. The expected next tag is:
+- **`Release / Verify` passed completely**, including production container-bundle verification;
+- `Release / Publish` started with its separate write-capable permission set;
+- GHCR authentication, QEMU, and Buildx setup passed;
+- API and web multi-platform staging candidate indexes were built and pushed for `linux/amd64` + `linux/arm64`;
+- the workflow reached the first real release vulnerability scan.
+
+The release then stopped fail-closed at `API / amd64` Trivy scanning. The concrete blocker was:
+
+- `org.postgresql:postgresql` `42.7.11`;
+- `CVE-2026-54291`;
+- severity `HIGH`;
+- fixed version `42.7.12`.
+
+The API's Ubuntu runtime OS itself produced zero HIGH/CRITICAL findings at that gate.
+
+### TDD reproduction and broader runtime finding
+
+Before changing production code, PR #29 introduced the ordinary `Container Security CI` and observed both production images fail under the unchanged HIGH/CRITICAL policy.
+
+The web failure showed that the previous `node:24.18.1-bookworm-slim` final runtime carried:
+
+- 22 Debian HIGH/CRITICAL findings;
+- 7 npm/runtime-library HIGH/CRITICAL findings;
+- no HIGH/CRITICAL findings in the actual Next.js/React application packages at that threshold.
+
+Rather than suppressing scanner results, PR #29:
+
+- updated pgJDBC to `42.7.12`;
+- moved only the final web runtime to `gcr.io/distroless/nodejs24-debian13:nonroot`;
+- removed shell/package-manager requirements from web startup;
+- changed Docker/Compose health execution to the distroless Node binary;
+- retained the same fail-closed Trivy policy.
+
+The same security workflow then passed for API and web, and `Release Bundle CI` passed the complete PostgreSQL → API → web topology on the exact final PR head.
+
+### What rc.2 does not prove
+
+Because `rc.2` stopped before staging smoke/promotion, it does **not** prove:
+
+- staging digest-pinned Compose smoke;
+- final-package copy or final-package digest smoke;
+- GitHub final-image attestations;
+- SemVer OCI version tags;
+- final manifest verification;
+- attached release SBOM/scan/checksum evidence;
+- final GHCR package visibility.
+
+No `latest` update is attributed to rc.2.
+
+## Next validation: `v0.1.0-rc.3`
+
+The next validation must be a **new immutable prerelease** from current verified `main`:
 
 ```text
-v0.1.0-rc.2
+v0.1.0-rc.3
 ```
 
-It must remain a GitHub prerelease. A successful rc.2 must:
+Do not rerun or retarget rc.1/rc.2.
 
-- pass both `Release / Verify` and `Release / Publish`;
-- create and verify both target architectures;
-- pass all vulnerability and digest-pinned staging/final smoke gates;
-- attach the expected evidence assets;
-- preserve `latest` untouched;
+A successful rc.3 must:
+
+- pass both `Release / Verify` and `Release / Publish` end to end;
+- verify both target architectures for API and web;
+- pass every release Trivy and SBOM step;
+- pass staging and final-package exact-digest Compose smoke tests;
+- create final-package GitHub provenance attestations;
+- promote the exact verified digests to the prerelease SemVer tags without rebuild;
+- attach all expected release evidence and checksums;
+- demonstrate that prerelease publication leaves `latest` untouched;
 - keep staging packages private;
-- allow final package visibility to be verified independently.
+- allow final package visibility/anonymous pull behavior to be verified independently.
 
-Do not create a stable release until at least one prerelease has exercised the complete workflow successfully and its attached evidence has been inspected.
+Do not create a stable release until at least one prerelease has completed the full workflow and its evidence has been inspected.
 
 ## GHCR visibility
 
-Package publication and package visibility are separate concerns.
+Package publication and package visibility are separate concerns:
 
-- staging packages are an internal release-engineering boundary and must remain private;
-- final API/web packages may be made public only as a deliberate distribution decision;
-- a public source repository is not treated as proof that a newly created GHCR package is anonymously pullable.
+- staging packages must remain private;
+- final API/web packages may be public only as a deliberate distribution decision;
+- public repository visibility is not evidence that a new GHCR package is anonymously pullable.
 
-After the first successful prerelease, verify both staging-package privacy and final-package visibility explicitly. Until final-package visibility is proven, documentation must not promise anonymous public pulls.
+After the first successful prerelease, verify both staging privacy and final-package visibility explicitly before documenting anonymous pull instructions.
 
 ## Manual local start
 
@@ -131,7 +194,7 @@ docker build -t zakup-gotov-api:local -f apps/api/Dockerfile .
 docker build -t zakup-gotov-web:local -f apps/web/Dockerfile .
 ```
 
-Then provide runtime values and start the bundle:
+Then start the bundle:
 
 ```bash
 export API_IMAGE='zakup-gotov-api:local'
@@ -144,18 +207,18 @@ docker compose -f compose.release.yaml up -d --wait
 
 Open `http://localhost:3000`.
 
-The API remains internal to the Compose network. The web container reaches it through `API_BASE_URL=http://api:8080`.
+The API remains internal; web reaches it through `API_BASE_URL=http://api:8080`.
 
-Stop containers while retaining database data:
+Stop while retaining database data:
 
 ```bash
 docker compose -f compose.release.yaml down
 ```
 
-Remove containers **and** the PostgreSQL volume only when destructive data removal is intended:
+Remove containers **and** the PostgreSQL volume only when destructive removal is intended:
 
 ```bash
 docker compose -f compose.release.yaml down --volumes
 ```
 
-Never commit a real database password or a populated local `.env` file.
+Never commit a real database password or populated local `.env` file.

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -51,7 +51,8 @@ Required checks are activated only after they have completed successfully at lea
 Additional proven candidates:
 
 - `Release Bundle CI` — builds the production API/web images and executes the full PostgreSQL → API → web Compose topology;
-- `Release Contract CI` — verifies version/prerelease semantics, digest-only release Compose rendering, immutable release dependencies, release-workflow syntax, and security/promotion ordering without write permissions.
+- `Release Contract CI` — verifies version/prerelease semantics, digest-only release Compose rendering, immutable release dependencies, release-workflow syntax, and security/promotion ordering without write permissions;
+- `Container Security / API` and `Container Security / Web` — build the exact production images with fresh base images and fail closed on Trivy `HIGH`/`CRITICAL` vulnerabilities before release publication.
 
 These candidates should be added to `main` required checks only when the ruleset change can be applied and independently verified. Documentation must not describe them as already enforced until then.
 
@@ -74,14 +75,23 @@ Third-party and GitHub-owned actions in permanent security-sensitive workflows a
 
 Do not grant workflows permission to approve pull requests.
 
-Release boundaries:
+Release and container-security boundaries:
 
 - `Release Bundle CI` is ordinary read-only PR/main verification;
 - `Release Contract CI` is ordinary read-only PR/main verification;
+- `Container Security CI` is ordinary read-only PR/main/daily verification and must not receive package or OIDC write permissions;
 - `.github/workflows/release.yml` runs only for a published GitHub Release;
 - its `Release / Verify` job remains `contents: read`;
 - only the downstream `Release / Publish` job may receive `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
 - package/OIDC write permissions must never be copied into ordinary PR CI.
+
+Container vulnerability policy:
+
+- exact production API/web Dockerfiles are scanned before release in ordinary CI;
+- the release workflow still performs both-platform scans on the published staging candidates;
+- `HIGH` and `CRITICAL` findings fail the gate;
+- scanner ignores, severity reduction, `ignore-unfixed`, or equivalent bypasses require explicit security justification and must never be introduced merely to unblock a release;
+- removing unnecessary runtime software is preferred over suppressing findings when the software is not required for application execution.
 
 ## Security features
 
@@ -93,6 +103,7 @@ Target security baseline for this public repository:
 - Dependabot version updates;
 - CodeQL code scanning;
 - Dependency Review on pull requests;
+- production-container vulnerability scanning before release;
 - secret scanning;
 - push protection;
 - Private Vulnerability Reporting;
@@ -126,11 +137,13 @@ Runtime-proven production container baseline:
 
 - separate production `api` and `web` images;
 - Next.js standalone runtime;
+- distroless non-root final web runtime with no shell/package-manager dependency;
 - a no-source-build Compose definition for `web + api + PostgreSQL 18.4`;
 - persistent PostgreSQL named volume;
 - explicit health/readiness dependencies;
 - API kept internal to the Compose network while the web port is host-published;
-- automated exact-topology startup/smoke verification with failure diagnostics.
+- automated exact-topology startup/smoke verification with failure diagnostics;
+- read-only pre-release production-image HIGH/CRITICAL scanning.
 
 Implemented versioned publishing contract:
 
@@ -142,14 +155,14 @@ Implemented versioned publishing contract:
 - per-platform SPDX SBOM evidence is generated;
 - BuildKit provenance/SBOM and GitHub provenance attestations are created for exact image digests;
 - release-specific Compose is pinned to immutable application-image digests;
-- that exact published digest set is pulled and smoke-tested before promotion;
+- staging and final-package digest sets are pulled and smoke-tested before version promotion;
 - promotion copies the verified image indexes without rebuild;
 - stable releases may update `latest`; prereleases never do;
 - Compose, manifests, scans, SBOMs, verification metadata, and checksums are attached to the GitHub Release.
 
-This release-event path must be exercised by a real prerelease before it is considered runtime-proven. A stable release should not be used for first validation.
+`v0.1.0-rc.1` and `v0.1.0-rc.2` have exercised the real release-event path and exposed two defects at progressively later boundaries. Neither constitutes complete end-to-end publication proof. A new prerelease must complete the full workflow before a stable release is considered.
 
-GHCR package visibility must be independently checked after first publication. Public repository visibility is not treated as evidence that new package images are anonymously pullable.
+GHCR package visibility must be independently checked after the first successful publication. Public repository visibility is not treated as evidence that new package images are anonymously pullable.
 
 ## Audit cadence
 


### PR DESCRIPTION
## Summary
Synchronize repository truth after merged PR #29 and the real `v0.1.0-rc.2` release run.

## Recorded evidence
- rc.1 release-helper executable-mode failure and PR #28 fix remain preserved;
- rc.2 fully passed `Release / Verify`, entered `Release / Publish`, authenticated/published both multi-platform staging candidates, then failed closed at the first Trivy gate;
- API finding is recorded as pgJDBC 42.7.11 / CVE-2026-54291 HIGH / fixed in 42.7.12;
- PR #29 TDD reproduction and the broader old web-runtime findings are recorded;
- the new read-only `Container Security CI` and distroless web runtime are part of the verified baseline;
- no scanner suppression or severity weakening is claimed or permitted;
- `v0.1.0-rc.3` is now the next immutable release validation target;
- GHCR staging/final visibility and the additional required-check candidates remain explicitly unproven until verified.

## Files
- `docs/PROJECT_STATE.md`
- `docs/RELEASES.md`
- `docs/REPOSITORY_GOVERNANCE.md`
- `CHANGELOG.md`

Docs-only change; no executable behavior is modified.