### PR TITLE
spike(provider): test Pyaterochka plain HTTP path

### DIFF
--- a/.github/workflows/provider-live-probe.yml
+++ b/.github/workflows/provider-live-probe.yml
@@ -1,0 +1,75 @@
+name: Provider Live Probe
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-live-probe-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pyaterochka:
+    name: Pyaterochka Plain HTTP Phase A
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 38 &&
+       github.actor == 'True-Ruslan' &&
+       github.event.comment.body == '/provider-probe pyaterochka')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Pyaterochka plain HTTP Phase A
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=PyaterochkaPlainHttpProbeTest \
+            -Dzakup.live.pyaterochka=true \
+            test 2>&1 | tee "$RUNNER_TEMP/pyaterochka-live-probe.log"
+
+      - name: Publish sanitized evidence summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo '## Pyaterochka plain HTTP Phase A' >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "$RUNNER_TEMP/pyaterochka-live-probe.log" ]]; then
+            evidence="$(grep -F 'PYATEROCHKA_PHASE_A' "$RUNNER_TEMP/pyaterochka-live-probe.log" | tail -n 1 || true)"
+            if [[ -n "$evidence" ]]; then
+              printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo 'No successful Phase A evidence line was emitted; inspect the test failure/status without copying response bodies.' >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo 'Probe log was not created.' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - `docs/integrations/retailer-feasibility.md` with evidence-based provider decision labels, initial Kuper/Yandex Eats/Lenta/VkusVill/Magnit/X5 research, explicit no-scraping boundaries, and deterministic fixture/live-probe acceptance criteria for M0B.
 - Shared M0B provider feasibility harness: `ProviderAccessType`, `ProviderCapability`, provider-scoped `LocationContext`, `ProductQuery`, the `RetailerProvider` port, structural `FixtureRetailerProvider`/`LiveRetailerProvider` separation, offline `ProviderFeasibilityHarness`, and explicit `ProviderLiveProbe`.
 - Expanded retailer-feasibility research and `docs/superpowers/plans/2026-08-10-m0b-provider-spikes.md`, covering Pyaterochka, Perekrestok, Magnit, Chizhik, Ozon Fresh, Samokat and Kuper with a fixed 20-item corpus and measurable M0 decision criteria.
+- Pyaterochka/5ka Phase A plain-HTTP probe using the JDK HTTP client with store-scoped request construction, fixed timeouts, no retries or browser-derived credentials/headers, and an opt-in read-only `Provider Live Probe` workflow that emits only sanitized status evidence.
 
 ### Changed
 
@@ -103,6 +104,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - `v0.1.0-rc.2` proved the corrected `Release / Verify` path end to end, started `Release / Publish`, authenticated to GHCR, and built/pushed both multi-platform staging image indexes before the first Trivy gate intentionally stopped publication on a HIGH API dependency finding.
 - The final Next.js production runtime moved from full Node 24 Bookworm-slim to distroless Node 24 Debian 13/non-root, removing shell/package-manager runtime requirements while preserving the Node 24.18.1 build toolchain and verified standalone-server behavior.
 - M0B now permits controlled evaluation of `PUBLIC_UNOFFICIAL_API` consumer backends when ordinary requests work without access-control or anti-bot circumvention; third-party wrappers remain research evidence rather than an inherited permission or production dependency.
+- Pyaterochka is now an active Phase A spike rather than a paper candidate: the exact public-backend request hypotheses and non-evasive probe are executable, while provider support remains explicitly blocked on the real raw-HTTP result.
 
 ### Fixed
 
@@ -142,3 +144,4 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Both target image architectures are scanned for `HIGH` and `CRITICAL` vulnerabilities before version promotion, and release consumers are bound to immutable application-image digests through the attached Compose asset.
 - `v0.1.0-rc.2` demonstrated the release security boundary fail-closed: publication stopped at the first HIGH finding before final-package copy, attestation, SemVer promotion, evidence upload, or any stable `latest` action; remediation used dependency/runtime hardening rather than scanner suppression.
 - Provider feasibility deliberately excludes CAPTCHA/anti-bot bypass, browser-fingerprint evasion and proxy/IP rotation used to circumvent blocking; offline feasibility code accepts fixture-provider types while live-capable adapters require the separate explicit live-probe entry point.
+- The Pyaterochka live-probe workflow has read-only repository permissions, no secrets, a fixed owner/issue command gate, finite timeouts, no retry/evasion behavior, and emits only sanitized status evidence rather than retailer response bodies or exact store/product IDs.

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/pyaterochka/PyaterochkaPlainHttpProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/pyaterochka/PyaterochkaPlainHttpProbe.java
@@ -1,0 +1,134 @@
+package io.github.trueruslan.zakupgotov.provider.pyaterochka;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+final class PyaterochkaPlainHttpProbe {
+
+    private static final String API_BASE = "https://5d.5ka.ru/api";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
+    private static final Map<String, String> REQUEST_HEADERS = Map.of(
+            "Accept", "application/json",
+            "User-Agent", "ZakupGotov-M0B-PlainHttpProbe/0.1 (+https://github.com/True-Ruslan/zakup-gotov)");
+    private static final Pattern SAP_CODE = Pattern.compile("\\\"sapCode\\\"\\s*:\\s*\\\"?([^\\\",}]+)\\\"?");
+    private static final Pattern PLU = Pattern.compile("\\\"plu\\\"\\s*:\\s*\\\"?([^\\\",}]+)\\\"?");
+    private static final Pattern PRICE_FIELD = Pattern.compile("\\\"[^\\\"]*price[^\\\"]*\\\"\\s*:", Pattern.CASE_INSENSITIVE);
+
+    private final HttpClient httpClient;
+
+    private PyaterochkaPlainHttpProbe(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    static PyaterochkaPlainHttpProbe create() {
+        return new PyaterochkaPlainHttpProbe(HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    Map<String, String> requestHeaders() {
+        return REQUEST_HEADERS;
+    }
+
+    URI storeLookupUri(double longitude, double latitude) {
+        return URI.create(API_BASE + "/orders/v1/orders/stores/?lon=" + longitude + "&lat=" + latitude);
+    }
+
+    URI searchUri(String sapCode, String query, int limit) {
+        if (sapCode == null || sapCode.isBlank()) {
+            throw new IllegalArgumentException("sapCode must not be blank");
+        }
+        if (query == null || query.isBlank()) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
+        if (limit < 1 || limit > 20) {
+            throw new IllegalArgumentException("limit must be between 1 and 20");
+        }
+        var encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8).replace("+", "%20");
+        return URI.create(API_BASE + "/catalog/v3/stores/" + sapCode + "/search"
+                + "?mode=store&include_restrict=true&q=" + encodedQuery + "&limit=" + limit);
+    }
+
+    PhaseAResult runPhaseA(double longitude, double latitude, String query) throws IOException, InterruptedException {
+        var storeResponse = get(storeLookupUri(longitude, latitude));
+        if (!isSuccess(storeResponse.statusCode())) {
+            return PhaseAResult.storeGateFailed(storeResponse.statusCode());
+        }
+
+        var sapCode = firstMatch(SAP_CODE, storeResponse.body());
+        if (sapCode.isEmpty()) {
+            return PhaseAResult.storeShapeFailed(storeResponse.statusCode());
+        }
+
+        var searchResponse = get(searchUri(sapCode.get(), query, 3));
+        if (!isSuccess(searchResponse.statusCode())) {
+            return PhaseAResult.searchGateFailed(storeResponse.statusCode(), sapCode.get(), searchResponse.statusCode());
+        }
+
+        var plu = firstMatch(PLU, searchResponse.body());
+        var priceEvidence = PRICE_FIELD.matcher(searchResponse.body()).find();
+        return new PhaseAResult(
+                storeResponse.statusCode(),
+                sapCode.get(),
+                searchResponse.statusCode(),
+                plu.orElse(""),
+                priceEvidence);
+    }
+
+    private HttpResponse<String> get(URI uri) throws IOException, InterruptedException {
+        var builder = HttpRequest.newBuilder(uri)
+                .GET()
+                .timeout(REQUEST_TIMEOUT);
+        REQUEST_HEADERS.forEach(builder::header);
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private static boolean isSuccess(int status) {
+        return status >= 200 && status < 300;
+    }
+
+    private static Optional<String> firstMatch(Pattern pattern, String body) {
+        var matcher = pattern.matcher(body == null ? "" : body);
+        return matcher.find() ? Optional.of(matcher.group(1).trim()) : Optional.empty();
+    }
+
+    record PhaseAResult(
+            int storeLookupStatus,
+            String sapCode,
+            int searchStatus,
+            String productPlu,
+            boolean priceEvidence) {
+
+        static PhaseAResult storeGateFailed(int status) {
+            return new PhaseAResult(status, "", -1, "", false);
+        }
+
+        static PhaseAResult storeShapeFailed(int status) {
+            return new PhaseAResult(status, "", -1, "", false);
+        }
+
+        static PhaseAResult searchGateFailed(int storeStatus, String sapCode, int searchStatus) {
+            return new PhaseAResult(storeStatus, sapCode, searchStatus, "", false);
+        }
+
+        String toEvidenceLine() {
+            return "PYATEROCHKA_PHASE_A"
+                    + " store_status=" + storeLookupStatus
+                    + " sap_code_present=" + !sapCode.isBlank()
+                    + " search_status=" + searchStatus
+                    + " plu_present=" + !productPlu.isBlank()
+                    + " price_evidence=" + priceEvidence;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/pyaterochka/PyaterochkaPlainHttpProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/pyaterochka/PyaterochkaPlainHttpProbeTest.java
@@ -1,0 +1,49 @@
+package io.github.trueruslan.zakupgotov.provider.pyaterochka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PyaterochkaPlainHttpProbeTest {
+
+    @Test
+    void buildsStoreScopedConsumerApiRequests() {
+        var probe = PyaterochkaPlainHttpProbe.create();
+
+        assertThat(probe.storeLookupUri(37.6208, 55.7539).toString())
+                .isEqualTo("https://5d.5ka.ru/api/orders/v1/orders/stores/?lon=37.6208&lat=55.7539");
+        assertThat(probe.searchUri("12345", "молоко", 3).toString())
+                .isEqualTo("https://5d.5ka.ru/api/catalog/v3/stores/12345/search"
+                        + "?mode=store&include_restrict=true&q=%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE&limit=3");
+    }
+
+    @Test
+    void plainHttpPolicyUsesNoCapturedBrowserHeadersOrCredentials() {
+        var probe = PyaterochkaPlainHttpProbe.create();
+
+        assertThat(probe.requestHeaders()).containsOnlyKeys("Accept", "User-Agent");
+        assertThat(probe.requestHeaders().keySet())
+                .doesNotContainAnyElementsOf(Set.of(
+                        "Cookie",
+                        "Authorization",
+                        "x-app-version",
+                        "x-device-id",
+                        "x-platform"));
+    }
+
+    @Test
+    void livePhaseAProbeRunsOnlyWhenExplicitlyEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("zakup.live.pyaterochka"));
+
+        var result = PyaterochkaPlainHttpProbe.create().runPhaseA(37.6208, 55.7539, "молоко");
+        System.out.println(result.toEvidenceLine());
+
+        assertThat(result.storeLookupStatus()).isBetween(200, 299);
+        assertThat(result.sapCode()).isNotBlank();
+        assertThat(result.searchStatus()).isBetween(200, 299);
+        assertThat(result.productPlu()).isNotBlank();
+        assertThat(result.priceEvidence()).isTrue();
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -10,29 +10,21 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A closure + M0B Retailer Feasibility (parallel)**  
-Current focus: **finish the outstanding `v0.1.0-rc.3` release proof in parallel with controlled retailer-provider spikes, using the shared feasibility harness and allowing public unofficial consumer APIs only when they work without access-control or anti-bot circumvention**
+Current focus: **prove the first real retailer path with the Pyaterochka plain-HTTP Phase A gate while keeping the still-outstanding `v0.1.0-rc.3` release proof explicit**
 
 ## Product status
 
-The platform foundation is executable and automatically verified. The core retailer-comparison product is **not implemented yet**. The current web surface intentionally presents project status rather than fake store cards, prices, or comparison behavior.
+The platform foundation is executable and automatically verified. The core retailer-comparison user flow is **not implemented yet**. The current web surface intentionally presents project status rather than fake retailer cards, prices, or basket comparison behavior.
 
-M0B feasibility work is active in parallel with the remaining M0A release-event proof. The normalized provider-offer boundary and reusable provider feasibility harness are implemented and TDD-verified in PR #37, but **no retailer/provider is supported yet**. Support still requires an acceptable technical/usage-rights path plus reproducible sanitized fixtures and provider contract/parser tests.
+M0B is now executable rather than research-only:
 
-Starting M0B discovery does not waive the remaining M0A release requirements. `v0.1.0-rc.3` is still required before the versioned GHCR publication path can be called fully runtime-proven.
+- PR #35 established the normalized `ObservedOffer` trust boundary;
+- PR #37 established the reusable provider feasibility harness and was squash-merged to `main` as `e318c8ee92ab5f62dd593f4fd214735eb8c59750` after full CI/security verification;
+- PR #39 is the first concrete retailer spike and implements a non-evasive Pyaterochka Phase A probe plus an explicit live-probe workflow.
 
-## Completed foundation work
+**No retailer/provider is supported yet.** Pyaterochka remains `SPIKE_IF_RAW_HTTP_WORKS` until the real live Phase A request proves that store lookup, store-scoped product search, SKU/PLU identity and price evidence are available through ordinary HTTP without prohibited circumvention.
 
-- PR #1 — product, architecture, engineering, security, contribution, state/roadmap, and planning foundation.
-- PR #2–#9 — Java/Node/pnpm workspace, Java 25 + Spring Boot API, PostgreSQL 18/Flyway/jOOQ persistence, OpenAPI/client generation, responsive Next.js/React web, constrained Actuator surface, security workflows, and unified verification.
-- PR #10–#12 — repository governance, deterministic required-check candidates, immutable Action pins, and cleanup of generated boilerplate.
-- PR #15/#19/#20/#23 — verified dependency/action maintenance without weakening compatibility or security gates.
-- PR #25 — production API/web Docker images, PostgreSQL 18.4-compatible no-source-build Compose topology, and executable `Release Bundle CI` smoke verification.
-- PR #26 — versioned release contract and staged multi-platform GHCR workflow with vulnerability scans, SBOM/provenance evidence, exact-digest smoke verification, no-rebuild promotion, release assets, and stable-only `latest` policy.
-- PR #27 — synchronized release-engineering state before the first real release event.
-- PR #28 — TDD executable-mode regression fix after `v0.1.0-rc.1` exposed non-executable release helpers on clean checkouts.
-- PR #29 — TDD container-security gate and runtime hardening after `v0.1.0-rc.2`: pgJDBC `42.7.12`, distroless non-root web runtime, and read-only PR/main/daily HIGH/CRITICAL image scanning.
-- PR #35 — initial M0B provider-offer trust boundary and retailer feasibility evidence: `ObservedOffer`, explicit normalized availability, TDD fail-closed validation, primary-source integration matrix, and Kuper access-proof tracking.
-- PR #37 — shared M0B provider feasibility harness: access/capability model, provider-scoped location/query model, `RetailerProvider` port, structural fixture/live provider split, offline harness, explicit live-probe entry point, expanded retailer research, and the executable multi-provider spike plan.
+Starting retailer spikes does not waive the remaining M0A release requirement. `v0.1.0-rc.3` is still required before the versioned GHCR publication path can be called fully runtime-proven.
 
 ## Verified platform baseline
 
@@ -46,7 +38,7 @@ Starting M0B discovery does not waive the remaining M0A release requirements. `v
 - Flyway;
 - jOOQ;
 - pgJDBC `42.7.12`;
-- Testcontainers with real PostgreSQL 18.4 in integration tests.
+- Testcontainers with real PostgreSQL 18.4 integration tests.
 
 ### Contracts and clients
 
@@ -63,37 +55,25 @@ Starting M0B discovery does not waive the remaining M0A release requirements. `v
 - TypeScript 5.9.3 compatibility line;
 - Node 24.18.1 builder/toolchain;
 - Next.js standalone output;
-- production runtime on `gcr.io/distroless/nodejs24-debian13:nonroot`;
-- no shell or package manager required in the final web runtime;
+- distroless Node 24 Debian 13 non-root production runtime;
 - Vitest + Testing Library;
-- production Playwright coverage for desktop and mobile viewports.
+- Playwright desktop/mobile production-browser coverage.
 
 ### Operations and container topology
 
-Public management HTTP surface remains intentionally limited to:
-
-- `/actuator/health`;
-- `/actuator/health/liveness`;
-- `/actuator/health/readiness`;
-- `/actuator/info`.
-
-Environment, configuration-properties, and metrics Actuator endpoints remain HTTP-inaccessible. Request-detail logging is disabled by default. Provider credentials, raw payloads, authorization material, precise user addresses, and arbitrary user input must not become telemetry labels/log content by default.
-
-Production container baseline:
-
-- separate multi-stage API and web Dockerfiles;
-- non-root runtime users for both application images;
-- web runtime is distroless and starts the standalone Next.js server without a shell;
-- `compose.release.yaml` contains no local source `build:` directives;
-- PostgreSQL 18.4 uses a persistent named volume at `/var/lib/postgresql`;
-- PostgreSQL health gates API startup, API readiness gates web startup;
-- web health verifies both its own HTTP surface and API reachability over `API_BASE_URL`;
-- only web publishes a host port by default; API remains internal;
+- separate multi-stage API/web production images;
+- non-root application runtimes;
+- `compose.release.yaml` contains no source `build:` directives;
+- PostgreSQL 18.4 persistent storage uses `/var/lib/postgresql`;
+- PostgreSQL health gates API startup and API readiness gates web startup;
+- only web is host-published by default; API and PostgreSQL remain internal;
 - release-bundle failures emit Compose state/log diagnostics before cleanup.
+
+Public management HTTP remains limited to health/liveness/readiness/info. Environment, configuration-properties and metrics Actuator endpoints remain HTTP-inaccessible. Request-detail logging is disabled by default.
 
 ## Automated verification
 
-PR/main checks currently available:
+Repository checks currently include:
 
 - **API CI**;
 - **Contract CI**;
@@ -102,179 +82,143 @@ PR/main checks currently available:
 - **CodeQL / Java**;
 - **CodeQL / JavaScript-TypeScript**;
 - **Dependency Review**;
-- **Release Bundle CI** — builds production API/web images and smoke-tests PostgreSQL → API → web;
-- **Release Contract CI** — read-only verification of SemVer/prerelease semantics, immutable release dependencies, digest-only Compose rendering, workflow syntax and release trust ordering;
-- **Container Security CI** — read-only PR/main/daily build of the exact production API/web Dockerfiles with fresh bases followed by fail-closed Trivy `HIGH`/`CRITICAL` vulnerability scans;
-- local/clean-runner `./scripts/verify.sh`;
+- **Release Bundle CI**;
+- **Release Contract CI**;
+- **Container Security CI** for API and web production images;
+- local `./scripts/verify.sh`;
 - local/CI `./scripts/verify-release-bundle.sh`.
 
-PR #29 proved the container-security gate TDD-first: the initial workflow failed for both production images, then the same unchanged `CRITICAL,HIGH` / `exit-code: 1` policy passed after root-cause remediation. The final PR head also passed Release Bundle CI, demonstrating that the distroless startup and health-check path works in the real Compose topology.
+The independently verified `main` ruleset still enforces the original seven required checks. `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` are proven required-check candidates but have not yet been independently verified as enforced ruleset checks.
 
-PR #35 started M0B with the same evidence discipline. Its TDD cycles produced the normalized `ObservedOffer` boundary with `10/10` provider-offer tests and `15/15` total API tests while Spring Modulith verification and real PostgreSQL 18.4 integration remained green.
+## M0B provider architecture
 
-PR #37 continues the TDD chain:
+### Normalized offer boundary
 
-- RED #1: test-only commit failed at `testCompile` because the feasibility-harness types did not exist;
-- GREEN #1: the initial harness implementation passed `ProviderFeasibilityHarnessTest` `5/5`, the complete API suite `20/20`, real PostgreSQL 18.4/Testcontainers and packaged JAR verification;
-- independent change-review then found that the first fixture/live boundary relied on a provider-supplied execution-mode enum and could therefore be misdeclared;
-- RED #2 replaced that expectation with structural `FixtureRetailerProvider` / `LiveRetailerProvider` types plus a separate `ProviderLiveProbe`, and failed on exactly those missing types;
-- the implementation removed the self-declared execution-mode flag, made the offline harness accept only fixture-provider types, added the explicit live-probe path, and also requires both `PRODUCT_SEARCH` and `PRICE` capabilities for offer search.
+`ObservedOffer` requires:
 
-The complete PR workflow set, including Web E2E, Release Bundle, Release Contract, CodeQL, Dependency Review and both production-image security scans, must pass again on the final documentation-synchronized head before merge.
+- provider ID;
+- fulfillment-context ID;
+- provider SKU;
+- non-negative price;
+- ISO 4217 currency;
+- explicit availability (`AVAILABLE`, `UNAVAILABLE`, `UNKNOWN`);
+- observation timestamp;
+- source reference.
 
-The independently verified `main` ruleset still enforces the original seven CI/security checks. `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` are proven required-check candidates but are not yet independently verified as enforced ruleset checks.
+Incomplete or inconsistent external data fails closed before later comparison logic.
 
-## Repository governance and security state
+### Shared feasibility harness
 
-Verified repository-admin baseline:
+Merged PR #37 provides:
 
-- squash merge only;
-- auto-merge/update-branch enabled;
-- merged source branches deleted automatically;
-- steady state is `main` plus active PR branches;
-- stale/missing required checks block `main` merge;
-- default Actions token permissions are read-only and Actions cannot approve pull requests;
-- Dependency Graph, Dependabot alerts/security updates, secret scanning, push protection, private vulnerability reporting, CodeQL, and Dependency Review are operational.
+- `ProviderAccessType`: `OFFICIAL_API`, `PUBLIC_UNOFFICIAL_API`, `PARTNER_API`;
+- explicit capabilities for location, catalog, search, price and availability;
+- provider-scoped `LocationContext`;
+- normalized `ProductQuery`;
+- common `RetailerProvider` port;
+- structural `FixtureRetailerProvider` / `LiveRetailerProvider` separation;
+- `ProviderFeasibilityHarness.offline()` accepting fixture providers only;
+- separate `ProviderLiveProbe` for network-capable providers;
+- validation requiring `PRODUCT_SEARCH` + `PRICE` and matching provider/fulfillment provenance.
 
-Release permissions remain separated:
+PR #37 was developed in two TDD cycles. The first implementation passed but review found that a provider-supplied fixture/live enum could be misdeclared; a second RED→GREEN cycle replaced it with the structural type split. Final backend verification on the PR head proved `ProviderFeasibilityHarnessTest` **7/7**, `ObservedOfferTest` **10/10**, total API suite **22/22**, real PostgreSQL 18.4 and packaged JAR build. The full PR workflow set, including Web E2E, CodeQL, Release Bundle, Release Contract, Dependency Review and both production-image security scans, passed before merge.
 
-- `Release / Verify` is read-only;
-- only downstream `Release / Publish` receives `contents: write`, `packages: write`, `attestations: write`, and `id-token: write`;
-- ordinary PR CI, including `Container Security CI`, has no package/OIDC write permission;
-- security-sensitive Actions are pinned to full commit SHAs;
-- QEMU binfmt and BuildKit helper images are digest-pinned in the release workflow.
+## Public unofficial API policy
 
-No `.trivyignore`, VEX suppression, severity reduction, `ignore-unfixed`, or scanner bypass was introduced to resolve `rc.2`.
+An undocumented consumer backend is not rejected solely because it is unofficial. It may be evaluated as `PUBLIC_UNOFFICIAL_API` only when the required path works without:
+
+- stolen/forged private credentials;
+- another user's session;
+- CAPTCHA solving or bypass;
+- anti-bot/access-control circumvention;
+- browser-fingerprint evasion;
+- proxy/IP rotation used to defeat blocking;
+- retry behavior intended to bypass `403`/`429` or similar provider decisions.
+
+Rate limits and provider failures are evidence, not obstacles to hide. Third-party wrappers are research references only; their source-code license does not grant rights to the retailer's underlying data.
+
+Detailed evidence is in [`integrations/retailer-feasibility.md`](integrations/retailer-feasibility.md). The provider sequence and fixed 20-item corpus are in [`superpowers/plans/2026-08-10-m0b-provider-spikes.md`](superpowers/plans/2026-08-10-m0b-provider-spikes.md).
+
+## Pyaterochka / 5ka Phase A
+
+Tracking: issue #38 and draft PR #39.
+
+Current research identifies the consumer-backend base `https://5d.5ka.ru/api` and these hypotheses:
+
+- coordinate-based store lookup;
+- store identifier `sapCode`;
+- `{sapCode}`-scoped catalog/search/product routes;
+- product PLU identity;
+- price-bearing search/product responses.
+
+The current Open-Inflation reference obtains these calls through a Camoufox browser warm-up, optional robot/CAPTCHA interaction, and captured `x-app-version`, `x-device-id`, and `x-platform` request headers. **Zakup Gotov does not inherit those techniques.** A separate direct request to the public 5ka catalog surface also returned HTTP 403 during research, so raw HTTP viability must be tested rather than assumed.
+
+PR #39 therefore implements a separate JDK `HttpClient` Phase A probe with:
+
+- only `Accept` and a transparent Zakup Gotov `User-Agent`;
+- fixed connect/request timeouts;
+- no cookies or authorization;
+- no captured app/device/platform headers;
+- no browser automation;
+- no proxies;
+- no retry/evasion loop;
+- store lookup → search only, stopping at the first failed gate;
+- sanitized evidence only: status codes plus booleans for `sapCode`, PLU and price evidence.
+
+TDD evidence so far:
+
+- RED commit `099cb2ace80e7492b9ed0279f82420ec39106fd4`: API CI failed at `testCompile` only because `PyaterochkaPlainHttpProbe` did not yet exist;
+- GREEN implementation commit `e91e6bfab20d5a700cbb08fc0c2b1a8193f82a3b`: `PyaterochkaPlainHttpProbeTest` ran **3 tests, 0 failures/errors, 1 intentionally skipped live test**; complete API suite ran **25 tests, 0 failures/errors, 1 skipped**; PostgreSQL 18.4 and JAR build passed;
+- a new read-only `Provider Live Probe` workflow is opt-in only and is not part of normal PR CI;
+- normal repository workflows on the workflow-introduction head passed API, Contract, Web, CodeQL, Dependency Review, Release Bundle, Release Contract and Container Security.
+
+Current result: **Phase A implementation is ready; live raw-HTTP proof is still pending.** This is not provider support and no fixtures/20-item corpus are justified until Phase A passes.
+
+## Current retailer priorities
+
+- **Pyaterochka / 5ka** — `SPIKE_IF_RAW_HTTP_WORKS`; active Phase A, live proof pending.
+- **Perekrestok** — `SPIKE_NOW`; next controlled provider spike.
+- **Magnit** — `SPIKE_NOW`; priority independent non-X5 proof path.
+- **Chizhik** — `SPIKE_IF_RAW_HTTP_WORKS`; reject if browser/proxy evasion is required.
+- **Ozon Fresh / Samokat** — `RESEARCH_REQUIRED`.
+- **Kuper** — `PROMISING_CONTACT_REQUIRED`; issue #36 tracks official Client apps API access/rights questions.
+- **Yandex Eats Retail API** — `PARTNER_SIDE_ONLY` for the currently documented integration direction.
+- **Lenta / VkusVill** — `BLOCKED_WITHOUT_AGREEMENT` under the current evidence.
 
 ## Release-engineering state
 
-### Runtime-proven locally and in PR CI
+### `v0.1.0-rc.1`
 
-- production API/web images build successfully;
-- PostgreSQL 18.4 → API → web Compose startup is automated and green;
-- API remains internal while web is host-published;
-- PostgreSQL 18 volume-layout compatibility is covered by real Compose execution;
-- release helper executable modes are regression-tested;
-- exact production images are scanned before release in ordinary read-only CI;
-- the real GitHub `release: published` event checks out and verifies the exact release source.
+The real release event proved metadata/main ancestry, repository verification, web build and Playwright, then failed because release helper scripts were not executable on a clean checkout. PR #28 fixed that defect with a regression test.
 
-### `v0.1.0-rc.1` — release-helper mode defect
+### `v0.1.0-rc.2`
 
-`rc.1` targeted `d3066258915542c2488d9a3277680b2cc478d611`. `Release / Verify` passed release metadata/main-ancestry validation, repository verification, production web build, and all responsive Playwright tests, then failed because `scripts/verify-release-bundle.sh` was stored as mode `100644`. `Release / Publish` never started.
+`Release / Verify` passed and `Release / Publish` reached GHCR staging multi-platform builds. Publication then failed closed at the first Trivy gate on pgJDBC `42.7.11` / `CVE-2026-54291` (`HIGH`). Follow-up testing also exposed HIGH/CRITICAL findings in the previous Node Bookworm-slim web runtime. PR #29 updated pgJDBC to `42.7.12`, moved final web runtime to distroless Node 24 Debian 13/non-root, and added ordinary PR/main/daily production-image security scans without weakening Trivy policy.
 
-PR #28 reproduced the executable-mode problem in a regression test and corrected both release helpers to `100755`.
+`rc.2` therefore does **not** prove final package promotion, attestations, SemVer OCI tags, final digest smoke, release evidence assets or final GHCR visibility.
 
-### `v0.1.0-rc.2` — publish path reached, security gate failed closed
+### Outstanding `v0.1.0-rc.3`
 
-`rc.2` targeted corrected `main` at `184751e164f199fdc5262cf77ea86c931daf59f7`.
-
-Proven by the real release event:
-
-- `Release / Verify` completed successfully, including the production container bundle;
-- `Release / Publish` started with its separate write-capable permission boundary;
-- GHCR login, QEMU, and Buildx setup succeeded;
-- both API and web multi-platform staging candidate indexes built and pushed for `linux/amd64` + `linux/arm64`;
-- publication stopped at the first Trivy gate before any final-package/version promotion.
-
-The exact API blocker was `org.postgresql:postgresql 42.7.11`, `CVE-2026-54291` (`HIGH`), fixed in `42.7.12`; the API Ubuntu runtime itself had zero HIGH/CRITICAL findings.
-
-A TDD reproduction moved the same policy into ordinary CI before applying fixes. It additionally showed that the old Node Bookworm-slim web runtime carried 22 Debian HIGH/CRITICAL findings plus 7 npm/runtime-library findings, while the application Next.js/React packages were clean at that threshold. PR #29 therefore updated pgJDBC and replaced only the final web runtime with distroless Node 24 Debian 13/non-root rather than suppressing findings.
-
-Because `rc.2` failed before promotion, it does **not** prove final packages, GitHub provenance attestations, SemVer OCI tags, release evidence assets, or a successful final digest-pinned Compose smoke. No `latest` update is attributed to `rc.2`.
-
-### Merged release design still awaiting complete end-to-end publication
-
-The workflow still requires this sequence:
-
-1. strict SemVer + GitHub prerelease-state validation;
-2. multi-platform staging builds for API/web;
-3. both-platform HIGH/CRITICAL scans and SPDX SBOM evidence;
-4. staging digest-pinned Compose smoke;
-5. no-rebuild copy into final packages under deterministic `verified-<source-sha>` tags;
-6. final-package digest-pinned Compose smoke;
-7. GitHub provenance attestations;
-8. SemVer tag promotion without rebuild;
-9. stable-only optional `latest`;
-10. amd64/arm64 manifest verification and release evidence upload.
-
-A successful `v0.1.0-rc.3` is required before this path can be called fully runtime-proven. GHCR package visibility must then be independently checked: staging must remain private, and final package anonymous/public availability must not be claimed unless explicitly verified.
-
-The current assistant GitHub integration can mutate repository/PR/issue state but does not expose GitHub Release creation, and no separate authenticated release-capable CLI/API credential is available in this execution environment. Therefore `rc.3` has **not** been fabricated via a mutable tag or alternate trigger; the real `release: published` proof remains explicitly outstanding.
-
-See [`RELEASES.md`](RELEASES.md).
-
-## M0B retailer-feasibility state
-
-### Shared provider boundary
-
-- `ObservedOffer` requires `providerId`, `fulfillmentContextId`, provider SKU, non-negative price, ISO 4217 currency, explicit availability, `observedAt`, and `sourceReference`;
-- availability is normalized as `AVAILABLE`, `UNAVAILABLE`, or `UNKNOWN` rather than inferred silently;
-- provider access is classified as `OFFICIAL_API`, `PUBLIC_UNOFFICIAL_API`, or `PARTNER_API`;
-- provider capabilities explicitly model location resolution, catalog, product search, price and availability;
-- `LocationContext` is provider-scoped and contains a fulfillment-context identifier plus coarse locality rather than a precise user address;
-- `ProviderFeasibilityHarness.offline()` accepts only `FixtureRetailerProvider`;
-- network-capable integrations implement `LiveRetailerProvider` and use the separate explicit `ProviderLiveProbe` path;
-- offer-search validation requires `PRODUCT_SEARCH` and `PRICE`, and returned offers must match both provider identity and requested fulfillment context;
-- normal deterministic CI performs **no live retailer calls**.
-
-### Public unofficial API policy
-
-A data source is not rejected merely because its API is undocumented. A public consumer backend may be tested as `PUBLIC_UNOFFICIAL_API` when the ordinary product can use it without bypassing access controls. M0B explicitly excludes stolen/forged private credentials, other users' sessions, CAPTCHA/anti-bot bypass, browser-fingerprint evasion, proxy/IP rotation used to circumvent blocking, and ignoring provider rate limits. Third-party wrappers are research evidence only; their source-code license does not grant rights to retailer data.
-
-Detailed evidence and decisions are recorded in [`integrations/retailer-feasibility.md`](integrations/retailer-feasibility.md), and the executable sequence is in [`superpowers/plans/2026-08-10-m0b-provider-spikes.md`](superpowers/plans/2026-08-10-m0b-provider-spikes.md).
-
-Current priority decisions:
-
-- **Pyaterochka / 5ka** — `SPIKE_IF_RAW_HTTP_WORKS`: strong store-scoped technical evidence exists, but the first gate is proving the necessary calls work without Camoufox/stealth/proxy rotation;
-- **Perekrestok** — `SPIKE_NOW`: public-site request/schema evidence is sufficient for a controlled feasibility probe; exact store-specific price/availability semantics still need proof;
-- **Magnit** — `SPIKE_NOW`: public catalog exposes `shopCode`-scoped behavior and is the priority independent non-X5 path;
-- **Chizhik** — `SPIKE_IF_RAW_HTTP_WORKS`: third-party evidence is useful, but the path is rejected if plain HTTP cannot replace browser/proxy evasion techniques;
-- **Ozon Fresh / Samokat** — `RESEARCH_REQUIRED`: location-specific consumer-backend semantics still need characterization;
-- **Kuper** — `PROMISING_CONTACT_REQUIRED`: official API program publishes a Client apps API, but exact read-side scope, access, caching/fixture rights and comparison-use permission must be confirmed;
-- **Yandex Eats Retail API** — `PARTNER_SIDE_ONLY`: documented API integrates Yandex/Yango with a partner retailer/POS and is not currently a read-side Zakup Gotov API;
-- **Lenta / VkusVill** — `BLOCKED_WITHOUT_AGREEMENT`: current consumer surfaces/terms are not treated as a sufficient production reuse basis.
-
-Issue #36 continues to track the exact Kuper integration questions. No provider is considered supported until reproducible sanitized fixtures and parser/contract tests prove an acceptable path. A one-off successful live request is insufficient.
+A successful real GitHub Release `published` event is still required to prove the complete staged build → scan/SBOM → digest smoke → no-rebuild final copy → final digest smoke → attestation → SemVer promotion → evidence path. The current assistant GitHub integration does not expose GitHub Release creation, so this proof remains explicitly outstanding rather than being replaced with a manual tag.
 
 ## Dependency maintenance state
 
-Compatible dependency/Actions maintenance is merged only after full verification. Known incompatible major updates remain intentionally deferred rather than bypassed:
+Known incompatible major updates remain deferred rather than bypassing checks:
 
-- TypeScript 7.0.2 is incompatible with the current `openapi-typescript 7.13.0` peer range;
-- ESLint 10 breaks the current lint configuration;
-- `@types/node` 26 remains deferred while the toolchain/runtime line is Node 24.
-
-## Approved engineering policy
-
-[`ENGINEERING.md`](ENGINEERING.md) remains mandatory:
-
-- TDD for executable behavior;
-- evidence before completion claims;
-- automation-first verification;
-- real integration dependencies when practical and deterministic;
-- short-lived branches and small PRs;
-- documentation/changelog synchronized with repository reality;
-- no silent security/test bypasses;
-- no retailer live calls in normal deterministic CI.
-
-## Current critical unknowns
-
-1. Which target retailers expose a technically stable and acceptable path to location-specific catalog, price, and availability data?
-2. Can at least two providers achieve useful basket coverage with acceptable freshness/reliability?
-3. Can public unofficial APIs remain usable through ordinary non-evasive HTTP, or do some candidates depend on unstable anti-bot behavior?
-4. What location precision must be used transiently and what, if anything, may be persisted?
-5. How can delivery fees/minimum-order constraints be obtained and normalized per retailer?
-6. What deterministic product-matching quality is achievable before AI assistance is justified?
+- TypeScript 7.0.2 vs current `openapi-typescript` peer range;
+- ESLint 10 vs current lint configuration;
+- `@types/node` 26 while runtime/toolchain remain Node 24.
 
 ## Immediate next work
 
-1. Merge PR #37 only after the final documentation-synchronized head passes API/Contract/Web+E2E/CodeQL/Dependency Review/Release Bundle/Release Contract/Container Security gates.
-2. Start `spike/m0b-pyaterochka`: first prove the required store/catalog/product calls with ordinary HTTP and no Camoufox/stealth/proxy rotation; stop and record `UNSUITABLE_PUBLIC_PATH` if bypass techniques are required.
-3. If the plain-HTTP gate passes, run the fixed 20-item grocery corpus against one Moscow store, capture sanitized fixtures, add deterministic parser/contract tests, then repeat against a second store and measure coverage plus price/availability differences.
-4. Run the same harness for **Perekrestok**, and prioritize **Magnit** as the independent non-X5 proof path.
-5. Continue Kuper issue #36 and second-wave Ozon Fresh/Samokat discovery in parallel.
-6. Publish **`v0.1.0-rc.3`** through the real GitHub Release `published` event when a release-capable path is available, then inspect the full release/GHCR proof; do not substitute a manual tag.
-7. Add `Release Bundle CI`, `Release Contract CI`, and `Container Security CI` to the `main` ruleset when the settings mutation can be applied and independently verified.
+1. Finish PR #39 with documentation synchronization, full CI/security verification and final read-only review.
+2. Merge PR #39 so the opt-in `Provider Live Probe` workflow exists on the default branch.
+3. Trigger the exact Pyaterochka Phase A live probe from issue #38.
+4. If raw HTTP passes, record sanitized fixtures and run the fixed 20-item corpus against two stores; if access requires prohibited browser/CAPTCHA/stealth/proxy behavior, mark `UNSUITABLE_PUBLIC_PATH` and move on without bypassing it.
+5. Start Perekrestok and prioritize Magnit as the independent non-X5 path.
+6. Continue Kuper issue #36 and second-wave Ozon Fresh/Samokat research in parallel.
+7. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
+8. Add Release Bundle/Contract/Container Security to the `main` ruleset when the settings mutation can be applied and independently verified.
 
 ## Definition of M0 success
 

--- a/docs/integrations/retailer-feasibility.md
+++ b/docs/integrations/retailer-feasibility.md
@@ -38,12 +38,13 @@ The executable provider model distinguishes:
 - `PARTNER_SIDE_ONLY` — official API exists, but its documented direction is for a retailer/merchant partner rather than a read-side comparison client.
 - `BLOCKED_WITHOUT_AGREEMENT` — public consumer data exists, but current terms do not provide an acceptable production assumption for automated reuse.
 - `RESEARCH_REQUIRED` — public surface exists but the location/catalog/price path is not sufficiently characterized yet.
+- `UNSUITABLE_PUBLIC_PATH` — the required consumer path cannot be exercised without prohibited circumvention; do not build a production adapter from it.
 
 ## Current matrix
 
 | Candidate | Technical evidence | Location / store evidence | Current decision | Next proof required |
 |---|---|---|---|---|
-| **Pyaterochka / 5ka** | Public 5ka catalog exposes prices. Open-Inflation `pyaterochka_api` documents store-scoped category/product calls and PLU identity. | Wrapper obtains the selected delivery store `sapCode` and passes it into catalog/product calls; geolocation suggest/geocode are also exposed. | `SPIKE_IF_RAW_HTTP_WORKS` | Reproduce selected-store + 20-item corpus using ordinary HTTP without Camoufox/stealth; capture sanitized fixtures; compare two stores. |
+| **Pyaterochka / 5ka** | Open-Inflation `pyaterochka_api` identifies `5d.5ka.ru/api` store lookup, store-scoped catalog/search/product routes and PLU identity. The same client performs Camoufox warm-up, optional CAPTCHA interaction and captures `x-app-version`, `x-device-id`, `x-platform`; those behaviors are excluded from Zakup Gotov. A dedicated JDK `HttpClient` probe now models the same minimal store→search path with only `Accept` plus a transparent Zakup Gotov `User-Agent`, fixed timeouts and no retry/evasion loop. | Store lookup route accepts coordinates and search is explicitly scoped by `{sapCode}`. A separate direct request to the public 5ka catalog surface returned HTTP 403 during research, so the raw-HTTP gate is materially necessary. | `SPIKE_IF_RAW_HTTP_WORKS` — Phase A code ready; live result not yet proven. | Run the explicit GitHub `Provider Live Probe`. PASS requires ordinary HTTP store lookup → `sapCode` → `молоко` search → PLU + price evidence. Any required CAPTCHA/browser/stealth/proxy circumvention results in `UNSUITABLE_PUBLIC_PATH`. |
 | **Perekrestok** | Open-Inflation `perekrestok_api` reproduces ordinary site network calls, exposes geolocation, category tree and product feed/IDs, with schema-snapshot tests. | City/session context is demonstrated; exact store-level price/availability semantics still need independent proof. | `SPIKE_NOW` | Identify fulfillment/store selector, run fixed corpus, prove price/store linkage and availability semantics, save fixtures. |
 | **Magnit** | Official public catalog exposes current product prices and supports a `shopCode` query parameter. | Public catalog pages with different `shopCode` values return different catalog sizes/content, strong evidence that store context matters. | `SPIKE_NOW` | Discover the ordinary backend calls used by the public catalog, then test two explicit stores with a 20-item corpus using non-evasive HTTP. |
 | **Chizhik** | Open-Inflation `chizhik_api` exposes cities, categories, products and active offers. | Geolocation/catalog APIs exist in the wrapper, but the README installs Camoufox and explicitly discusses optional proxies/imitating a regular user. | `SPIKE_IF_RAW_HTTP_WORKS` | Determine whether required catalog calls work with a plain HTTP client. If stealth/proxy rotation is required, mark the path unsuitable. |
@@ -68,7 +69,21 @@ Independent technical reference:
 
 - https://github.com/Open-Inflation/pyaterochka_api
 
-The reference documents a public-site network client that obtains a selected delivery store `sapCode`, uses that store ID for catalog/product calls, exposes PLU product identity, and includes geolocation calls. Its README also installs Camoufox. Zakup Gotov will therefore use it only to identify hypotheses/endpoints; the first spike must prove that plain HTTP is sufficient before this path can advance.
+The reference identifies these store-scoped consumer-backend requests:
+
+- catalog base: `https://5d.5ka.ru/api`;
+- nearest store: `GET /orders/v1/orders/stores/?lon={longitude}&lat={latitude}`;
+- categories: `GET /catalog/v2/stores/{sapCode}/categories?...`;
+- search: `GET /catalog/v3/stores/{sapCode}/search?mode=store&include_restrict=true&q={query}&limit={limit}`;
+- product: `GET /catalog/v2/stores/{sapCode}/products/{plu}?mode=store&include_restrict=true`.
+
+The same third-party client is **not** suitable as a production dependency for our policy: before making those requests it starts Camoufox, opens the main site, optionally attempts to interact with a robot/CAPTCHA control, and captures `x-app-version`, `x-device-id`, and `x-platform` from browser traffic. Those steps are research evidence that access may be guarded, not techniques Zakup Gotov is allowed to inherit.
+
+PR #39 therefore implements a separate plain-HTTP Phase A probe using the JDK HTTP client only. Its deterministic tests prove exact URI construction and that the request policy contains only `Accept` and a transparent Zakup Gotov `User-Agent`; it contains no Cookie, Authorization, captured app/device/platform headers, browser automation, proxy support or retry loop. The live test is disabled by default and requires the explicit `zakup.live.pyaterochka=true` opt-in.
+
+A dedicated `Provider Live Probe` GitHub Actions workflow runs the live test only via manual dispatch or the exact `/provider-probe pyaterochka` command on tracking issue #38 from repository owner `True-Ruslan`. The workflow has `contents: read`, no secrets, a finite timeout, and publishes only a sanitized status line: HTTP status plus booleans indicating whether `sapCode`, PLU and price evidence were found. Response bodies and exact store/product IDs are not emitted as evidence.
+
+Current status: **Phase A implementation ready, live proof pending.** The public 5ka catalog surface returned HTTP 403 from an independent direct request during this research pass, so failure of the live raw-HTTP probe would be consistent with an access-control/anti-bot dependency and must not be worked around.
 
 ### Perekrestok
 
@@ -169,11 +184,11 @@ A single successful manual request is not provider support.
 
 ## Implementation sequence
 
-1. Land the shared feasibility harness (`feat/m0b-provider-feasibility-harness`).
-2. First retailer spike: **Pyaterochka**, but only after proving the relevant calls work without Camoufox/stealth/proxy rotation.
-3. In parallel or immediately after: **Perekrestok**.
-4. Use **Magnit** as the priority independent non-X5 path.
-5. Evaluate **Chizhik** only under the plain-HTTP gate.
-6. Research **Ozon Fresh** and **Samokat** as the second wave.
-7. Keep **Kuper** official-access work active in parallel through issue #36.
+1. Shared feasibility harness — merged in PR #37.
+2. **Pyaterochka Phase A** — PR #39: merge the non-evasive probe/workflow after full CI, then run the explicit live probe. Continue to fixtures/corpus only on raw-HTTP PASS.
+3. **Perekrestok** — controlled provider spike using the same harness.
+4. **Magnit** — priority independent non-X5 path.
+5. **Chizhik** — evaluate only under the plain-HTTP gate.
+6. **Ozon Fresh** and **Samokat** — second-wave discovery.
+7. **Kuper** — keep official-access work active in parallel through issue #36.
 8. Do not enter M1 Shopping Core until at least two acceptable provider paths satisfy the M0 exit criteria, preferably including one non-X5 provider.


### PR DESCRIPTION
## Goal
Run the first real M0B retailer feasibility spike: determine whether Pyaterochka/5ka exposes a usable store-scoped consumer path through ordinary non-evasive HTTP.

Tracking: #38.

## Implemented
- test-first `PyaterochkaPlainHttpProbe` Phase A contract;
- JDK `HttpClient` implementation scoped to the researched public `5d.5ka.ru/api` store→search path;
- fixed connect/request timeouts and no retry/evasion loop;
- request policy limited to `Accept` and a transparent Zakup Gotov `User-Agent`;
- no cookies/auth or captured `x-app-version`, `x-device-id`, `x-platform` headers;
- sanitized result model exposing only HTTP statuses and presence of `sapCode`, PLU and price evidence;
- live test disabled in ordinary CI unless `zakup.live.pyaterochka=true` is explicitly supplied;
- read-only `Provider Live Probe` workflow, manually dispatchable or gated to exact `/provider-probe pyaterochka` command on issue #38 from `True-Ruslan`;
- retailer evidence, changelog and project-state synchronization.

## TDD evidence

### RED
Commit `099cb2ace80e7492b9ed0279f82420ec39106fd4` added only `PyaterochkaPlainHttpProbeTest`.

API CI run `31373592571` passed Java 25/Maven setup and failed at `testCompile` only because `PyaterochkaPlainHttpProbe` did not yet exist.

### GREEN
Commit `e91e6bfab20d5a700cbb08fc0c2b1a8193f82a3b` added the minimal non-evasive implementation.

API CI run `31373682270` proved:
- `PyaterochkaPlainHttpProbeTest`: **3 tests, 0 failures/errors, 1 intentionally skipped live test**;
- `ObservedOfferTest`: **10/10 PASS**;
- `ProviderFeasibilityHarnessTest`: **7/7 PASS**;
- complete API suite: **25 tests, 0 failures/errors, 1 skipped**;
- real PostgreSQL 18.4/Testcontainers/Flyway/jOOQ: PASS;
- packaged Spring Boot JAR: BUILD SUCCESS.

The live test is skipped by default by design, so ordinary PR CI has no retailer-network dependency.

## Research evidence
The Open-Inflation reference identifies the consumer-backend base `https://5d.5ka.ru/api`, coordinate-based store lookup, `{sapCode}`-scoped catalog/search/product routes and PLU identity. However, that client also performs Camoufox warm-up, optional robot/CAPTCHA interaction and captures browser-derived `x-app-version`, `x-device-id`, `x-platform`; those behaviors are explicitly excluded from Zakup Gotov.

An independent direct request to the public 5ka catalog surface also returned HTTP 403. Therefore Phase A must be treated as a real raw-HTTP gate, not assumed to pass.

## Live-probe boundary
The new workflow:
- has `contents: read` only;
- uses no secrets;
- has finite timeouts;
- has no browser/proxy/retry circumvention;
- emits only sanitized status evidence, never response bodies or exact store/product IDs;
- is not part of normal PR CI.

The workflow must exist on `main` before the issue-comment trigger can execute the default-branch definition. Therefore this PR establishes the safe probe mechanism first; **provider support is not claimed by merging it**.

## Current status
`PHASE_A_READY_LIVE_PENDING`

Pyaterochka remains `SPIKE_IF_RAW_HTTP_WORKS`. No fixtures, 20-item corpus, provider adapter or supported-provider status are justified until the real live probe passes.

## Non-goals
- no Camoufox/Playwright/Selenium;
- no CAPTCHA interaction;
- no proxy/IP rotation;
- no fingerprint/anti-bot evasion;
- no borrowed/private sessions;
- no fixture or provider support claim before live proof;
- no M1 basket functionality.

## Merge gates
Final documentation-synchronized head `ec05082c9221c1f5589c272ce38a4a4beffba83e` must pass API, Contract, Web+E2E, CodeQL, Dependency Review, Release Bundle, Release Contract and Container Security; then perform final read-only review.

## Immediate post-merge action
Post exactly `/provider-probe pyaterochka` to issue #38, inspect the resulting live workflow and record either:
- Phase A PASS → proceed to sanitized fixtures + fixed 20-item corpus across two stores; or
- raw-HTTP failure / guarded path → record evidence and do not introduce browser/CAPTCHA/stealth/proxy bypass.