### PR TITLE
spike(provider): test Magnit public store pages

### DIFF
--- a/.github/workflows/provider-live-probe-magnit.yml
+++ b/.github/workflows/provider-live-probe-magnit.yml
@@ -1,0 +1,127 @@
+name: Provider Live Probe - Magnit
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: provider-live-probe-magnit-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  magnit:
+    name: Magnit Public Page Phase A
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 45 &&
+      github.actor == 'True-Ruslan' &&
+      github.event.comment.body == '/provider-probe magnit'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Magnit public-page Phase A
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=MagnitPublicPageProbeTest \
+            -Dzakup.live.magnit=true \
+            test 2>&1 | tee "$RUNNER_TEMP/magnit-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Magnit public-page Phase A' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/magnit-live-probe.log" ]]; then
+            evidence="$(grep -F 'MAGNIT_PHASE_A' "$RUNNER_TEMP/magnit-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='MAGNIT_PHASE_A no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            first_status="$(sed -n 's/.*first_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            first_sku="$(sed -n 's/.*first_sku_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            first_price="$(sed -n 's/.*first_price_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            second_status="$(sed -n 's/.*second_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            second_sku="$(sed -n 's/.*second_sku_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            second_price="$(sed -n 's/.*second_price_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            prices_equal="$(sed -n 's/.*prices_equal=\([^ ]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$first_status" =~ ^2[0-9][0-9]$ \
+               && "$first_sku" == 'true' \
+               && "$first_price" == 'true' \
+               && "$second_status" =~ ^2[0-9][0-9]$ \
+               && "$second_sku" == 'true' \
+               && "$second_price" == 'true' ]]; then
+              state='success'
+              if [[ "$prices_equal" == 'true' ]]; then
+                outcome='pass-same-price'
+              else
+                outcome='pass-different-price'
+              fi
+            elif [[ ! "$first_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="first-${first_status:-unknown}"
+            elif [[ "$first_sku" != 'true' ]]; then
+              outcome='first-sku-missing'
+            elif [[ "$first_price" != 'true' ]]; then
+              outcome='first-price-missing'
+            elif [[ ! "$second_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="second-${second_status:-unknown}"
+            elif [[ "$second_sku" != 'true' ]]; then
+              outcome='second-sku-missing'
+            elif [[ "$second_price" != 'true' ]]; then
+              outcome='second-price-missing'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Phase A evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Magnit / ${outcome}"
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$state" \
+            -f context="$context" \
+            -f description="$description" >/dev/null

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
@@ -85,6 +85,29 @@ final class MagnitPublicPageProbe {
         return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
     }
 
+    static Optional<BigDecimal> closestPriceToSku(String html, String expectedSku) {
+        if (expectedSku == null || expectedSku.isBlank()) {
+            throw new IllegalArgumentException("expectedSku must not be blank");
+        }
+        var text = visibleText(html);
+        var skuIndex = text.indexOf(expectedSku);
+        if (skuIndex < 0) {
+            return Optional.empty();
+        }
+
+        var matcher = PRICE.matcher(text);
+        BigDecimal bestPrice = null;
+        var bestDistance = Integer.MAX_VALUE;
+        while (matcher.find()) {
+            var distance = Math.abs(matcher.start() - skuIndex);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                bestPrice = new BigDecimal(matcher.group(1).replace(',', '.'));
+            }
+        }
+        return Optional.ofNullable(bestPrice);
+    }
+
     private static String visibleText(String html) {
         return (html == null ? "" : html)
                 .replace("&nbsp;", " ")
@@ -99,12 +122,9 @@ final class MagnitPublicPageProbe {
 
         static PageEvidence from(HttpResponse<String> response, String expectedSku) {
             var body = response.body() == null ? "" : response.body();
-            var text = visibleText(body);
-            var priceMatcher = PRICE.matcher(text);
-            Optional<BigDecimal> price = priceMatcher.find()
-                    ? Optional.of(new BigDecimal(priceMatcher.group(1).replace(',', '.')))
-                    : Optional.empty();
-            return new PageEvidence(response.statusCode(), body.contains(expectedSku), price);
+            var skuEvidence = body.contains(expectedSku);
+            var price = skuEvidence ? closestPriceToSku(body, expectedSku) : Optional.<BigDecimal>empty();
+            return new PageEvidence(response.statusCode(), skuEvidence, price);
         }
 
         boolean complete() {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
@@ -1,0 +1,151 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+final class MagnitPublicPageProbe {
+
+    private static final String ORIGIN = "https://magnit.ru";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
+    private static final Map<String, String> REQUEST_HEADERS = Map.of(
+            "Accept", "text/html,application/xhtml+xml",
+            "User-Agent", "ZakupGotov-M0B-PublicPageProbe/0.1 (+https://github.com/True-Ruslan/zakup-gotov)");
+    private static final Pattern PRICE = Pattern.compile("(\\d{1,6}(?:[.,]\\d{1,2})?)\\s*₽");
+
+    private final HttpClient httpClient;
+
+    private MagnitPublicPageProbe(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    static MagnitPublicPageProbe create() {
+        return new MagnitPublicPageProbe(HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    Map<String, String> requestHeaders() {
+        return REQUEST_HEADERS;
+    }
+
+    URI productUri(String productSlug, String shopCode) {
+        if (productSlug == null || productSlug.isBlank()) {
+            throw new IllegalArgumentException("productSlug must not be blank");
+        }
+        if (shopCode == null || shopCode.isBlank()) {
+            throw new IllegalArgumentException("shopCode must not be blank");
+        }
+        return URI.create(ORIGIN + "/product/" + productSlug + "?shopCode=" + shopCode + "&shopType=1");
+    }
+
+    PhaseAResult runPhaseA(String productSlug, String expectedSku, String firstShop, String secondShop)
+            throws IOException, InterruptedException {
+        if (expectedSku == null || expectedSku.isBlank()) {
+            throw new IllegalArgumentException("expectedSku must not be blank");
+        }
+
+        var first = get(productUri(productSlug, firstShop));
+        var firstEvidence = PageEvidence.from(first, expectedSku);
+        if (!firstEvidence.complete()) {
+            return PhaseAResult.firstGateFailed(firstEvidence);
+        }
+
+        var second = get(productUri(productSlug, secondShop));
+        var secondEvidence = PageEvidence.from(second, expectedSku);
+        if (!secondEvidence.complete()) {
+            return PhaseAResult.secondGateFailed(firstEvidence, secondEvidence);
+        }
+
+        return new PhaseAResult(
+                firstEvidence.status(),
+                firstEvidence.skuEvidence(),
+                true,
+                secondEvidence.status(),
+                secondEvidence.skuEvidence(),
+                true,
+                firstEvidence.price().orElseThrow().compareTo(secondEvidence.price().orElseThrow()) == 0);
+    }
+
+    private HttpResponse<String> get(URI uri) throws IOException, InterruptedException {
+        var builder = HttpRequest.newBuilder(uri)
+                .GET()
+                .timeout(REQUEST_TIMEOUT);
+        REQUEST_HEADERS.forEach(builder::header);
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private static String visibleText(String html) {
+        return (html == null ? "" : html)
+                .replace("&nbsp;", " ")
+                .replace("&#8381;", "₽")
+                .replace("&#x20bd;", "₽")
+                .replace("&#x20BD;", "₽")
+                .replaceAll("<[^>]+>", " ")
+                .replaceAll("\\s+", " ");
+    }
+
+    private record PageEvidence(int status, boolean skuEvidence, Optional<BigDecimal> price) {
+
+        static PageEvidence from(HttpResponse<String> response, String expectedSku) {
+            var body = response.body() == null ? "" : response.body();
+            var text = visibleText(body);
+            var priceMatcher = PRICE.matcher(text);
+            Optional<BigDecimal> price = priceMatcher.find()
+                    ? Optional.of(new BigDecimal(priceMatcher.group(1).replace(',', '.')))
+                    : Optional.empty();
+            return new PageEvidence(response.statusCode(), body.contains(expectedSku), price);
+        }
+
+        boolean complete() {
+            return status >= 200 && status < 300 && skuEvidence && price.isPresent();
+        }
+    }
+
+    record PhaseAResult(
+            int firstStatus,
+            boolean firstSkuEvidence,
+            boolean firstPricePresent,
+            int secondStatus,
+            boolean secondSkuEvidence,
+            boolean secondPricePresent,
+            boolean pricesEqual) {
+
+        static PhaseAResult firstGateFailed(PageEvidence first) {
+            return new PhaseAResult(
+                    first.status(), first.skuEvidence(), first.price().isPresent(), -1, false, false, false);
+        }
+
+        static PhaseAResult secondGateFailed(PageEvidence first, PageEvidence second) {
+            return new PhaseAResult(
+                    first.status(),
+                    first.skuEvidence(),
+                    first.price().isPresent(),
+                    second.status(),
+                    second.skuEvidence(),
+                    second.price().isPresent(),
+                    false);
+        }
+
+        String toEvidenceLine() {
+            return "MAGNIT_PHASE_A"
+                    + " first_status=" + firstStatus
+                    + " first_sku_evidence=" + firstSkuEvidence
+                    + " first_price_present=" + firstPricePresent
+                    + " second_status=" + secondStatus
+                    + " second_sku_evidence=" + secondSkuEvidence
+                    + " second_price_present=" + secondPricePresent
+                    + " prices_equal=" + pricesEqual;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbe.java
@@ -96,16 +96,29 @@ final class MagnitPublicPageProbe {
         }
 
         var matcher = PRICE.matcher(text);
-        BigDecimal bestPrice = null;
-        var bestDistance = Integer.MAX_VALUE;
+        BigDecimal nearestBeforeSku = null;
+        var nearestBeforeDistance = Integer.MAX_VALUE;
+        BigDecimal nearestAfterSku = null;
+        var nearestAfterDistance = Integer.MAX_VALUE;
+
         while (matcher.find()) {
-            var distance = Math.abs(matcher.start() - skuIndex);
-            if (distance < bestDistance) {
-                bestDistance = distance;
-                bestPrice = new BigDecimal(matcher.group(1).replace(',', '.'));
+            var price = new BigDecimal(matcher.group(1).replace(',', '.'));
+            if (matcher.end() <= skuIndex) {
+                var distance = skuIndex - matcher.end();
+                if (distance < nearestBeforeDistance) {
+                    nearestBeforeDistance = distance;
+                    nearestBeforeSku = price;
+                }
+            } else if (matcher.start() >= skuIndex + expectedSku.length()) {
+                var distance = matcher.start() - (skuIndex + expectedSku.length());
+                if (distance < nearestAfterDistance) {
+                    nearestAfterDistance = distance;
+                    nearestAfterSku = price;
+                }
             }
         }
-        return Optional.ofNullable(bestPrice);
+
+        return Optional.ofNullable(nearestBeforeSku != null ? nearestBeforeSku : nearestAfterSku);
     }
 
     private static String visibleText(String html) {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbeTest.java
@@ -1,0 +1,53 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class MagnitPublicPageProbeTest {
+
+    private static final String PRODUCT_SLUG =
+            "1000379971-moloko_sgushchennoe_360g_zhestyanaya_banka_zao_amkk_45";
+
+    @Test
+    void buildsSameProductForTwoExplicitStoreContexts() {
+        var probe = MagnitPublicPageProbe.create();
+
+        assertThat(probe.productUri(PRODUCT_SLUG, "139147").toString())
+                .isEqualTo("https://magnit.ru/product/" + PRODUCT_SLUG + "?shopCode=139147&shopType=1");
+        assertThat(probe.productUri(PRODUCT_SLUG, "773577").toString())
+                .isEqualTo("https://magnit.ru/product/" + PRODUCT_SLUG + "?shopCode=773577&shopType=1");
+    }
+
+    @Test
+    void requestPolicyUsesNoLoginOrPartnerCredentials() {
+        var probe = MagnitPublicPageProbe.create();
+
+        assertThat(probe.requestHeaders()).containsOnlyKeys("Accept", "User-Agent");
+        assertThat(probe.requestHeaders().keySet())
+                .doesNotContainAnyElementsOf(Set.of(
+                        "Cookie",
+                        "Authorization",
+                        "X-Api-Key",
+                        "X-Auth-Token",
+                        "Sec-CH-UA"));
+    }
+
+    @Test
+    void livePhaseAProbeRunsOnlyWhenExplicitlyEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("zakup.live.magnit"));
+
+        var result = MagnitPublicPageProbe.create()
+                .runPhaseA(PRODUCT_SLUG, "1000379971", "139147", "773577");
+        System.out.println(result.toEvidenceLine());
+
+        assertThat(result.firstStatus()).isBetween(200, 299);
+        assertThat(result.firstSkuEvidence()).isTrue();
+        assertThat(result.firstPricePresent()).isTrue();
+        assertThat(result.secondStatus()).isBetween(200, 299);
+        assertThat(result.secondSkuEvidence()).isTrue();
+        assertThat(result.secondPricePresent()).isTrue();
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitPublicPageProbeTest.java
@@ -3,6 +3,7 @@ package io.github.trueruslan.zakupgotov.provider.magnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.math.BigDecimal;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,21 @@ class MagnitPublicPageProbeTest {
                         "X-Api-Key",
                         "X-Auth-Token",
                         "Sec-CH-UA"));
+    }
+
+    @Test
+    void bindsPriceEvidenceToTheExpectedSkuInsteadOfFirstPagePrice() {
+        var html = """
+                <div>Реклама другого товара 1 ₽</div>
+                <section>
+                  <div>129,99 ₽</div>
+                  <div>Артикул 1000379971</div>
+                </section>
+                <footer>999 ₽</footer>
+                """;
+
+        assertThat(MagnitPublicPageProbe.closestPriceToSku(html, "1000379971"))
+                .contains(new BigDecimal("129.99"));
     }
 
     @Test

--- a/docs/integrations/magnit-phase-a.md
+++ b/docs/integrations/magnit-phase-a.md
@@ -1,0 +1,74 @@
+# Magnit Phase A — public-page store-price feasibility
+
+Updated: 2026-08-10
+Status: `PHASE_A_IMPLEMENTATION_READY_LIVE_PENDING`
+Tracking: issue #45 / PR #46
+
+## Purpose
+
+Prove an independent non-X5 provider path using Magnit's ordinary public SSR pages rather than private or partner APIs.
+
+## Research evidence
+
+Magnit's public product/catalog pages accept `shopCode` and expose prices for a selected store context. Publicly indexed product pages for the same SKU/article `1000379971` have appeared under multiple Moscow `shopCode` values with different displayed prices, which is sufficient evidence to test store-context price observation directly from the public page.
+
+The official Magnit Market partner API is a different seller/partner surface requiring `X-Api-Key`; it is not used by this spike.
+
+## Phase A product and contexts
+
+Fixed public product:
+
+- article/SKU: `1000379971`;
+- slug: `1000379971-moloko_sgushchennoe_360g_zhestyanaya_banka_zao_amkk_45`.
+
+Explicit Moscow store contexts:
+
+- `shopCode=139147`;
+- `shopCode=773577`.
+
+The probe requests the same public product page for both contexts with `shopType=1`.
+
+## Request policy
+
+`MagnitPublicPageProbe` uses JDK `HttpClient` only:
+
+- `Accept: text/html,application/xhtml+xml`;
+- transparent Zakup Gotov `User-Agent`;
+- fixed connect/request timeouts;
+- no Cookie or login;
+- no Authorization / partner API key;
+- no browser automation;
+- no CAPTCHA/anti-bot bypass;
+- no proxy/IP rotation or fingerprint evasion;
+- no retry loop.
+
+## Phase A acceptance
+
+Each public page must return:
+
+1. HTTP 2xx;
+2. expected SKU/article evidence;
+3. ruble price evidence.
+
+Both contexts must pass. The observed prices may be equal or different; either result proves the same SKU is observable under two explicit store contexts. A difference is additional store-specific pricing evidence.
+
+Location → `shopCode` resolution is deliberately **not** claimed by this slice and remains a separate capability gate.
+
+## Sanitized evidence
+
+Live evidence contains only:
+
+- first/second HTTP status;
+- SKU-evidence boolean for each page;
+- price-present boolean for each page;
+- whether the two parsed prices are equal.
+
+No numeric price, street address, response body, cookie, token, or hidden identifier is emitted.
+
+The dedicated live workflow publishes:
+
+`Provider Live Probe / Magnit / <outcome>`
+
+Possible outcomes include `pass-same-price`, `pass-different-price`, `first-<status>`, `first-sku-missing`, `first-price-missing`, corresponding second-page failures, `no-evidence`, or `failed`.
+
+Only a pass outcome permits Phase B fixture/corpus work.


### PR DESCRIPTION
## Goal
Test the highest-priority independent non-X5 path using Magnit's ordinary public SSR product pages rather than a private/partner API.

Tracking: #45.

## Research evidence
Magnit's public product/catalog pages accept `shopCode`. Publicly indexed pages for the same article `1000379971` have appeared under multiple Moscow store contexts with different displayed prices. The official Magnit Market seller API is a separate partner surface requiring `X-Api-Key` and is not used here.

## TDD evidence
### RED — initial implementation boundary
Commit `0be5ddc1443e9ee7fa490966b27a3ef73071584f` added only `MagnitPublicPageProbeTest`.
API CI passed Java 25/Maven setup and failed at `testCompile` only because `MagnitPublicPageProbe` did not exist.

### GREEN — Phase A probe
`MagnitPublicPageProbe` uses JDK `HttpClient` only, with fixed timeouts and no cookies/auth/API keys/browser/proxy/retry path.

It requests the same fixed public product SKU `1000379971` for two explicit Moscow contexts:
- `shopCode=139147`;
- `shopCode=773577`.

Each page must produce HTTP 2xx, expected SKU evidence and ruble price evidence. Numeric prices are used only in-memory to determine whether the two observations are equal; numeric prices are not emitted by the live evidence.

The live test is opt-in and skipped in ordinary CI.

### RED → GREEN — price/SKU binding regression
On head `f362e8a8ffec2f2acf9a131d11b201f536d9a1f1`, ordinary `API CI` deterministically failed `MagnitPublicPageProbeTest.bindsPriceEvidenceToTheExpectedSkuInsteadOfFirstPagePrice`: the parser selected unrelated footer price `999` instead of the expected product-local `129.99`.

Root cause: `closestPriceToSku()` minimized absolute flattened-text distance, so a following unrelated price could beat the price immediately preceding the SKU/article evidence.

Head `7ff2ab989451c63dd5b4771f85c340e749938de6` fixes the proven mechanism without weakening the regression test: the nearest price preceding the SKU is preferred, with the nearest following price used only as a fallback when no preceding price exists. The previously failing test is unchanged and the complete API verification is GREEN.

## Live workflow
A dedicated `.github/workflows/provider-live-probe-magnit.yml` is issue-#45-only and uses `contents: read` + `statuses: write` solely for sanitized evidence.

Status context:
`Provider Live Probe / Magnit / <outcome>`

Pass outcomes:
- `pass-same-price`;
- `pass-different-price`.

Failure outcomes distinguish first/second HTTP, missing SKU, missing price, no evidence, or generic failure.

No response body, numeric price, street address, cookie, token, or partner credential is published.

## Documentation
`docs/integrations/magnit-phase-a.md` records the public-page hypothesis, fixed SKU/contexts, request policy and decision rule.

## Non-goals
- no private/partner API;
- no location→shopCode capability claim yet;
- no production provider adapter;
- no 20-item corpus before Phase A PASS;
- no live Magnit network dependency in ordinary PR CI.

## Merge gate
Exact head `7ff2ab989451c63dd5b4771f85c340e749938de6` passed API, Contract, Web+E2E, CodeQL Java + JavaScript/TypeScript, Dependency Review, Release Bundle, Release Contract, Retailer Bridge and Container Security API/Web. A read-only review found no blocking issue.

## Immediate post-merge
Post exactly `/provider-probe magnit` to issue #45, read `Provider Live Probe / Magnit / <outcome>` on the new main SHA, then either proceed to fixtures/corpus or record the fail-closed result.