### PR TITLE
ci(provider): expose sanitized live-probe evidence

### DIFF
--- a/.github/workflows/provider-live-probe.yml
+++ b/.github/workflows/provider-live-probe.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: provider-live-probe-${{ github.event.issue.number || github.ref }}
@@ -57,19 +58,41 @@ jobs:
             -Dzakup.live.pyaterochka=true \
             test 2>&1 | tee "$RUNNER_TEMP/pyaterochka-live-probe.log"
 
-      - name: Publish sanitized evidence summary
+      - name: Publish sanitized evidence
         if: always()
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           echo '## Pyaterochka plain HTTP Phase A' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
           if [[ -f "$RUNNER_TEMP/pyaterochka-live-probe.log" ]]; then
             evidence="$(grep -F 'PYATEROCHKA_PHASE_A' "$RUNNER_TEMP/pyaterochka-live-probe.log" | tail -n 1 || true)"
-            if [[ -n "$evidence" ]]; then
-              printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo 'No successful Phase A evidence line was emitted; inspect the test failure/status without copying response bodies.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          state='failure'
+          description='PYATEROCHKA_PHASE_A no_sanitized_evidence=true'
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+            if [[ "$evidence" == *'store_status=2'* \
+               && "$evidence" == *'sap_code_present=true'* \
+               && "$evidence" == *'search_status=2'* \
+               && "$evidence" == *'plu_present=true'* \
+               && "$evidence" == *'price_evidence=true'* ]]; then
+              state='success'
             fi
           else
-            echo 'Probe log was not created.' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No sanitized Phase A evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
           fi
+
+          # Commit statuses have a 140-character description limit. The evidence line is intentionally compact.
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$state" \
+            -f context='Provider Live Probe / Pyaterochka' \
+            -f description="$description" >/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - `docs/integrations/retailer-feasibility.md` with evidence-based provider decision labels, initial Kuper/Yandex Eats/Lenta/VkusVill/Magnit/X5 research, explicit no-scraping boundaries, and deterministic fixture/live-probe acceptance criteria for M0B.
 - Shared M0B provider feasibility harness: `ProviderAccessType`, `ProviderCapability`, provider-scoped `LocationContext`, `ProductQuery`, the `RetailerProvider` port, structural `FixtureRetailerProvider`/`LiveRetailerProvider` separation, offline `ProviderFeasibilityHarness`, and explicit `ProviderLiveProbe`.
 - Expanded retailer-feasibility research and `docs/superpowers/plans/2026-08-10-m0b-provider-spikes.md`, covering Pyaterochka, Perekrestok, Magnit, Chizhik, Ozon Fresh, Samokat and Kuper with a fixed 20-item corpus and measurable M0 decision criteria.
-- Pyaterochka/5ka Phase A plain-HTTP probe using the JDK HTTP client with store-scoped request construction, fixed timeouts, no retries or browser-derived credentials/headers, and an opt-in read-only `Provider Live Probe` workflow that emits only sanitized status evidence.
+- Pyaterochka/5ka Phase A plain-HTTP probe using the JDK HTTP client with store-scoped request construction, fixed timeouts, no retries or browser-derived credentials/headers, plus an opt-in `Provider Live Probe` workflow that emits sanitized evidence and can publish that evidence as a dedicated commit status.
 
 ### Changed
 
@@ -105,6 +105,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - The final Next.js production runtime moved from full Node 24 Bookworm-slim to distroless Node 24 Debian 13/non-root, removing shell/package-manager runtime requirements while preserving the Node 24.18.1 build toolchain and verified standalone-server behavior.
 - M0B now permits controlled evaluation of `PUBLIC_UNOFFICIAL_API` consumer backends when ordinary requests work without access-control or anti-bot circumvention; third-party wrappers remain research evidence rather than an inherited permission or production dependency.
 - Pyaterochka is now an active Phase A spike rather than a paper candidate: the exact public-backend request hypotheses and non-evasive probe are executable, while provider support remains explicitly blocked on the real raw-HTTP result.
+- Live-probe evidence publication uses a dedicated legacy commit-status context so connected tooling can read the sanitized result without broadening the workflow to issue/content/package write permissions.
 
 ### Fixed
 
@@ -144,4 +145,4 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Both target image architectures are scanned for `HIGH` and `CRITICAL` vulnerabilities before version promotion, and release consumers are bound to immutable application-image digests through the attached Compose asset.
 - `v0.1.0-rc.2` demonstrated the release security boundary fail-closed: publication stopped at the first HIGH finding before final-package copy, attestation, SemVer promotion, evidence upload, or any stable `latest` action; remediation used dependency/runtime hardening rather than scanner suppression.
 - Provider feasibility deliberately excludes CAPTCHA/anti-bot bypass, browser-fingerprint evasion and proxy/IP rotation used to circumvent blocking; offline feasibility code accepts fixture-provider types while live-capable adapters require the separate explicit live-probe entry point.
-- The Pyaterochka live-probe workflow has read-only repository permissions, no secrets, a fixed owner/issue command gate, finite timeouts, no retry/evasion behavior, and emits only sanitized status evidence rather than retailer response bodies or exact store/product IDs.
+- The Pyaterochka live-probe workflow keeps `contents: read` and adds only `statuses: write` for the dedicated sanitized result context; it has no retailer credentials, a fixed owner/issue command gate, finite timeouts, no retry/evasion behavior, and publishes no retailer response bodies or exact store/product IDs.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A closure + M0B Retailer Feasibility (parallel)**  
-Current focus: **prove the first real retailer path with the Pyaterochka plain-HTTP Phase A gate while keeping the still-outstanding `v0.1.0-rc.3` release proof explicit**
+Current focus: **obtain the first machine-readable Pyaterochka plain-HTTP Phase A result while keeping the still-outstanding `v0.1.0-rc.3` release proof explicit**
 
 ## Product status
 
@@ -20,7 +20,8 @@ M0B is now executable rather than research-only:
 
 - PR #35 established the normalized `ObservedOffer` trust boundary;
 - PR #37 established the reusable provider feasibility harness and was squash-merged to `main` as `e318c8ee92ab5f62dd593f4fd214735eb8c59750` after full CI/security verification;
-- PR #39 is the first concrete retailer spike and implements a non-evasive Pyaterochka Phase A probe plus an explicit live-probe workflow.
+- PR #39 implemented the first concrete retailer spike — a non-evasive Pyaterochka Phase A probe plus an opt-in live-probe workflow — and was squash-merged to `main` as `4efabe78f82d23fb24f58aa4c6a4a0e15cd93af0` after full CI/security verification;
+- PR #40 adds a narrow commit-status evidence channel so issue-comment-triggered live results can be retrieved by connected tooling without manual Actions UI access.
 
 **No retailer/provider is supported yet.** Pyaterochka remains `SPIKE_IF_RAW_HTTP_WORKS` until the real live Phase A request proves that store lookup, store-scoped product search, SKU/PLU identity and price evidence are available through ordinary HTTP without prohibited circumvention.
 
@@ -141,7 +142,7 @@ Detailed evidence is in [`integrations/retailer-feasibility.md`](integrations/re
 
 ## Pyaterochka / 5ka Phase A
 
-Tracking: issue #38 and draft PR #39.
+Tracking: issue #38; probe/workflow implementation merged in PR #39; evidence transport hardening is PR #40.
 
 Current research identifies the consumer-backend base `https://5d.5ka.ru/api` and these hypotheses:
 
@@ -153,7 +154,7 @@ Current research identifies the consumer-backend base `https://5d.5ka.ru/api` an
 
 The current Open-Inflation reference obtains these calls through a Camoufox browser warm-up, optional robot/CAPTCHA interaction, and captured `x-app-version`, `x-device-id`, and `x-platform` request headers. **Zakup Gotov does not inherit those techniques.** A separate direct request to the public 5ka catalog surface also returned HTTP 403 during research, so raw HTTP viability must be tested rather than assumed.
 
-PR #39 therefore implements a separate JDK `HttpClient` Phase A probe with:
+PR #39 implements a separate JDK `HttpClient` Phase A probe with:
 
 - only `Accept` and a transparent Zakup Gotov `User-Agent`;
 - fixed connect/request timeouts;
@@ -165,18 +166,19 @@ PR #39 therefore implements a separate JDK `HttpClient` Phase A probe with:
 - store lookup → search only, stopping at the first failed gate;
 - sanitized evidence only: status codes plus booleans for `sapCode`, PLU and price evidence.
 
-TDD evidence so far:
+TDD and merge evidence:
 
 - RED commit `099cb2ace80e7492b9ed0279f82420ec39106fd4`: API CI failed at `testCompile` only because `PyaterochkaPlainHttpProbe` did not yet exist;
 - GREEN implementation commit `e91e6bfab20d5a700cbb08fc0c2b1a8193f82a3b`: `PyaterochkaPlainHttpProbeTest` ran **3 tests, 0 failures/errors, 1 intentionally skipped live test**; complete API suite ran **25 tests, 0 failures/errors, 1 skipped**; PostgreSQL 18.4 and JAR build passed;
-- a new read-only `Provider Live Probe` workflow is opt-in only and is not part of normal PR CI;
-- normal repository workflows on the workflow-introduction head passed API, Contract, Web, CodeQL, Dependency Review, Release Bundle, Release Contract and Container Security.
+- final PR #39 head passed API, Contract, Web + Web E2E, CodeQL, Dependency Review, Release Bundle, Release Contract and both production-image Container Security scans before squash merge.
 
-Current result: **Phase A implementation is ready; live raw-HTTP proof is still pending.** This is not provider support and no fixtures/20-item corpus are justified until Phase A passes.
+The opt-in `Provider Live Probe` workflow is not part of ordinary PR CI. PR #40 keeps `contents: read` and adds only `statuses: write` so the workflow can attach context `Provider Live Probe / Pyaterochka` to the default-branch SHA. The status description contains only the same compact sanitized evidence; no response body or exact store/product ID is published. GitHub's ephemeral workflow token is used only for the status write; there are no retailer credentials/secrets.
+
+Current result: **Phase A implementation is merged; machine-readable live raw-HTTP proof is still pending.** An initial issue-comment trigger was sent after PR #39, but the connected tooling cannot enumerate issue-comment workflow runs. PR #40 exists specifically so the next run publishes a retrievable commit status. This is not provider support and no fixtures/20-item corpus are justified until Phase A passes.
 
 ## Current retailer priorities
 
-- **Pyaterochka / 5ka** — `SPIKE_IF_RAW_HTTP_WORKS`; active Phase A, live proof pending.
+- **Pyaterochka / 5ka** — `SPIKE_IF_RAW_HTTP_WORKS`; active Phase A, machine-readable live proof pending.
 - **Perekrestok** — `SPIKE_NOW`; next controlled provider spike.
 - **Magnit** — `SPIKE_NOW`; priority independent non-X5 proof path.
 - **Chizhik** — `SPIKE_IF_RAW_HTTP_WORKS`; reject if browser/proxy evasion is required.
@@ -211,9 +213,9 @@ Known incompatible major updates remain deferred rather than bypassing checks:
 
 ## Immediate next work
 
-1. Finish PR #39 with documentation synchronization, full CI/security verification and final read-only review.
-2. Merge PR #39 so the opt-in `Provider Live Probe` workflow exists on the default branch.
-3. Trigger the exact Pyaterochka Phase A live probe from issue #38.
+1. Finish PR #40 with full CI/security verification and read-only review, then squash-merge it.
+2. Re-trigger exactly `/provider-probe pyaterochka` on issue #38.
+3. Read `Provider Live Probe / Pyaterochka` from the new `main` commit status and record the sanitized Phase A result.
 4. If raw HTTP passes, record sanitized fixtures and run the fixed 20-item corpus against two stores; if access requires prohibited browser/CAPTCHA/stealth/proxy behavior, mark `UNSUITABLE_PUBLIC_PATH` and move on without bypassing it.
 5. Start Perekrestok and prioritize Magnit as the independent non-X5 path.
 6. Continue Kuper issue #36 and second-wave Ozon Fresh/Samokat research in parallel.

--- a/docs/integrations/retailer-feasibility.md
+++ b/docs/integrations/retailer-feasibility.md
@@ -79,9 +79,11 @@ The reference identifies these store-scoped consumer-backend requests:
 
 The same third-party client is **not** suitable as a production dependency for our policy: before making those requests it starts Camoufox, opens the main site, optionally attempts to interact with a robot/CAPTCHA control, and captures `x-app-version`, `x-device-id`, and `x-platform` from browser traffic. Those steps are research evidence that access may be guarded, not techniques Zakup Gotov is allowed to inherit.
 
-PR #39 therefore implements a separate plain-HTTP Phase A probe using the JDK HTTP client only. Its deterministic tests prove exact URI construction and that the request policy contains only `Accept` and a transparent Zakup Gotov `User-Agent`; it contains no Cookie, Authorization, captured app/device/platform headers, browser automation, proxy support or retry loop. The live test is disabled by default and requires the explicit `zakup.live.pyaterochka=true` opt-in.
+PR #39 implements a separate plain-HTTP Phase A probe using the JDK HTTP client only. Its deterministic tests prove exact URI construction and that the request policy contains only `Accept` and a transparent Zakup Gotov `User-Agent`; it contains no Cookie, Authorization, captured app/device/platform headers, browser automation, proxy support or retry loop. The live test is disabled by default and requires the explicit `zakup.live.pyaterochka=true` opt-in.
 
-A dedicated `Provider Live Probe` GitHub Actions workflow runs the live test only via manual dispatch or the exact `/provider-probe pyaterochka` command on tracking issue #38 from repository owner `True-Ruslan`. The workflow has `contents: read`, no secrets, a finite timeout, and publishes only a sanitized status line: HTTP status plus booleans indicating whether `sapCode`, PLU and price evidence were found. Response bodies and exact store/product IDs are not emitted as evidence.
+A dedicated `Provider Live Probe` GitHub Actions workflow runs the live test only via manual dispatch or the exact `/provider-probe pyaterochka` command on tracking issue #38 from repository owner `True-Ruslan`. The workflow uses least privilege: `contents: read` plus `statuses: write` solely to attach one sanitized `Provider Live Probe / Pyaterochka` commit status to the default-branch SHA. It uses only GitHub's ephemeral workflow token for that status write and has **no retailer credentials or retailer secrets**. The status description and job summary contain only HTTP status codes plus booleans indicating whether `sapCode`, PLU and price evidence were found; response bodies and exact store/product IDs are not emitted.
+
+The commit-status channel exists so automated tooling can retrieve issue-comment-triggered probe evidence without manual Actions UI access. A status is `success` only when store/search HTTP gates are 2xx and `sapCode`, PLU and price evidence are all present; every other outcome is published as `failure` with sanitized evidence.
 
 Current status: **Phase A implementation ready, live proof pending.** The public 5ka catalog surface returned HTTP 403 from an independent direct request during this research pass, so failure of the live raw-HTTP probe would be consistent with an access-control/anti-bot dependency and must not be worked around.
 
@@ -185,7 +187,7 @@ A single successful manual request is not provider support.
 ## Implementation sequence
 
 1. Shared feasibility harness — merged in PR #37.
-2. **Pyaterochka Phase A** — PR #39: merge the non-evasive probe/workflow after full CI, then run the explicit live probe. Continue to fixtures/corpus only on raw-HTTP PASS.
+2. **Pyaterochka Phase A** — probe/workflow merged in PR #39; add machine-readable status evidence, then run the explicit live probe. Continue to fixtures/corpus only on raw-HTTP PASS.
 3. **Perekrestok** — controlled provider spike using the same harness.
 4. **Magnit** — priority independent non-X5 path.
 5. **Chizhik** — evaluate only under the plain-HTTP gate.


### PR DESCRIPTION
## Goal
Make opt-in retailer live-probe results machine-readable through GitHub commit statuses so they can be inspected without depending on manual Actions UI access.

## Change
- keep `contents: read`;
- add only `statuses: write` to the dedicated live-probe workflow;
- after every live probe, publish context `Provider Live Probe / Pyaterochka` on the event's default-branch SHA;
- status description contains only the existing sanitized evidence line (HTTP status + presence booleans), truncated to GitHub's status-description limit;
- set status `success` only when both HTTP gates are 2xx and sapCode/PLU/price evidence are present; otherwise `failure`;
- no retailer payload, IDs, cookies, credentials or response bodies are published.

## Why
The connected GitHub tooling can read commit statuses but does not enumerate issue-comment-triggered workflow runs. This turns the live result into a durable, inspectable evidence channel without granting issue/package/content write access.

## Verification
Declarative workflow change: Release Contract CI and the complete repository gate must validate syntax/security integration before merge.

## Scope
No retailer request behavior changes. No extra retry/evasion. No retailer credentials. No normal-PR live network dependency.
