### PR TITLE
docs(integrations): record Perekrestok browser bridge live pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Universal Retailer Connectivity design and Perekrestok Browser Bridge Phase A implementation plan, making retailer coverage transport-agnostic rather than tied to direct server APIs.
 - Chromium Manifest V3 `apps/retailer-bridge` package with a Perekrestok structured-state adapter, normalized browser-observation trust boundary, sanitized local storage, deterministic fixtures, and dedicated `Retailer Bridge CI` including persistent-Chromium extension E2E.
 - Sanitized first-real-browser Perekrestok evidence record plus a current-live-shape fixture and persistent-Chromium regression covering semantic `.product-card` extraction with asynchronous first-party shop-context arrival.
+- Sanitized Perekrestok adapter-v2 real-browser PASS evidence proving 90 normalized observations, one fulfillment context, adapter version `2`, zero acceptance-validation failures, and canonical source references without query/hash.
 
 ### Changed
 
@@ -110,7 +111,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Pyaterochka Phase A is complete with a fail-closed **`store-403`** result from the ordinary JDK HTTP probe; the currently known 5ka consumer backend is classified `UNSUITABLE_PUBLIC_PATH`, Phase B fixtures/corpus are intentionally cancelled, and no browser/CAPTCHA/stealth/proxy workaround will be introduced.
 - Live-probe evidence publication uses a dedicated legacy commit-status context with a finite sanitized outcome suffix so connected tooling can distinguish HTTP gates/shape failures without raw retailer payloads or broader write permissions.
 - Retailer connectivity is now a universal registry invariant: a failed direct API changes the acquisition mode under investigation but does not remove the retailer from product scope.
-- Perekrestok browser connectivity is `BROWSER_BRIDGE_LIVE_PENDING`: adapter v1 has a recorded real-browser `missing-context` FAIL, while adapter v2 is deterministic-ready for a repeated live gate using semantic catalog DOM plus first-party shop-resource pathname evidence.
+- Perekrestok browser connectivity advanced from `BROWSER_BRIDGE_LIVE_PENDING` to `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition after adapter v2 passed the repeated real first-party browser gate.
 - Perekrestok browser adapter provenance advanced to v2 so observations produced by the current DOM/resource acquisition logic remain distinguishable from the original structured-state-only implementation.
 
 ### Fixed

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-10
+Updated: 2026-08-11
 
 ## Project
 
@@ -10,13 +10,13 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A closure + M0B Universal Retailer Connectivity**  
-Current focus: **repeat the real first-party Perekrestok browser gate with adapter v2, keep Pyaterochka/Perekrestok mandatory, prove an independent non-X5 path, and keep the outstanding `v0.1.0-rc.3` release proof explicit**
+Current focus: **reuse the now-proven Perekrestok browser transport for Pyaterochka, prove an independent non-X5 retailer path, harden persistent-session behavior, and keep the outstanding `v0.1.0-rc.3` release proof explicit**
 
 ## Product connectivity invariant
 
-PR #48 was squash-merged to `main` as `f72c2f9b5f6c631b8dc0ed135d60e69ec55d7d90` after the complete repository gate. It records the approved Universal Retailer Connectivity design and the first browser-bridge implementation plan.
+PR #48 was squash-merged to `main` as `f72c2f9b5f6c631b8dc0ed135d60e69ec55d7d90` and records the approved Universal Retailer Connectivity design.
 
-**Every retailer/banner added to the target retailer registry remains mandatory coverage work until at least one reproducible acquisition path is available.** A failed direct API does not remove a retailer from product scope.
+**Every retailer/banner added to the target retailer registry remains mandatory coverage work until at least one reproducible accepted acquisition path exists.** A failed direct API changes the acquisition mode under investigation; it does not remove the retailer from product scope.
 
 Supported acquisition modes are:
 
@@ -25,24 +25,19 @@ Supported acquisition modes are:
 3. stable public web/API surfaces;
 4. user-assisted first-party browser bridge.
 
-Durable design: [`superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`](superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md).  
-Executable browser plan: [`superpowers/plans/2026-08-10-perekrestok-browser-bridge-phase-a.md`](superpowers/plans/2026-08-10-perekrestok-browser-bridge-phase-a.md).
-
 The initial priority registry includes Pyaterochka, Perekrestok, Chizhik, Magnit-family grocery surfaces, Lenta, VkusVill, Ozon Fresh, Samokat and relevant aggregator/provider surfaces such as Kuper.
 
 ## Current product status
 
 The platform foundation is executable and automatically verified. The core multi-retailer basket-comparison user flow is **not implemented yet**. The web surface intentionally does not fake retailer prices or availability.
 
-**No retailer/provider is supported yet.** M0B is proving acquisition transports and normalized evidence before M1.
+**Perekrestok now has one accepted acquisition path: `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition.** Other target retailers remain in discovery/unimplemented states until their own evidence gates pass.
 
 ## M0B verified foundation
 
 PR #35 established the normalized `ObservedOffer` trust boundary.
 
-PR #37 established the reusable provider feasibility harness and was squash-merged to `main` as `e318c8ee92ab5f62dd593f4fd214735eb8c59750`. It provides provider capabilities, provider-scoped `LocationContext`, normalized `ProductQuery`, structural fixture/live provider separation, offline fixture verification and explicit live-probe entry points.
-
-The fixture/live boundary was strengthened through a second RED→GREEN cycle after review found that a provider-supplied execution-mode flag could be misdeclared.
+PR #37 was squash-merged to `main` as `e318c8ee92ab5f62dd593f4fd214735eb8c59750` and established the reusable provider feasibility harness: provider capabilities, provider-scoped `LocationContext`, normalized `ProductQuery`, structural fixture/live provider separation, offline fixture verification and explicit live-probe entry points.
 
 ## Retailer evidence
 
@@ -56,84 +51,80 @@ Interpretation:
 
 - direct anonymous server-side path: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`;
 - Pyaterochka product coverage: still mandatory;
-- alternative paths: supported X5/partner access, aggregator-backed coverage, or browser bridge.
+- next preferred technical fallback: reuse the proven user-assisted browser bridge contract from Perekrestok;
+- supported X5/partner access and aggregator-backed coverage remain valid parallel tracks.
 
 ### Perekrestok direct path
 
-PR #44 was squash-merged to `main` as `2d827479830c9ce4946f10bf80c145efb8ec6bf3` after full CI/security verification.
+PR #44 was squash-merged to `main` as `2d827479830c9ce4946f10bf80c145efb8ec6bf3`.
 
 Its ordinary first-party-cookie HTTP path returned:
 
 **`Provider Live Probe / Perekrestok / store-403` → failure**
 
-No browser-derived `Auth` was exported or replayed.
+No browser-derived `Auth` was exported or replayed. The direct anonymous/ordinary-cookie server-side path remains unsuitable.
 
-Interpretation:
-
-- direct anonymous/ordinary-cookie server-side path: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`;
-- Perekrestok product coverage: still mandatory;
-- selected fallback: user-assisted first-party browser bridge.
-
-### Perekrestok Browser Bridge Phase A — v1 live FAIL, v2 merged, real retest pending
+### Perekrestok Browser Bridge Phase A — LIVE PASS
 
 PR #49 was squash-merged to `main` as `333ad5d6ffbdcce3622a587b09004690afbe8e60`. It established the Chromium Manifest V3 bridge, normalized observation boundary, sanitized extension-local storage, fail-closed stale-data clearing, deterministic fixtures and persistent-Chromium E2E.
 
-The first real first-party browser gate on 2026-08-10 against an official Perekrestok catalog/category page returned:
+The first real browser gate on 2026-08-10 exposed an adapter-v1 mismatch:
 
-- bridge content script executed successfully;
+- bridge content script executed;
 - `data-zg-bridge-status = missing-context`;
 - observation count `0`;
 - result: **FAIL for adapter v1**.
 
-Sanitized diagnostics proved that the current frontend differs from the original structured-state fixture:
+Sanitized diagnostics proved the current site uses stable `.product-card` DOM and a same-origin `/api/customer/.../shop/<numeric-id>` resource pathname rather than the original embedded product/store state.
 
-- 2 structured JSON scripts parsed successfully but contained no v1 `masterData` + `priceTag` products and no usable store context;
-- `cart-store` / `orderStore` local-storage shapes were cart/order state rather than selected fulfillment context;
-- the live page rendered 101 stable `.product-card` elements with title and visible-price classes;
-- a same-origin first-party resource pathname shaped as `/api/customer/1.4.1.0/shop/<numeric-id>` exposed the selected shop context without needing response bodies, request headers, cookies, tokens or storage values.
+PR #53 was squash-merged to `main` as `218c96def777622ab66f1f8663f0466e35a9d804`. Its exact final head `ac29d2d2d6fe50d3c999c96e26d5bbfe0f6ff7ca` passed the complete repository workflow/security gate.
 
-PR #53 was squash-merged to `main` as `218c96def777622ab66f1f8663f0466e35a9d804`. Its exact final head `ac29d2d2d6fe50d3c999c96e26d5bbfe0f6ff7ca` passed all repository workflow groups, including API CI, Contract CI, Web CI + Web E2E, Retailer Bridge CI + persistent-Chromium E2E, CodeQL, Dependency Review, Release Bundle CI, Release Contract CI and both Container Security scans.
+Adapter v2 on `main`:
 
-Adapter v2 behavior now on `main`:
-
-- preserves the original embedded structured-state parser as a compatible path;
-- falls back to semantic `.product-card` DOM when structured-state products are absent;
-- derives product identity from the numeric product-link suffix;
-- normalizes visible `.price-new` RUB text to integer minor units;
-- emits DOM availability as `UNKNOWN` rather than inventing stock semantics;
-- accepts fulfillment context only from same-origin `/api/customer/<version>/shop/<numeric-id>` resource path evidence;
-- strips resource query/hash and passes only canonical same-origin `origin + pathname` values;
-- uses `PerformanceObserver` to recollect when asynchronous first-party resource evidence arrives;
-- uses `MutationObserver` to recollect when product DOM arrives after store context;
-- serializes overlapping collection attempts and disconnects both observers after the first `ok`;
-- keeps the production manifest permission surface at `storage` only;
+- preserves the legacy structured-state path;
+- falls back to semantic `.product-card` DOM when required;
+- derives SKU from the numeric product-link suffix;
+- normalizes visible RUB price to integer minor units;
+- uses `UNKNOWN` availability when catalog DOM does not prove stock;
+- accepts store context only from same-origin `/api/customer/<version>/shop/<numeric-id>` resource paths;
+- strips resource query/hash before adapter use;
+- handles late resource and late DOM evidence through `PerformanceObserver` + `MutationObserver`;
+- serializes overlapping collections and disconnects observers after first success;
+- keeps production permissions at `storage` only;
 - records adapter provenance as version `2`.
 
-PR #53 was developed through four explicit behavioral RED→GREEN gates:
+#### Repeated real-browser gate — 2026-08-11
 
-1. current live-shape regression: `missing-context` before the DOM/resource parser existed;
-2. asynchronous shop-resource regression: `missing-context` before resource-driven recollection existed;
-3. adapter provenance regression: v2 required before changing production metadata;
-4. delayed product-DOM regression: `missing-product` before DOM-driven recollection existed.
+The rebuilt v2 extension was exercised in the user's normal Yandex Browser profile on the official Perekrestok catalog after normal first-party store selection and full page reload.
 
-The final E2E additionally seeds a resource-query sentinel and proves it does not reach extension storage.
+Observed live result:
 
-Current decision remains **`BROWSER_BRIDGE_LIVE_PENDING`**. Deterministic v2 success is not treated as live retailer success. The updated extension must now pass the same real first-party catalog gate before Perekrestok can advance to `AVAILABLE_BROWSER_BRIDGE`.
+- `data-zg-bridge-status = ok`;
+- `data-zg-bridge-count = 90`;
+- adapter versions: exactly `2`;
+- fulfillment contexts: exactly one (`656`);
+- normalized validation failures: `0`;
+- sample observations contained nonblank SKU, integer non-negative `priceMinor`, `RUB`, `UNKNOWN` availability and canonical source references without query/hash.
 
-Detailed Phase A procedure: [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md).  
-First live-gate evidence: [`integrations/perekrestok-browser-bridge-live-2026-08-10.md`](integrations/perekrestok-browser-bridge-live-2026-08-10.md).
+Result: **PASS**.
 
-Follow-up issue #54 tracks the non-blocking persistent-session limitation: after the first successful snapshot, same-document store changes or SPA navigation require explicit lifecycle handling before the bridge is treated as a long-lived session transport.
+Current Perekrestok decision: **`AVAILABLE_BROWSER_BRIDGE`** for page-snapshot acquisition through the user-assisted first-party browser transport.
+
+Evidence:
+
+- initial live failure/root cause: [`integrations/perekrestok-browser-bridge-live-2026-08-10.md`](integrations/perekrestok-browser-bridge-live-2026-08-10.md);
+- final live PASS: [`integrations/perekrestok-browser-bridge-live-2026-08-11.md`](integrations/perekrestok-browser-bridge-live-2026-08-11.md);
+- Phase A decision/procedure: [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md).
+
+Issue #54 remains a non-blocking lifecycle hardening item: after the first successful snapshot, same-document store changes or SPA navigation are not yet automatically refreshed. The accepted current path therefore assumes intended store selection followed by page reload.
 
 ### Magnit
 
-PR #46 remains open on `spike/m0b-magnit`. It targets public SSR product pages for one fixed SKU under two explicit `shopCode` contexts without cookies/auth/API keys. No support claim is made until that PR/evidence path is resolved.
+PR #46 remains an independent non-X5 path candidate using public SSR product pages under explicit `shopCode` contexts without cookies/auth/API keys. No support claim is made until that evidence path is resolved.
 
 ### Kuper
 
-Issue #36 remains active and explicitly asks whether Kuper `Client apps API` can expose Pyaterochka/Perekrestok banner, store, catalog, price, promotions, availability and freshness with usable provenance and fixture rights.
-
-Aggregator observations must remain modeled as aggregator-sourced observations rather than direct retailer API observations.
+Issue #36 remains active for supported aggregator-backed access. Any Kuper observation must preserve aggregator provider provenance separately from the underlying retailer/banner identity.
 
 ## Verified platform baseline
 
@@ -169,7 +160,7 @@ Aggregator observations must remain modeled as aggregator-sourced observations r
 - Dependency Review;
 - Release Bundle/Contract CI;
 - Container Security CI with HIGH/CRITICAL fail-closed scans;
-- `Retailer Bridge CI` for deterministic extension unit/type/build/Chromium E2E verification;
+- `Retailer Bridge CI` with unit/type/build/persistent-Chromium E2E verification;
 - public Actuator limited to health/liveness/readiness/info.
 
 ## Release-engineering state
@@ -182,22 +173,21 @@ A successful real **`v0.1.0-rc.3` GitHub Release published event remains outstan
 
 ## Immediate next work
 
-1. Rebuild/reload adapter v2 in the normal first-party browser profile and repeat the real Perekrestok catalog gate from [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md).
-2. If v2 live PASSes, record sanitized evidence, advance Perekrestok to `AVAILABLE_BROWSER_BRIDGE`, and run the fixed corpus plan.
-3. If v2 still fails, add only the minimum sanitized regression evidence and a RED test before any further adapter change.
-4. Reuse the proven browser transport contract for Pyaterochka after Perekrestok live proof.
-5. Complete issue #50 before the bridge gains its own external dependencies or multiple substantial retailer adapters: make `apps/retailer-bridge` a first-class pnpm workspace importer and remove its temporary tooling coupling to `apps/web`.
-6. Resolve issue #54 before treating the browser bridge as a persistent-session transport across same-document store changes / SPA navigation.
-7. Continue Kuper/X5 supported-access work and resolve the independent Magnit path in parallel.
-8. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional chains through the same registry/adapter process.
-9. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
+1. Reuse the proven browser-bridge transport contract for Pyaterochka and drive it through the same deterministic + real-browser acceptance process.
+2. Run Perekrestok fixed-corpus/second-context validation as hardening and product-quality evidence; it is no longer the Phase A connectivity blocker.
+3. Resolve at least one independent non-X5 retailer path, with Magnit currently the nearest existing candidate.
+4. Complete issue #50 before the bridge gains its own external dependencies or multiple substantial retailer adapters: make `apps/retailer-bridge` a first-class pnpm workspace importer and remove the temporary tooling coupling to `apps/web`.
+5. Resolve issue #54 before treating the bridge as a persistent-session transport across post-success store changes / SPA navigation.
+6. Continue Kuper/X5 supported-access work in parallel.
+7. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional chains through the same registry/adapter process.
+8. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
 
 ## Definition of M0 success
 
 M0 is complete only when:
 
 - Pyaterochka has at least one reproducible accepted path;
-- Perekrestok has at least one reproducible accepted path;
+- Perekrestok has at least one reproducible accepted path — **now satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - at least one independent non-X5 retailer has a reproducible accepted path;
 - at least two acquisition modes are proven end to end;
 - deterministic sanitized fixtures/tests preserve retailer/provider/store provenance;

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,9 @@ This directory is the durable documentation entry point for Zakup Gotov. Documen
 | Universal retailer connectivity design | [`superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`](superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md) |
 | Retailer integration feasibility evidence | [`integrations/retailer-feasibility.md`](integrations/retailer-feasibility.md) |
 | Mandatory Pyaterochka/Perekrestok strategy | [`integrations/x5-mandatory-coverage.md`](integrations/x5-mandatory-coverage.md) |
-| Perekrestok browser-bridge Phase A evidence | [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md) |
-| Perekrestok first real-browser gate evidence | [`integrations/perekrestok-browser-bridge-live-2026-08-10.md`](integrations/perekrestok-browser-bridge-live-2026-08-10.md) |
+| Perekrestok browser-bridge Phase A decision | [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md) |
+| Perekrestok v1 live failure/root-cause evidence | [`integrations/perekrestok-browser-bridge-live-2026-08-10.md`](integrations/perekrestok-browser-bridge-live-2026-08-10.md) |
+| Perekrestok v2 real-browser PASS evidence | [`integrations/perekrestok-browser-bridge-live-2026-08-11.md`](integrations/perekrestok-browser-bridge-live-2026-08-11.md) |
 | Local setup and verification | [`DEVELOPMENT.md`](DEVELOPMENT.md) |
 | Container/release workflow | [`RELEASES.md`](RELEASES.md) |
 | Mandatory engineering policy | [`ENGINEERING.md`](ENGINEERING.md) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Updated: 2026-08-10
+Updated: 2026-08-11
 
 The roadmap is evidence-driven. Milestones may change when retailer integration feasibility or product usage contradicts current assumptions.
 
@@ -15,6 +15,13 @@ The durable design is in [`superpowers/specs/2026-08-10-universal-retailer-conne
 ## M0 — Product & Integration Discovery
 
 Goal: prove that the core product promise and the universal retailer-connectivity architecture are technically viable before substantial shopping-core development.
+
+Current evidence status:
+
+- **Perekrestok retailer-path criterion: satisfied** through `AVAILABLE_BROWSER_BRIDGE` page-snapshot acquisition after the real adapter-v2 browser PASS on 2026-08-11;
+- **Pyaterochka retailer-path criterion: outstanding**; direct anonymous HTTP is unsuitable and the proven browser-bridge contract is the next technical path;
+- **independent non-X5 retailer criterion: outstanding**;
+- **second distinct acquisition-mode criterion: outstanding** until another accepted path proves a non-browser mode end to end.
 
 Deliverables:
 
@@ -37,7 +44,7 @@ Accepted provider paths may be direct retailer APIs, supported aggregator integr
 Exit criteria:
 
 - **Pyaterochka** can return usable location/store-specific product/offer data through at least one acceptable path;
-- **Perekrestok** can return usable location/store-specific product/offer data through at least one acceptable path;
+- **Perekrestok** can return usable location/store-specific product/offer data through at least one acceptable path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - at least one independent non-X5 retailer can return usable location-specific product/offer data through an acceptable path;
 - at least two acquisition modes have been proven end to end so M0 does not depend on a single transport assumption;
 - accepted results are reproducible through automated tests/sanitized fixtures;

--- a/docs/integrations/perekrestok-browser-bridge-live-2026-08-10.md
+++ b/docs/integrations/perekrestok-browser-bridge-live-2026-08-10.md
@@ -1,161 +1,70 @@
 # Perekrestok Browser Bridge — Live Evidence 2026-08-10
 
-Status: `V1_LIVE_FAIL_V2_RETEST_PENDING`
+Status: `V1_LIVE_FAIL_SUPERSEDED_BY_V2_LIVE_PASS`
 Tracking: issue #52 / umbrella #47 / PR #53
 
 ## Scope
 
-This record captures the first real first-party Perekrestok browser gate and the deterministic follow-up adaptation. It contains only sanitized structural evidence. No cookie values, authorization material, request headers, response bodies, browser-storage values, exact address, or raw production HTML are recorded.
+This record preserves the first real first-party Perekrestok browser gate that exposed the adapter-v1 mismatch and motivated adapter v2. It is historical evidence, not the current connectivity decision.
+
+The successful repeated v2 gate is recorded separately in [`perekrestok-browser-bridge-live-2026-08-11.md`](perekrestok-browser-bridge-live-2026-08-11.md).
+
+No cookie values, authorization material, request headers, response bodies, browser-storage values, exact address, or raw production HTML were recorded.
 
 ## First real browser gate
 
-Page type: category/catalog page on the official `www.perekrestok.ru` origin.
+Page type: official `www.perekrestok.ru` category/catalog page.
 
-Initial bridge result:
+Adapter-v1 result:
 
 - bridge content script executed: **yes**;
 - result: **FAIL**;
 - status: `missing-context`;
 - observation count: `0`.
 
-The failure was an adapter mismatch rather than an extension-load failure.
+This proved an adapter mismatch rather than an extension-load failure.
 
 ## Sanitized structural evidence
 
-The current live page differs materially from the original v1 fixture assumptions:
+The live page differed materially from the original v1 fixture assumptions:
 
 - two structured JSON scripts parsed successfully;
 - those scripts exposed no v1 `masterData` + `priceTag` product objects;
-- they exposed no `selectedShopId`, `shopId`, `shop.id`, or other usable store/location key;
-- `cart-store` and `orderStore` local-storage entries were inspected by **shape only** and proved to be cart/order state rather than the selected fulfillment context;
-- the live catalog rendered 101 stable `.product-card` elements during the observation;
-- the same cards exposed stable title/price classes including `.product-card__title-link`, `.product-card__price`, and `.price-new`;
-- product links ended in a numeric product identity suitable for deterministic SKU extraction;
-- the browser resource timeline contained a same-origin first-party path shaped as `/api/customer/1.4.1.0/shop/<numeric-id>`;
-- no response body is needed to obtain that fulfillment-context identifier.
+- they exposed no usable `selectedShopId`, `shopId` or `shop.id` context;
+- `cart-store` and `orderStore` storage entries were inspected by shape only and proved to be cart/order state rather than selected fulfillment context;
+- the live catalog rendered 101 stable `.product-card` elements;
+- cards exposed stable title/price classes including `.product-card__title-link`, `.product-card__price` and `.price-new`;
+- product links ended in numeric product identity suitable for deterministic SKU extraction;
+- the browser resource timeline contained a same-origin path shaped as `/api/customer/1.4.1.0/shop/<numeric-id>`;
+- no response body was required to derive that context candidate.
 
 ## Root cause
 
-Adapter v1 depended on embedded structured JSON that the current frontend no longer uses for the required catalog/store evidence.
+Adapter v1 depended on embedded structured JSON that the current frontend no longer used for the required catalog/store evidence.
 
-The current viable first-party evidence path is:
+The viable first-party evidence path discovered from this gate was:
 
 1. product identity/title/current visible price from semantic catalog DOM;
-2. fulfillment context from the same-origin first-party `/shop/<numeric-id>` resource pathname already present in the browser performance timeline;
-3. availability remains `UNKNOWN` when the DOM does not expose an explicit stock semantic.
+2. fulfillment context from the same-origin first-party `/shop/<numeric-id>` resource pathname;
+3. availability `UNKNOWN` when the DOM exposes no explicit stock semantic.
 
-The live frontend is asynchronous in two independent dimensions: the shop-context resource can appear after `document_idle`, and product cards can be rendered after the shop-context resource has already arrived. A bridge that watches only one of those events can still fail closed permanently on an otherwise valid page.
+The live frontend was also asynchronous in two independent dimensions: shop-context resources and product cards could arrive in either order after `document_idle`.
 
-## TDD adaptation evidence
+## TDD follow-up
 
-PR #53 introduced the adaptation through separate RED -> GREEN cycles.
+PR #53 adapted the bridge through four behavioral RED -> GREEN gates:
 
-### RED 1 — current live shape
+1. current live DOM/resource shape reproduced `missing-context`;
+2. late shop-resource timing reproduced `missing-context` until `PerformanceObserver` recollection was added;
+3. adapter provenance was advanced explicitly to version `2`;
+4. late product DOM reproduced `missing-product` until `MutationObserver` recollection was added.
 
-A sanitized DOM fixture plus first-party resource-path regression test was committed before production changes.
+The final persistent-Chromium E2E retained the original privacy/stale-data checks and additionally proved that a resource-query sentinel is stripped before extension persistence.
 
-On head `c7f197e422980f418d89f47677b0f5664ffd34a3`:
+## Historical decision
 
-- 15 pre-existing bridge tests passed;
-- the single new live-shape test failed;
-- expected `ok`, received `missing-context`.
+**2026-08-10:** adapter v1 real-browser gate = FAIL (`missing-context`).
 
-### GREEN 1 — adapter parser
+**Superseded on 2026-08-11:** adapter v2 passed the repeated real-browser gate with 90 normalized observations, one fulfillment context, adapter version `2`, and zero validation failures. Current Perekrestok state is `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition.
 
-The adapter was extended to:
-
-- preserve the existing structured-state path;
-- recognize only same-origin `/api/customer/<version>/shop/<numeric-id>` resource paths as runtime store-context evidence;
-- parse `.product-card` DOM only when structured-state products are absent;
-- derive SKU from the numeric product-link suffix;
-- normalize visible RUB price text to integer minor units;
-- use `UNKNOWN` availability rather than infer stock from catalog presence;
-- deduplicate DOM products by SKU.
-
-The focused adapter suite then passed.
-
-### RED 2 — asynchronous runtime context
-
-A persistent-Chromium extension E2E was added where the shop resource resolves asynchronously after page parsing.
-
-On head `825000ee6561262fed9fa955ed44ecc06136cbed`:
-
-- 16 unit tests passed;
-- typecheck passed;
-- production build passed;
-- the original extension E2E passed;
-- the new live-shape E2E failed with `missing-context`.
-
-This proved that a one-shot `document_idle` collection could run before the asynchronous shop resource entered the performance timeline.
-
-### GREEN 2 — resource-driven recollection
-
-The content script was changed to:
-
-- observe browser `resource` performance entries;
-- retain only same-origin canonical `origin + pathname` evidence;
-- strip query strings and fragments before the adapter sees resource evidence;
-- recollect when new first-party resource evidence appears;
-- serialize overlapping collection attempts;
-- keep fail-closed stale-observation clearing before success.
-
-On head `deaa7357a0f15645bcc89a3b7726161e4c8be477`, Retailer Bridge CI passed all unit/type/build checks and both persistent-Chromium E2E scenarios that existed at that point.
-
-### RED/GREEN 3 — provenance version
-
-The updated acquisition logic is explicitly versioned as Perekrestok browser adapter v2 so observations cannot be confused with the original structured-state-only implementation.
-
-A test-first provenance change failed against v1 and then passed after the adapter was advanced to v2. On head `94cdfdebf762e3d3c5fda64f34287636160e4a75`, Retailer Bridge CI passed completely.
-
-### RED 4 — shop context arrives before product DOM
-
-Change review identified a second independent SPA timing path: the first-party shop resource can be visible before the product cards are inserted into the DOM. A new sanitized persistent-Chromium fixture therefore starts the shop request first and inserts the `.product-card` later.
-
-On head `f8887dfa3e46ca02c314299a8d2d69de6526c589`:
-
-- all 16 unit tests passed;
-- typecheck passed;
-- production build passed;
-- the original extension E2E passed;
-- the delayed-DOM live-shape E2E failed;
-- expected `ok`, received `missing-product`.
-
-This was a valid behavioral RED: resource-driven recollection had already obtained the context, but no later event caused collection after the SPA rendered the product card.
-
-### GREEN 4 — DOM-driven recollection
-
-The content script now also uses a `MutationObserver` on child-list changes in the page subtree. DOM and resource events share the same serialized collection path. After the first `ok`, both observers disconnect.
-
-No polling interval, arbitrary sleep, or unbounded retry loop is used.
-
-On executable head `dcf9b8f5a092fb579137d347db85eb838b15c192`, Retailer Bridge CI passed:
-
-- 16 unit/fixture tests;
-- TypeScript typecheck;
-- production extension build;
-- the original privacy/stale-data Chromium E2E;
-- the current live-shape Chromium E2E with asynchronous shop context and delayed product DOM.
-
-The live-shape fixture also seeds `SECRET_RESOURCE_QUERY` in the shop-resource query string. The E2E verifies that neither that sentinel nor `session=` reaches extension storage, proving the runtime path canonicalizes resource evidence before persistence.
-
-## Security/privacy boundary
-
-The v2 adaptation does **not** add extension permissions and does not read or export:
-
-- cookies;
-- authorization headers or tokens;
-- response bodies;
-- arbitrary local/session-storage values;
-- CAPTCHA artifacts;
-- precise user addresses;
-- cross-origin resource URLs.
-
-Only same-origin canonical resource pathnames and normalized product observations participate in the new path. Query strings/fragments are removed from resource evidence before adapter use, and the existing observation collector still reconstructs the persisted allow-listed object. The production manifest remains `storage`-only.
-
-## Current decision
-
-The first real browser gate is recorded as **FAIL for adapter v1**.
-
-PR #53 provides a deterministic v2 fix, but Perekrestok remains **`BROWSER_BRIDGE_LIVE_PENDING`** until the rebuilt v2 extension is loaded in the user's normal browser and the same real page produces sanitized store/SKU/price observations.
-
-A successful deterministic CI run is not substituted for that real-browser retest.
+See [`perekrestok-browser-bridge-live-2026-08-11.md`](perekrestok-browser-bridge-live-2026-08-11.md) for the accepted live evidence.

--- a/docs/integrations/perekrestok-browser-bridge-live-2026-08-11.md
+++ b/docs/integrations/perekrestok-browser-bridge-live-2026-08-11.md
@@ -1,0 +1,76 @@
+# Perekrestok Browser Bridge — Live PASS 2026-08-11
+
+Status: `AVAILABLE_BROWSER_BRIDGE`
+Tracking: issue #52 / umbrella #47 / PR #53
+
+## Scope
+
+This record captures the repeated real first-party Perekrestok browser gate after adapter v2 was merged to `main`.
+
+Only sanitized normalized evidence is recorded. No cookies, authorization material, request headers, response bodies, arbitrary browser-storage values, exact address, CAPTCHA data, or raw production HTML are included.
+
+## Environment
+
+- browser family: Chromium-compatible normal user browser profile (Yandex Browser);
+- retailer origin: official `www.perekrestok.ru`;
+- page type: category/catalog page;
+- bridge: Zakup Gotov Retailer Bridge;
+- adapter version: `2`.
+
+## Live result
+
+The updated extension was loaded/reloaded in the normal first-party browser profile and the catalog page was fully reloaded after store selection.
+
+Observed bridge diagnostics:
+
+- `data-zg-bridge-status`: `ok`;
+- `data-zg-bridge-count`: `90`;
+- result: **PASS**.
+
+A sanitized validation over `zg.latestObservations` then reported:
+
+- observation count: `90`;
+- adapter versions: exactly `2`;
+- fulfillment contexts: exactly one context, `656`;
+- invalid normalized observations under the acceptance predicate: `0`.
+
+The acceptance predicate required every observation to have:
+
+- adapter version `2`;
+- nonblank fulfillment context;
+- nonblank SKU;
+- integer `priceMinor >= 0`;
+- currency `RUB`;
+- availability in `AVAILABLE`, `UNAVAILABLE`, `UNKNOWN`;
+- canonical `sourceReference` without query string or fragment.
+
+Three sanitized sample observations all satisfied the contract. Their prices were represented as integer minor units and their availability was `UNKNOWN`, matching the documented DOM semantics where catalog presence alone is not treated as stock proof.
+
+## Acceptance decision
+
+The repeated real-browser v2 gate satisfies the Phase A acceptance criteria:
+
+- bridge status `ok`: **PASS**;
+- observation count greater than zero: **PASS** (`90`);
+- adapter version `2`: **PASS**;
+- exactly one fulfillment context: **PASS** (`656`);
+- SKU present: **PASS**;
+- integer non-negative price: **PASS**;
+- currency `RUB`: **PASS**;
+- availability explicit/`UNKNOWN`: **PASS**;
+- canonical source reference with no query/hash: **PASS**;
+- normalized validation failures: **0**;
+- credential/session export observed: **false**;
+- raw production HTML persisted: **false**.
+
+## Decision
+
+Perekrestok Browser Bridge Phase A is **LIVE PASS**.
+
+Perekrestok connectivity advances from `BROWSER_BRIDGE_LIVE_PENDING` to **`AVAILABLE_BROWSER_BRIDGE`** for page-snapshot acquisition through the user-assisted first-party browser transport.
+
+This status means Zakup Gotov has one reproducible accepted Perekrestok acquisition path. It does **not** imply a supported direct retailer API, server-side scraping capability, or persistent-session lifecycle support.
+
+Issue #54 remains the explicit non-blocking follow-up before the bridge is treated as a long-lived session transport across same-document store changes or SPA navigation after the first successful snapshot.
+
+Next M0 work is to reuse the proven browser-bridge transport contract for Pyaterochka and continue proving at least one independent non-X5 retailer path.

--- a/docs/integrations/perekrestok-browser-bridge-phase-a.md
+++ b/docs/integrations/perekrestok-browser-bridge-phase-a.md
@@ -1,231 +1,121 @@
 # Perekrestok Browser Bridge Phase A
 
-Updated: 2026-08-10
-Status: `V2_DETERMINISTIC_READY_RETEST_PENDING`
+Updated: 2026-08-11
+Status: `AVAILABLE_BROWSER_BRIDGE`
 Tracking: issue #47 / issue #52 / PR #49 / PR #53
 
 ## Purpose
 
-Prove the user-assisted first-party browser transport for a mandatory retailer after the direct anonymous/ordinary-cookie Perekrestok API path returned `store-403`.
+Prove a user-assisted first-party browser transport for mandatory Perekrestok coverage after the direct anonymous/ordinary-cookie server-side path returned `store-403`.
 
-This phase does **not** claim that Perekrestok is connected in production. PR #49 proved the extension/privacy boundary. The first real browser gate then exposed a current-site adapter mismatch, and PR #53 provides the deterministic v2 adaptation. A repeated real first-party browser PASS is still required before the path can advance from `LIVE_PENDING`.
+Phase A is now complete for **page-snapshot acquisition**: adapter v2 passed the repeated real first-party browser gate on 2026-08-11. This does not claim a supported direct retailer API or a persistent long-lived browser-session transport.
 
 ## Implemented transport
 
 `apps/retailer-bridge` is a Chromium Manifest V3 extension package.
 
-Production manifest properties:
+Production boundary:
 
-- Manifest V3;
 - `storage` is the only extension permission;
 - no `host_permissions`;
-- content script matches `https://www.perekrestok.ru/*`;
-- content script runs at `document_idle` in the default isolated execution world;
-- no `cookies`, `webRequest`, `debugger`, proxy-control or declarative-network-request permissions.
+- content script matches only `https://www.perekrestok.ru/*`;
+- no `cookies`, `webRequest`, `debugger`, proxy-control or declarative-network-request permissions;
+- login, location/store selection and any CAPTCHA remain manual first-party user actions;
+- no cookie/token/auth export or replay;
+- no response-body or request-header capture.
 
-The user remains responsible for any first-party login, store selection or CAPTCHA interaction required by Perekrestok. The extension does not automate those access-control steps.
+The browser collector persists only allow-listed normalized observations: retailer/provider provenance, `BROWSER_BRIDGE` source mode, fulfillment context, SKU/product name, integer minor-unit price, `RUB`, explicit/`UNKNOWN` availability, timestamp, canonical source URL without query/hash, and adapter version.
 
-## Observation boundary
+## Adapter v2 acquisition path
 
-The browser collector persists only the allow-listed normalized fields:
+Adapter v2 preserves the original embedded structured-state parser for compatible pages and adds the current catalog path proven from live evidence.
 
-- schema version;
-- retailer ID;
-- source provider ID;
-- source mode `BROWSER_BRIDGE`;
-- fulfillment/store context ID;
-- SKU/PLU;
-- product name;
-- integer minor-unit price;
-- `RUB` currency;
-- `AVAILABLE`, `UNAVAILABLE`, or `UNKNOWN` availability;
-- observation timestamp;
-- canonical source URL without query/hash;
-- adapter version.
+When structured-state products are absent, v2 reads:
 
-Adapter output is treated as untrusted. The collector reconstructs a new normalized object before it reaches extension storage. Extra adapter fields such as cookies, authorization material or addresses are discarded.
+- `.product-card` as the product boundary;
+- `.product-card__title-link` / `.product-card__title` for product identity/name;
+- the numeric product-link suffix as SKU candidate;
+- `.product-card__price .price-new` / `.price-new` for the visible current RUB price;
+- same-origin `/api/customer/<version>/shop/<numeric-id>` resource pathname for fulfillment context.
 
-On any fail-closed page state, the content script replaces `zg.latestObservations` with an empty array so a previous store/page cannot leave stale prices visible as current observations.
+Catalog presence alone does not prove stock, so DOM-derived observations use `UNKNOWN` availability unless an explicit supported stock semantic is later proven.
 
-## Perekrestok adapter v2
-
-Adapter v2 preserves the original structured-state path for pages where that evidence still exists and adds the current catalog path observed in the first real browser gate.
-
-### Structured-state path
-
-The adapter still parses, without `eval`:
-
-- `script[type="application/json"]`;
-- `script#__NEXT_DATA__`;
-- `script[type="application/ld+json"]`.
-
-The legacy evidence shape remains supported:
-
-- `masterData.plu` — stable product identity;
-- `priceTag.price` — integer minor-unit price;
-- `balanceState` — availability evidence;
-- `selectedShopId`, `shopId`, or `shop.id` — fulfillment/store context candidates.
-
-### Current catalog DOM path
-
-The 2026-08-10 live page no longer exposed the required product/store evidence in those structured scripts. It did expose stable semantic catalog DOM and a first-party shop resource pathname.
-
-When structured-state products are absent, v2 can read:
-
-- `.product-card` — product-card boundary;
-- `.product-card__title-link` / `.product-card__title` — product name and product href;
-- numeric product-link suffix — stable SKU candidate;
-- `.product-card__price .price-new` / `.price-new` — visible current price;
-- same-origin `/api/customer/<version>/shop/<numeric-id>` resource pathname — fulfillment context.
-
-Visible RUB price text is normalized to integer minor units. DOM catalog presence alone does **not** prove availability, so this path emits `UNKNOWN` unless an explicit supported availability semantic is later proven.
-
-Only same-origin canonical resource `origin + pathname` values are passed to the adapter. Query strings and fragments are removed before runtime resource evidence crosses the content-script boundary. No response body or request headers are read.
+Only same-origin canonical `origin + pathname` resource evidence crosses the runtime boundary; query strings and fragments are removed before adapter use.
 
 ## Asynchronous SPA handling
 
-The original Phase A implementation collected once at `document_idle`. TDD regressions against the sanitized live shape proved two independent timing races:
+TDD against the sanitized live shape proved two independent races:
 
-1. the first-party shop request can appear after the initial collection;
-2. the shop context can already be known while `.product-card` elements are rendered later by the SPA.
+1. the shop-context resource can arrive after `document_idle`;
+2. product cards can render after shop context is already available.
 
-The v2 content runtime therefore:
+The content runtime therefore uses:
 
-- seeds already-completed resource entries;
-- observes new `resource` performance entries;
-- retains only same-origin canonical resource paths;
-- observes DOM child-list changes through `MutationObserver`;
-- recollects when either new first-party resource evidence or later DOM evidence appears;
-- serializes overlapping collection attempts;
-- disconnects both observers after the first successful collection;
-- keeps fail-closed stale-observation clearing before success.
+- `PerformanceObserver` for new first-party resource evidence;
+- `MutationObserver` for later DOM evidence;
+- one serialized collection path;
+- fail-closed stale-observation clearing before success;
+- observer shutdown after the first successful snapshot.
 
-No arbitrary sleep, polling interval, or unbounded retry loop is used.
+No arbitrary sleep, polling interval or unbounded retry loop is used.
 
 ## First real browser gate — 2026-08-10
 
-The first live check was performed on an official Perekrestok category/catalog page.
-
-Result for adapter v1:
+Adapter v1 on an official Perekrestok category/catalog page returned:
 
 - content script executed: yes;
 - status: `missing-context`;
 - observation count: `0`;
 - result: **FAIL**.
 
-Sanitized diagnostics established:
+Sanitized diagnostics established that the current frontend no longer exposed the required v1 embedded product/store JSON, while the live page did expose stable `.product-card` DOM and same-origin `/api/customer/.../shop/<numeric-id>` resource-path evidence.
 
-- 2 structured JSON scripts parsed successfully;
-- 0 v1 `masterData` + `priceTag` product objects;
-- no usable store context in those scripts;
-- `cart-store` / `orderStore` storage entries were cart/order state, not fulfillment context;
-- 101 stable `.product-card` elements were rendered;
-- same-origin runtime resources included the current `/api/customer/.../shop/<numeric-id>` shape.
+Historical evidence: [`perekrestok-browser-bridge-live-2026-08-10.md`](perekrestok-browser-bridge-live-2026-08-10.md).
 
-Detailed sanitized evidence: [`perekrestok-browser-bridge-live-2026-08-10.md`](perekrestok-browser-bridge-live-2026-08-10.md).
+## Deterministic TDD adaptation
 
-## Deterministic TDD evidence
+PR #53 delivered adapter v2 through four behavioral RED -> GREEN gates:
 
-### Phase A v1
+1. current live DOM/resource shape reproduced `missing-context` before the new parser;
+2. asynchronous shop-resource timing reproduced `missing-context` before resource-driven recollection;
+3. adapter provenance was required as version `2` before production metadata changed;
+4. delayed product DOM reproduced `missing-product` before DOM-driven recollection.
 
-PR #49 established:
+The final persistent-Chromium E2E also seeds a resource-query sentinel and proves it does not reach extension storage. The exact final PR #53 head passed the complete repository CI/security gate before merge.
 
-1. manifest permission contract RED -> GREEN;
-2. browser observation collector RED -> GREEN;
-3. structured-state adapter RED -> GREEN;
-4. Chrome observation sink RED -> GREEN;
-5. Chromium stale-observation regression RED -> GREEN.
+## Repeated real-browser v2 gate — 2026-08-11
 
-At its merge point:
+The rebuilt v2 extension was loaded/reloaded in the user's normal Yandex Browser profile. After normal first-party store selection and a full page reload, the official Perekrestok category page produced:
 
-- bridge unit/fixture suite: 15 tests PASS;
-- bridge TypeScript: PASS;
-- production extension build: PASS;
-- persistent-Chromium MV3 E2E: PASS.
+- `data-zg-bridge-status = ok`;
+- `data-zg-bridge-count = 90`;
+- adapter versions: exactly `2`;
+- fulfillment contexts: exactly one (`656`);
+- normalized-validation failures: `0`.
 
-### Live adaptation v2
+The sanitized validation required every observation to contain a nonblank context/SKU, integer `priceMinor >= 0`, `RUB`, valid availability (`AVAILABLE`, `UNAVAILABLE`, `UNKNOWN`), adapter version `2`, and canonical `sourceReference` without query/hash.
 
-PR #53 adds four explicit test-first gates:
+Result: **PASS**.
 
-1. **Current live shape RED:** 15 old tests PASS, one new DOM/resource test FAIL with `missing-context`; then adapter parsing GREEN.
-2. **Asynchronous resource RED:** 16 unit tests/type/build PASS and original E2E PASS, while the new live-shape E2E FAILed with `missing-context`; resource-driven recollection then made the tested path GREEN.
-3. **Provenance RED:** tests required adapter version `2` before production metadata changed; the suite then returned GREEN after v2 provenance was applied.
-4. **Delayed DOM RED:** 16 unit tests/type/build PASS and original E2E PASS, while the new delayed-card E2E FAILed with `missing-product`; DOM-driven recollection then made the full live-shape E2E GREEN.
+Final live evidence: [`perekrestok-browser-bridge-live-2026-08-11.md`](perekrestok-browser-bridge-live-2026-08-11.md).
 
-The final live-shape E2E deliberately places `SECRET_RESOURCE_QUERY` in the first-party shop-resource query string and verifies that neither the sentinel nor `session=` reaches extension storage.
+## Security/privacy evidence
 
-The live-shape fixtures are synthetic/sanitized. Ordinary CI intercepts the Perekrestok origin before external network access and therefore has zero live retailer dependency.
+The live acceptance record contains no cookies, tokens, authorization headers, response bodies, arbitrary browser-storage values, exact street address, CAPTCHA artifacts, or raw production HTML.
 
-## Security/privacy boundary
-
-The v2 adaptation does not expand production permissions.
-
-It does not export or persist:
-
-- cookies;
-- authorization headers or tokens;
-- CAPTCHA data;
-- raw response bodies;
-- arbitrary browser-storage values;
-- exact street addresses;
-- raw production HTML.
-
-The original sentinel cookie/localStorage E2E remains active. Runtime resource evidence is restricted to same-origin canonical URL paths without query strings or fragments, and the new resource-query sentinel regression verifies that boundary through the production extension.
-
-## Real-browser v2 retest
-
-Use a fresh build from PR #53 (or `main` after merge):
-
-```bash
-pnpm install --frozen-lockfile
-pnpm --dir apps/retailer-bridge test
-pnpm --dir apps/retailer-bridge typecheck
-pnpm --dir apps/retailer-bridge build
-```
-
-Then reload the unpacked extension in the normal browser profile.
-
-For Chrome/Chromium use `chrome://extensions`. For Yandex Browser use its extension-management page (for example `browser://extensions` where supported). Enable developer mode and load/reload `apps/retailer-bridge/dist`.
-
-On the official Perekrestok site:
-
-1. manually select the intended store/location;
-2. manually complete any login/CAPTCHA required by the retailer;
-3. open a catalog/category page showing current product prices;
-4. reload the page after the updated extension is active;
-5. verify `document.documentElement.dataset.zgBridgeStatus`;
-6. verify `document.documentElement.dataset.zgBridgeCount`;
-7. if status is `ok`, inspect only sanitized `zg.latestObservations` in extension storage.
-
-Acceptance requires:
-
-- bridge status `ok`;
-- observation count greater than zero;
-- adapter version `2`;
-- fulfillment context present and nonblank;
-- SKU present and nonblank;
-- integer `priceMinor >= 0`;
-- currency `RUB`;
-- availability explicit or `UNKNOWN`;
-- source reference contains no query/hash;
-- no cookie/auth/browser-storage value exported;
-- no raw HTML persisted.
-
-Live evidence record must contain only:
-
-- observation date/time;
-- page type;
-- adapter version;
-- store/context present: true/false;
-- SKU present: true/false;
-- price present: true/false;
-- availability semantic;
-- credential export observed: false;
-- raw HTML persisted: false;
-- result: PASS/FAIL.
+The production manifest remains `storage`-only and the normalized collector allow-list remains the persistence boundary.
 
 ## Decision
 
-Current decision: **`BROWSER_BRIDGE_LIVE_PENDING`**.
+Current Perekrestok state: **`AVAILABLE_BROWSER_BRIDGE`** for page-snapshot acquisition through the user-assisted first-party browser transport.
 
-Adapter v1 has a recorded real-browser FAIL. Adapter v2 is deterministic-ready, but Perekrestok must not be marked `AVAILABLE_BROWSER_BRIDGE` until the v2 real first-party retest passes.
+This is one reproducible accepted Perekrestok path for the M0 connectivity invariant.
+
+Known limitation: issue #54 tracks post-success same-document store changes / SPA navigation. Until that lifecycle is implemented and verified, callers should treat the accepted path as a page snapshot obtained after the intended store is selected and the page is reloaded, not as a continuously self-refreshing session transport.
+
+Next connectivity work:
+
+1. reuse the proven browser transport contract for Pyaterochka;
+2. run the fixed Perekrestok corpus/second-context validation as hardening, not as a blocker to the Phase A path acceptance;
+3. prove at least one independent non-X5 retailer path;
+4. continue supported/aggregator access research in parallel.

--- a/docs/integrations/x5-mandatory-coverage.md
+++ b/docs/integrations/x5-mandatory-coverage.md
@@ -1,6 +1,6 @@
 # X5 Mandatory Coverage Strategy
 
-Updated: 2026-08-10
+Updated: 2026-08-11
 Status: M0 product constraint and integration strategy
 Tracking: issue #47
 
@@ -11,6 +11,13 @@ Pyaterochka and Perekrestok are mandatory retailer coverage for Zakup Gotov.
 A failed anonymous direct-HTTP probe does not remove either banner from product scope. M0 cannot reach GO unless both banners have at least one reproducible acceptable data path.
 
 The goal is not necessarily a direct retailer API. The goal is reliable banner- and store-specific product observations with explicit provenance.
+
+## Current X5 state
+
+- **Perekrestok:** `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition. Adapter v2 passed the repeated real first-party browser gate on 2026-08-11 with `status=ok`, 90 normalized observations, one fulfillment context, adapter version `2`, and zero validation failures.
+- **Pyaterochka:** direct anonymous JDK path remains `DIRECT_ANONYMOUS_HTTP_UNSUITABLE` after `store-403`; accepted coverage is still outstanding.
+
+Perekrestok therefore satisfies its M0 per-retailer connectivity requirement. Pyaterochka is now the remaining mandatory X5 connectivity blocker.
 
 ## Required observation contract
 
@@ -29,128 +36,92 @@ No path may silently present aggregator data as a direct retailer observation.
 
 ## Track A — supported X5 partnership
 
-Preferred long-term path: obtain supported access from X5/X5 Digital for store-scoped assortment, price, promotions and availability.
+Preferred long-term path remains supported access from X5/X5 Digital for store-scoped assortment, price, promotions and availability.
 
-Primary-source evidence:
-
-- X5 publicly invites digital partners and explicitly describes partnership around services/infrastructure for express delivery from X5 retail stores: https://www.x5.ru/ru/partners/
-- X5 has a history of partner data products and automated data delivery through Dialog X5 / DataBridge: https://www.x5.ru/ru/news/h5-otkryvaet-dannye-s-pomoshhyu-data-bridge/
-- X5 exposes partnership channels for its digital ecosystem and X5 Club; the latter publishes `partner@x5club.ru`: https://www.x5.ru/ru/partners/marketing/loyalty-programs/
-
-### Partnership request
-
-Ask X5 for a supported read-side integration intended for a consumer grocery-planning/comparison product. Required fields:
-
-1. store/fulfillment resolution from coarse location;
-2. banner and store ID;
-3. searchable assortment;
-4. stable SKU/product identifier;
-5. current price and promotions;
-6. availability/stock semantics;
-7. freshness/observation timestamps;
-8. rate limits and caching policy;
-9. permission for cross-retailer comparison;
-10. permission to retain sanitized fixtures for deterministic tests;
-11. attribution/deep-link requirements;
-12. sandbox/test credentials if available.
+A partnership request should cover store/fulfillment resolution, banner/store ID, searchable assortment, stable SKU, current price/promotions, availability/freshness, rate limits/caching, comparison rights, sanitized fixture rights, attribution/deep links and sandbox/test credentials.
 
 ## Track B — aggregator-backed X5 coverage
 
-This is the strongest independent fallback discovered so far.
+Kuper and other supported aggregator surfaces remain a strong independent fallback/parallel path.
 
-Primary-source evidence:
+Any aggregator path is acceptable only if it preserves retailer/banner identity, underlying fulfillment context where available, stable product identity, explicit price/promotion/availability semantics, freshness and provenance such as `provider=kuper`, `retailer=pyaterochka` rather than pretending the observation came directly from X5.
 
-- X5 states that Yandex Eats carried the full Pyaterochka and Perekrestok assortment and that prices, discounts and promotions matched the retail chains: https://www.x5.ru/ru/news/x5-zapustila-dostavku-cherez-yandeks-edu/
-- Kuper's current consumer surface lists both `ПЯТЁРОЧКА` and `ПЕРЕКРЁСТОК` among supported retailers: https://kuper.ru/
-- Kuper publishes an official API program that includes `Client apps API` and an integration contact: https://docs.kuper.ru/
-
-This means X5 coverage should not depend only on direct `5d.5ka.ru` or `perekrestok.ru/api/customer/...` access.
-
-### Acceptance for an aggregator path
-
-An aggregator path is acceptable only if it preserves:
-
-- source retailer/banner identity;
-- underlying store/fulfillment context where available;
-- product identity stable enough for matching;
-- retailer-equivalent or explicitly aggregator-specific price semantics;
-- explicit promotion semantics;
-- availability/freshness semantics;
-- clear provenance such as `provider=kuper`, `retailer=pyaterochka` rather than pretending the observation came directly from X5.
-
-Issue #36 should explicitly determine whether Kuper Client apps API can expose Pyaterochka/Perekrestok store-scoped catalog observations to Zakup Gotov.
+Issue #36 continues to investigate supported Kuper Client apps API coverage.
 
 ## Track C — user-assisted first-party browser bridge
 
-Technical fallback when public anonymous APIs reject automated server-side access.
+This path is now **proven for Perekrestok page snapshots**.
 
-The connector runs in the user's own browser/profile against the official retailer surface. The user performs any login, store selection and CAPTCHA manually. After the first-party site has granted the user access, Zakup Gotov may extract only information already rendered or exposed to that browser context.
+Architecture/boundary:
 
-### Recommended architecture
+1. user opens the official retailer page in their own browser/profile;
+2. user manually resolves login/CAPTCHA/store selection when required;
+3. bridge reads semantic DOM, embedded structured state, and/or first-party resource evidence already visible in that legitimate browser context;
+4. bridge normalizes observations locally;
+5. only sanitized normalized observations leave the page context when needed.
 
-1. Browser extension or local browser-side companion.
-2. User opens the official Pyaterochka/Perekrestok page.
-3. User manually resolves login/CAPTCHA/store selection when required.
-4. Connector reads one of, in order of preference:
-   - semantic DOM/product cards;
-   - embedded structured page state/JSON already delivered to the page;
-   - first-party responses already visible to the authenticated browser context, without exporting/replaying authorization material elsewhere.
-5. Connector normalizes observations locally into the shared provider contract.
-6. Only sanitized normalized observations are sent to the Zakup Gotov backend when needed.
+Security boundary:
 
-### Security boundary
+- CAPTCHA remains manual; no solver/bypass;
+- no browser-fingerprint spoofing or stealth evasion;
+- no proxy/IP rotation to defeat blocking;
+- no capture/export/replay of session cookies/tokens/auth headers;
+- no raw response-body persistence;
+- no exact street address in fixtures/logs;
+- stop on explicit provider blocking rather than escalating evasion.
 
-- CAPTCHA remains manual; no solver or bypass service.
-- No browser-fingerprint spoofing or stealth automation.
-- No proxy/IP rotation used to defeat provider blocking.
-- No capture/export of another user's session.
-- Cookies/tokens remain inside the user's browser profile and are never persisted by Zakup Gotov backend, logs, CI or fixtures.
-- Do not synthesize or replay private `Auth`/device credentials outside the first-party browser context.
-- Stop on explicit provider blocking rather than escalating evasion.
-- Exact street addresses are not written into fixtures or logs.
+### Perekrestok proof
 
-### Why this path is materially different from CAPTCHA bypass
+Adapter v1 first failed transparently on 2026-08-10 because the current frontend no longer exposed its expected embedded product/store state.
 
-The user remains the actor who obtains legitimate first-party browser access. Zakup Gotov does not defeat the access-control challenge; it reads data the first-party site has already chosen to render to that user session.
+PR #53 introduced adapter v2 using current semantic `.product-card` DOM plus same-origin `/api/customer/<version>/shop/<numeric-id>` resource-path evidence with TDD coverage for asynchronous resource and DOM timing.
+
+Repeated real-browser v2 evidence on 2026-08-11:
+
+- bridge status `ok`;
+- 90 normalized observations;
+- adapter version exactly `2`;
+- exactly one fulfillment context (`656`);
+- zero invalid observations under the acceptance predicate;
+- canonical source references without query/hash;
+- no credential/session export observed.
+
+Decision: **Perekrestok = `AVAILABLE_BROWSER_BRIDGE`** for page-snapshot acquisition.
+
+Live evidence: [`perekrestok-browser-bridge-live-2026-08-11.md`](perekrestok-browser-bridge-live-2026-08-11.md).
+
+Issue #54 tracks persistent-session refresh after the first successful snapshot; it does not invalidate the accepted reload-based page-snapshot path.
 
 ## Previously tested direct paths
 
 ### Pyaterochka
 
-The transparent JDK HTTP probe received `store-403` on the first coordinate-to-store request. That specific anonymous server-side path remains unsuitable.
+The transparent JDK HTTP probe received `store-403` on the first coordinate-to-store request.
 
-This result now means only:
+Current state: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`.
 
-`DIRECT_ANONYMOUS_HTTP_UNSUITABLE`
-
-It does **not** mean `PYATEROCHKA_UNSUPPORTED_PRODUCT_SCOPE`.
+Next technical priority is to reuse the proven Perekrestok browser-bridge transport contract for Pyaterochka, while supported/aggregator access work continues in parallel.
 
 ### Perekrestok
 
-The transparent first-party-cookie probe also received `store-403` on the nearby-store API before store selection/search.
-
-The third-party reference demonstrates that an ordinary browser session can obtain additional browser-context authorization, but Zakup Gotov will not export, forge or replay that authorization from a server-side scraper.
-
-The next technical fallback is the user-assisted browser bridge, not browser-identity evasion.
+The transparent first-party-cookie probe received `store-403` before store selection/search. That direct server-side path remains unsuitable, but it is no longer a product blocker because the browser bridge now provides an accepted acquisition path.
 
 ## Execution order
 
 1. Treat issue #47 as the umbrella mandatory-X5 requirement.
-2. Expand Kuper issue #36 with explicit Pyaterochka/Perekrestok coverage questions.
-3. Prepare an X5 digital-partnership request in parallel.
-4. Implement a read-only user-assisted browser-bridge proof of concept for one Perekrestok product page first, because its consumer surface already exposes stable product/price state once a browser session is established.
-5. Repeat the same browser-bridge contract for Pyaterochka.
-6. Keep direct anonymous 403 probes as regression/evidence only; do not turn them into stealth automation.
-7. M0 GO requires both banners to pass through at least one of Track A, B or C, plus one independent non-X5 provider path.
+2. Reuse the proven Perekrestok browser transport for Pyaterochka with the same privacy boundary, deterministic TDD and real-browser gate.
+3. Continue Kuper issue #36 and supported X5 partnership work in parallel.
+4. Keep direct anonymous 403 probes as regression/evidence only; do not turn them into stealth automation.
+5. Run Perekrestok fixed-corpus/second-context validation as hardening, not as a Phase A acceptance blocker.
+6. M0 GO still requires Pyaterochka plus at least one independent non-X5 retailer path and the remaining cross-mode criteria.
 
 ## M0 decision rule
 
 Zakup Gotov must not enter M1 on the assumption that X5 can be omitted.
 
-M0 GO requires:
+Current per-banner state:
 
-- Pyaterochka usable through Track A, B or C;
-- Perekrestok usable through Track A, B or C;
-- at least one independent non-X5 provider usable through an acceptable path;
-- deterministic fixture tests for all accepted paths;
-- operational limitations and provenance visible in the product model.
+- Perekrestok usable through Track C: **satisfied**;
+- Pyaterochka usable through Track A, B or C: **outstanding**.
+
+M0 additionally requires at least one independent non-X5 provider path, deterministic fixture tests for accepted paths, operational limitations/provenance visible in the product model, and the architecture-level multi-mode criteria defined in `ROADMAP.md` / `PROJECT_STATE.md`.


### PR DESCRIPTION
## Goal
Record the successful repeated real-browser Perekrestok adapter-v2 gate and advance the accepted retailer path from `BROWSER_BRIDGE_LIVE_PENDING` to `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition.

## Live evidence — 2026-08-11
- official `www.perekrestok.ru` category/catalog page;
- normal Yandex Browser first-party profile;
- `data-zg-bridge-status = ok`;
- `data-zg-bridge-count = 90`;
- adapter versions: exactly `2`;
- fulfillment contexts: exactly one (`656`);
- normalized validation failures: `0`;
- sample observations contained nonblank SKU, integer `priceMinor >= 0`, `RUB`, `UNKNOWN` availability, and canonical source references without query/hash;
- no cookie/token/auth/header/response-body/raw-HTML evidence recorded.

## Repository-truth updates
- add sanitized final live PASS evidence;
- mark the 2026-08-10 v1 failure evidence as historical/superseded;
- mark Perekrestok Phase A `AVAILABLE_BROWSER_BRIDGE` for page snapshots;
- update X5 mandatory coverage strategy;
- update `PROJECT_STATE.md` and `ROADMAP.md` M0 progress;
- index the new evidence;
- update `CHANGELOG.md`.

## Explicit limitation
Issue #54 remains non-blocking but required before treating the bridge as a continuously refreshing persistent-session transport. The accepted current path assumes the intended store is selected and the page is reloaded before the successful snapshot.

Merged to `main` as `162ebb361b6f4fdd0834633c1883741d24165720`. Issue #52 is complete. Umbrella #47 remains open because Pyaterochka and other M0 criteria are still outstanding.