### PR TITLE
spike(provider): test Perekrestok plain HTTP path

### DIFF
--- a/.github/workflows/provider-live-probe.yml
+++ b/.github/workflows/provider-live-probe.yml
@@ -110,9 +110,115 @@ jobs:
             echo 'No sanitized Phase A evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          # The connector exposes status context even when it omits the legacy status description.
-          # Keep the outcome vocabulary finite and sanitized: status class / response-shape category only.
           context="Provider Live Probe / Pyaterochka / ${outcome}"
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$state" \
+            -f context="$context" \
+            -f description="$description" >/dev/null
+
+  perekrestok:
+    name: Perekrestok Plain HTTP Phase A
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 43 &&
+      github.actor == 'True-Ruslan' &&
+      github.event.comment.body == '/provider-probe perekrestok'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Perekrestok plain HTTP Phase A
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=PerekrestokPlainHttpProbeTest \
+            -Dzakup.live.perekrestok=true \
+            test 2>&1 | tee "$RUNNER_TEMP/perekrestok-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Perekrestok plain HTTP Phase A' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/perekrestok-live-probe.log" ]]; then
+            evidence="$(grep -F 'PEREKRESTOK_PHASE_A' "$RUNNER_TEMP/perekrestok-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='PEREKRESTOK_PHASE_A no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            store_status="$(sed -n 's/.*store_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            shop_present="$(sed -n 's/.*shop_id_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            selection_status="$(sed -n 's/.*selection_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            search_status="$(sed -n 's/.*search_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            plu_present="$(sed -n 's/.*plu_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            price_evidence="$(sed -n 's/.*price_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$store_status" =~ ^2[0-9][0-9]$ \
+               && "$shop_present" == 'true' \
+               && "$selection_status" =~ ^2[0-9][0-9]$ \
+               && "$search_status" =~ ^2[0-9][0-9]$ \
+               && "$plu_present" == 'true' \
+               && "$price_evidence" == 'true' ]]; then
+              state='success'
+              outcome='pass'
+            elif [[ ! "$store_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="store-${store_status:-unknown}"
+            elif [[ "$shop_present" != 'true' ]]; then
+              outcome='store-shape'
+            elif [[ ! "$selection_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="selection-${selection_status:-unknown}"
+            elif [[ ! "$search_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="search-${search_status:-unknown}"
+            elif [[ "$plu_present" != 'true' ]]; then
+              outcome='search-shape'
+            elif [[ "$price_evidence" != 'true' ]]; then
+              outcome='price-missing'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Phase A evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Perekrestok / ${outcome}"
           description="${description:0:140}"
           gh api \
             --method POST \

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/perekrestok/PerekrestokPlainHttpProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/perekrestok/PerekrestokPlainHttpProbe.java
@@ -1,0 +1,189 @@
+package io.github.trueruslan.zakupgotov.provider.perekrestok;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+final class PerekrestokPlainHttpProbe {
+
+    private static final String ORIGIN = "https://www.perekrestok.ru";
+    private static final String API_BASE = ORIGIN + "/api/customer/1.4.1.0";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
+    private static final Map<String, String> REQUEST_HEADERS = Map.of(
+            "Accept", "application/json",
+            "User-Agent", "ZakupGotov-M0B-PlainHttpProbe/0.1 (+https://github.com/True-Ruslan/zakup-gotov)");
+    private static final Pattern SHOP_ID = Pattern.compile("\\\"id\\\"\\s*:\\s*(\\d+)");
+    private static final Pattern PLU = Pattern.compile("\\\"plu\\\"\\s*:\\s*\\\"?([^\\\",}]+)\\\"?");
+    private static final Pattern PRICE = Pattern.compile(
+            "\\\"priceTag\\\"\\s*:\\s*\\{[^}]*\\\"price\\\"\\s*:\\s*(\\d+)",
+            Pattern.DOTALL);
+
+    private final CookieManager cookieManager;
+    private final HttpClient httpClient;
+
+    private PerekrestokPlainHttpProbe(CookieManager cookieManager, HttpClient httpClient) {
+        this.cookieManager = cookieManager;
+        this.httpClient = httpClient;
+    }
+
+    static PerekrestokPlainHttpProbe create() {
+        var cookies = new CookieManager(null, CookiePolicy.ACCEPT_ORIGINAL_SERVER);
+        var client = HttpClient.newBuilder()
+                .cookieHandler(cookies)
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+        return new PerekrestokPlainHttpProbe(cookies, client);
+    }
+
+    Map<String, String> requestHeaders() {
+        return REQUEST_HEADERS;
+    }
+
+    URI warmupUri() {
+        return URI.create(ORIGIN + "/");
+    }
+
+    URI nearbyStoresUri(double longitude, double latitude) {
+        return URI.create(API_BASE + "/shop"
+                + "?orderBy=distance&orderDirection=asc&page=1&perPage=3"
+                + "&lat=" + latitude + "&lng=" + longitude);
+    }
+
+    URI selectPickupUri(String shopId) {
+        if (shopId == null || shopId.isBlank()) {
+            throw new IllegalArgumentException("shopId must not be blank");
+        }
+        return URI.create(API_BASE + "/delivery/mode/pickup/" + shopId);
+    }
+
+    URI searchUri(String query) {
+        if (query == null || query.isBlank()) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
+        var encoded = URLEncoder.encode(query, StandardCharsets.UTF_8).replace("+", "%20");
+        return URI.create(API_BASE + "/catalog/search/all?textQuery=" + encoded + "&entityTypes%5B%5D=product");
+    }
+
+    PhaseAResult runPhaseA(double longitude, double latitude, String query) throws IOException, InterruptedException {
+        var warmup = get(warmupUri());
+        var sessionCookiePresent = cookieManager.getCookieStore().getCookies().stream()
+                .anyMatch(cookie -> cookie.getName().equalsIgnoreCase("session"));
+
+        var stores = get(nearbyStoresUri(longitude, latitude));
+        if (!isSuccess(stores.statusCode())) {
+            return PhaseAResult.storeGateFailed(warmup.statusCode(), sessionCookiePresent, stores.statusCode());
+        }
+
+        var shopId = firstMatch(SHOP_ID, stores.body());
+        if (shopId.isEmpty()) {
+            return PhaseAResult.storeShapeFailed(warmup.statusCode(), sessionCookiePresent, stores.statusCode());
+        }
+
+        var selection = put(selectPickupUri(shopId.get()));
+        if (!isSuccess(selection.statusCode())) {
+            return PhaseAResult.selectionGateFailed(
+                    warmup.statusCode(), sessionCookiePresent, stores.statusCode(), shopId.get(), selection.statusCode());
+        }
+
+        var search = get(searchUri(query));
+        if (!isSuccess(search.statusCode())) {
+            return PhaseAResult.searchGateFailed(
+                    warmup.statusCode(), sessionCookiePresent, stores.statusCode(), shopId.get(),
+                    selection.statusCode(), search.statusCode());
+        }
+
+        var plu = firstMatch(PLU, search.body()).orElse("");
+        var priceEvidence = PRICE.matcher(search.body() == null ? "" : search.body()).find();
+        return new PhaseAResult(
+                warmup.statusCode(),
+                sessionCookiePresent,
+                stores.statusCode(),
+                shopId.get(),
+                selection.statusCode(),
+                search.statusCode(),
+                plu,
+                priceEvidence);
+    }
+
+    private HttpResponse<String> get(URI uri) throws IOException, InterruptedException {
+        return send(HttpRequest.newBuilder(uri).GET());
+    }
+
+    private HttpResponse<String> put(URI uri) throws IOException, InterruptedException {
+        return send(HttpRequest.newBuilder(uri).PUT(HttpRequest.BodyPublishers.noBody()));
+    }
+
+    private HttpResponse<String> send(HttpRequest.Builder builder) throws IOException, InterruptedException {
+        builder.timeout(REQUEST_TIMEOUT);
+        REQUEST_HEADERS.forEach(builder::header);
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private static boolean isSuccess(int status) {
+        return status >= 200 && status < 300;
+    }
+
+    private static Optional<String> firstMatch(Pattern pattern, String body) {
+        var matcher = pattern.matcher(body == null ? "" : body);
+        return matcher.find() ? Optional.of(matcher.group(1).trim()) : Optional.empty();
+    }
+
+    record PhaseAResult(
+            int warmupStatus,
+            boolean sessionCookiePresent,
+            int storeStatus,
+            String shopId,
+            int selectionStatus,
+            int searchStatus,
+            String productPlu,
+            boolean priceEvidence) {
+
+        static PhaseAResult storeGateFailed(int warmupStatus, boolean session, int storeStatus) {
+            return new PhaseAResult(warmupStatus, session, storeStatus, "", -1, -1, "", false);
+        }
+
+        static PhaseAResult storeShapeFailed(int warmupStatus, boolean session, int storeStatus) {
+            return new PhaseAResult(warmupStatus, session, storeStatus, "", -1, -1, "", false);
+        }
+
+        static PhaseAResult selectionGateFailed(
+                int warmupStatus, boolean session, int storeStatus, String shopId, int selectionStatus) {
+            return new PhaseAResult(warmupStatus, session, storeStatus, shopId, selectionStatus, -1, "", false);
+        }
+
+        static PhaseAResult searchGateFailed(
+                int warmupStatus,
+                boolean session,
+                int storeStatus,
+                String shopId,
+                int selectionStatus,
+                int searchStatus) {
+            return new PhaseAResult(
+                    warmupStatus, session, storeStatus, shopId, selectionStatus, searchStatus, "", false);
+        }
+
+        String toEvidenceLine() {
+            return "PEREKRESTOK_PHASE_A"
+                    + " warmup_status=" + warmupStatus
+                    + " session_cookie_present=" + sessionCookiePresent
+                    + " store_status=" + storeStatus
+                    + " shop_id_present=" + !shopId.isBlank()
+                    + " selection_status=" + selectionStatus
+                    + " search_status=" + searchStatus
+                    + " plu_present=" + !productPlu.isBlank()
+                    + " price_evidence=" + priceEvidence;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/perekrestok/PerekrestokPlainHttpProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/perekrestok/PerekrestokPlainHttpProbeTest.java
@@ -1,0 +1,55 @@
+package io.github.trueruslan.zakupgotov.provider.perekrestok;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PerekrestokPlainHttpProbeTest {
+
+    @Test
+    void buildsStoreSelectionAndSearchRequests() {
+        var probe = PerekrestokPlainHttpProbe.create();
+
+        assertThat(probe.warmupUri().toString())
+                .isEqualTo("https://www.perekrestok.ru/");
+        assertThat(probe.nearbyStoresUri(37.6208, 55.7539).toString())
+                .isEqualTo("https://www.perekrestok.ru/api/customer/1.4.1.0/shop"
+                        + "?orderBy=distance&orderDirection=asc&page=1&perPage=3&lat=55.7539&lng=37.6208");
+        assertThat(probe.selectPickupUri("1235").toString())
+                .isEqualTo("https://www.perekrestok.ru/api/customer/1.4.1.0/delivery/mode/pickup/1235");
+        assertThat(probe.searchUri("молоко").toString())
+                .isEqualTo("https://www.perekrestok.ru/api/customer/1.4.1.0/catalog/search/all"
+                        + "?textQuery=%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE&entityTypes%5B%5D=product");
+    }
+
+    @Test
+    void requestPolicyDoesNotSendBrowserDerivedAuthorization() {
+        var probe = PerekrestokPlainHttpProbe.create();
+
+        assertThat(probe.requestHeaders()).containsOnlyKeys("Accept", "User-Agent");
+        assertThat(probe.requestHeaders().keySet())
+                .doesNotContainAnyElementsOf(Set.of(
+                        "Cookie",
+                        "Authorization",
+                        "Auth",
+                        "X-Auth-Token",
+                        "Sec-CH-UA"));
+    }
+
+    @Test
+    void livePhaseAProbeRunsOnlyWhenExplicitlyEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("zakup.live.perekrestok"));
+
+        var result = PerekrestokPlainHttpProbe.create().runPhaseA(37.6208, 55.7539, "молоко");
+        System.out.println(result.toEvidenceLine());
+
+        assertThat(result.storeStatus()).isBetween(200, 299);
+        assertThat(result.shopId()).isNotBlank();
+        assertThat(result.selectionStatus()).isBetween(200, 299);
+        assertThat(result.searchStatus()).isBetween(200, 299);
+        assertThat(result.productPlu()).isNotBlank();
+        assertThat(result.priceEvidence()).isTrue();
+    }
+}

--- a/docs/integrations/perekrestok-phase-a.md
+++ b/docs/integrations/perekrestok-phase-a.md
@@ -1,0 +1,88 @@
+# Perekrestok Phase A — plain HTTP feasibility
+
+Updated: 2026-08-10
+Status: `PHASE_A_IMPLEMENTATION_READY_LIVE_PENDING`
+Tracking: issue #43 / PR #44
+
+## Purpose
+
+Determine whether Perekrestok can provide a store-specific consumer data path through ordinary first-party HTTP without browser-only authorization or anti-bot circumvention.
+
+This is a feasibility probe, not a supported-provider implementation.
+
+## Research evidence
+
+The independent Open-Inflation `perekrestok_api` reference identifies consumer endpoints under:
+
+`https://www.perekrestok.ru/api/customer/1.4.1.0`
+
+Relevant calls include:
+
+- nearby shops: `GET /shop?...&lat={lat}&lng={lng}`;
+- pickup context: `PUT /delivery/mode/pickup/{shopId}`;
+- product search: `GET /catalog/search/all?textQuery={query}&entityTypes[]=product`;
+- product details / shop availability endpoints.
+
+Its recorded API snapshots contain concrete shop IDs and catalog-availability flags. Search snapshots contain product `plu`, `priceTag.price`, and `balanceState`, so Phase A can test meaningful product/price evidence rather than only HTTP reachability.
+
+However, the reference manager launches Camoufox, waits for a first-party `session` cookie, intercepts an `Auth` header from browser traffic, and then sends credentialed API requests. Zakup Gotov does **not** inherit the browser or intercepted-Auth behavior.
+
+## Allowed plain-HTTP path
+
+`PerekrestokPlainHttpProbe` uses JDK `HttpClient` with:
+
+- a standard first-party `CookieManager` limited to the original server;
+- one transparent request to `https://www.perekrestok.ru/` so ordinary `Set-Cookie` values may be accepted;
+- `Accept: application/json`;
+- transparent Zakup Gotov `User-Agent`;
+- fixed connect/request timeouts;
+- no retries.
+
+Ordinary cookies issued directly to this client are allowed, but cookie names/values are not sent to evidence output except the boolean fact that a `session` cookie was observed.
+
+The probe never explicitly sends or reconstructs:
+
+- `Auth` / Authorization tokens captured from browser traffic;
+- another user's cookies/session;
+- CAPTCHA solutions;
+- browser fingerprints;
+- proxy/IP rotation;
+- retry/evasion logic for `401`, `403`, or `429`.
+
+## Phase A sequence
+
+1. transparent main-site warmup to accept ordinary first-party cookies;
+2. nearby-store lookup for a coarse Moscow coordinate;
+3. extract one shop ID from a successful response;
+4. attempt pickup-store selection using the same first-party cookie jar;
+5. search `молоко`;
+6. require product PLU and price evidence.
+
+A non-2xx required gate stops the chain immediately.
+
+## Sanitized evidence
+
+The live probe emits only:
+
+- warmup HTTP status;
+- whether a `session` cookie name was observed;
+- store-lookup HTTP status;
+- whether a shop ID was found;
+- pickup-selection HTTP status;
+- search HTTP status;
+- whether a PLU was found;
+- whether price evidence was found.
+
+No cookie value, shop ID, PLU, address, response body, or authorization material is emitted.
+
+The GitHub workflow publishes a finite machine-readable status context:
+
+`Provider Live Probe / Perekrestok / <outcome>`
+
+where outcome is one of `pass`, `store-<status>`, `store-shape`, `selection-<status>`, `search-<status>`, `search-shape`, `price-missing`, `no-evidence`, or `failed`.
+
+## Decision rule
+
+Only `pass` allows Phase B fixture/corpus work.
+
+A browser-only authorization requirement, guarded HTTP gate, or anti-bot dependency is recorded as evidence and is not bypassed. Response-shape failure may be investigated only with public/non-evasive evidence to distinguish API drift from access control.


### PR DESCRIPTION
## Goal
Run the next M0B retailer feasibility spike: determine whether Perekrestok supports a location/store-specific consumer path through ordinary first-party HTTP without browser-derived authorization.

Tracking: #43.

## Research evidence
Open-Inflation `perekrestok_api` identifies consumer endpoints under `https://www.perekrestok.ru/api/customer/1.4.1.0`:
- nearby stores via `/shop?...&lat=...&lng=...`;
- pickup context via `PUT /delivery/mode/pickup/{shopId}`;
- search via `/catalog/search/all?textQuery=...&entityTypes[]=product`;
- product/shop availability endpoints.

Its snapshots contain shop IDs plus `isCatalogAvailable`/`isPickupAvailable`, while search snapshots contain product `plu`, `priceTag.price`, and `balanceState`.

The reference manager also launches Camoufox, waits for a first-party `session` cookie and intercepts browser traffic to obtain an `Auth` header. Zakup Gotov does **not** copy that browser/Auth path.

## TDD evidence
### RED
Commit `50ece63585ec8eca05f7e8facd998a72dfa73aa8` added only `PerekrestokPlainHttpProbeTest`.
API CI run `31376937587` passed Java 25/Maven setup and failed at `testCompile` only because `PerekrestokPlainHttpProbe` did not exist.

### GREEN
`PerekrestokPlainHttpProbe` now uses only JDK `HttpClient`, an original-server `CookieManager`, fixed timeouts, `Accept` and transparent Zakup Gotov `User-Agent`.

The ordinary test path verifies URI construction and absence of explicit Cookie/Auth/browser-derived headers; the live test is opt-in and skipped in normal CI. The complete backend suite remains green.

## Phase A behavior
The probe performs, at most:
1. transparent main-page GET to accept ordinary first-party `Set-Cookie` values;
2. nearby-store lookup;
3. one pickup-store selection using the same cookie jar;
4. one `молоко` search;
5. PLU + price-evidence check.

A required non-2xx gate stops immediately.

Allowed: ordinary first-party cookies issued directly to this client.
Prohibited: Camoufox/Playwright/Selenium, CAPTCHA interaction, intercepted/synthesized `Auth`, another user's session, proxy/IP rotation, fingerprint evasion, and retries intended to defeat 401/403/429.

## Live evidence
The existing `Provider Live Probe` workflow gains an issue-#43-only Perekrestok job. It emits no cookie value, shop ID, PLU or response body and publishes only:
`Provider Live Probe / Perekrestok / <outcome>`

Finite outcomes: `pass`, `store-<status>`, `store-shape`, `selection-<status>`, `search-<status>`, `search-shape`, `price-missing`, `no-evidence`, `failed`.

## Documentation
`docs/integrations/perekrestok-phase-a.md` records the exact research assumptions, allowed path, sanitized evidence and decision rule without prematurely changing provider support state.

## Non-goals
- no production provider adapter;
- no live calls in ordinary PR CI;
- no M1 shopping/basket work;
- no provider support claim before live Phase A.

## Merge gate
Final head `7ad1144315834817d731970e54637fd8dac160f0` must pass API, Contract, Web+E2E, CodeQL, Dependency Review, Release Bundle, Release Contract and Container Security. Then perform final read-only review and squash merge.

## Immediate post-merge
Post exactly `/provider-probe perekrestok` to issue #43 and read the outcome-bearing status on the new `main` SHA. Only `pass` proceeds to sanitized fixtures + the fixed 20-item corpus across two stores.