### PR TITLE
feat(bridge): add Pyaterochka first-party browser bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Chromium Manifest V3 `apps/retailer-bridge` package with a Perekrestok structured-state adapter, normalized browser-observation trust boundary, sanitized local storage, deterministic fixtures, and dedicated `Retailer Bridge CI` including persistent-Chromium extension E2E.
 - Sanitized first-real-browser Perekrestok evidence record plus a current-live-shape fixture and persistent-Chromium regression covering semantic `.product-card` extraction with asynchronous first-party shop-context arrival.
 - Sanitized Perekrestok adapter-v2 real-browser PASS evidence proving 90 normalized observations, one fulfillment context, adapter version `2`, zero acceptance-validation failures, and canonical source references without query/hash.
+- Pyaterochka Browser Bridge Phase A with official `5ka.ru` MV3 routing, distinct `pyaterochka`/`pyaterochka-browser` provenance, semantic rendered-product parsing, exact `5d.5ka.ru/api/catalog/v2/stores/<store-id>/...` context evidence, retailer-neutral adapter registry wiring, sanitized fixtures, and persistent-Chromium async-context/delayed-DOM coverage.
+- `docs/integrations/pyaterochka-browser-bridge-phase-a.md` recording the complete RED→GREEN evidence sequence, privacy boundary, deterministic acceptance and real first-party browser gate required before retailer availability can be claimed.
 
 ### Changed
 
@@ -113,6 +115,9 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Retailer connectivity is now a universal registry invariant: a failed direct API changes the acquisition mode under investigation but does not remove the retailer from product scope.
 - Perekrestok browser connectivity advanced from `BROWSER_BRIDGE_LIVE_PENDING` to `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition after adapter v2 passed the repeated real first-party browser gate.
 - Perekrestok browser adapter provenance advanced to v2 so observations produced by the current DOM/resource acquisition logic remain distinguishable from the original structured-state-only implementation.
+- Browser bridge adapter selection is now registry-based rather than hard-coded to Perekrestok, allowing multiple retailer adapters to coexist while preserving distinct retailer/provider provenance.
+- Pyaterochka browser connectivity is `BROWSER_BRIDGE_LIVE_PENDING`: deterministic unit/type/build/persistent-Chromium evidence is GREEN, but a real first-party browser observation is still required before `AVAILABLE_BROWSER_BRIDGE` may be claimed.
+- Issue #50 is now the explicit maintenance gate before any third substantial browser adapter or bridge-owned dependency so the retailer bridge becomes a first-class pnpm workspace package without mixing that refactor into retailer behavior.
 
 ### Fixed
 
@@ -132,6 +137,7 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - Browser-bridge fail-closed navigation now replaces stale prior retailer observations with an empty payload, preventing an earlier store/page price snapshot from remaining current after the active page loses a valid fulfillment context.
 - Perekrestok catalog extraction no longer depends exclusively on obsolete embedded product/store JSON; adapter v2 can use the current semantic product-card DOM with explicit `UNKNOWN` availability.
 - Perekrestok browser collection no longer loses asynchronously arriving shop context because runtime resource observation triggers a serialized recollection instead of relying on a single `document_idle` snapshot.
+- Browser resource observation no longer rejects the official Pyaterochka catalog-service context solely because it is cross-origin; it now permits only the exact allow-listed `5ka.ru` → `5d.5ka.ru/api/catalog/v2/stores/...` path and still fails closed for unrelated cross-origin resources.
 
 ### Security
 
@@ -158,3 +164,4 @@ The format follows the spirit of Keep a Changelog and semantic versioning will b
 - The Pyaterochka live-probe workflow keeps `contents: read` and adds only `statuses: write` for sanitized evidence; it has no retailer credentials, a fixed owner/issue command gate, finite timeouts, no retry/evasion behavior, and publishes no retailer response bodies or exact store/product IDs.
 - Perekrestok browser bridge production permissions are limited to `storage`; browser credentials remain in the first-party profile, adapter output is projected through an allow-list, source URLs lose query/hash, deterministic E2E seeds sentinel cookie/localStorage secrets and verifies neither reaches extension storage, and normal CI makes no live Perekrestok request.
 - Perekrestok v2 runtime context evidence is restricted to same-origin canonical resource `origin + pathname` values; query/fragment data, request headers, response bodies, cookies, tokens and arbitrary storage values are not passed to the adapter or persisted.
+- Pyaterochka browser bridge preserves the same `storage`-only MV3 permission surface; cross-origin context is restricted to the exact official `https://5d.5ka.ru/api/catalog/v2/stores/<store-id>/...` pathname while other 5d paths, lookalike origins and cross-retailer use are rejected, query/hash are stripped, and persistent-Chromium sentinel tests prove resource-query and browser-cookie secrets do not reach extension storage.

--- a/apps/retailer-bridge/e2e/perekrestok-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/perekrestok-extension.spec.ts
@@ -147,3 +147,74 @@ test("collects current catalog DOM after async shop and DOM evidence resolve", a
     await rm(userDataDir, { recursive: true, force: true });
   }
 });
+
+test("collects Pyaterochka catalog after async official service context and delayed DOM", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-pyaterochka-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  try {
+    const liveFixture = await readFile(
+      resolve(fixtureDir, "pyaterochka-live-dom-async-state.html"),
+      "utf8",
+    );
+
+    await context.route("https://5ka.ru/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: liveFixture,
+      });
+    });
+    await context.route("https://5d.5ka.ru/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "access-control-allow-origin": "https://5ka.ru" },
+        contentType: "application/json; charset=utf-8",
+        body: "{}",
+      });
+    });
+
+    await context.addCookies([
+      {
+        name: "session",
+        value: "SECRET_PYATEROCHKA_COOKIE",
+        domain: "5ka.ru",
+        path: "/",
+        secure: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    const page = await context.newPage();
+    await page.goto("https://5ka.ru/catalog/fixture-live-dom");
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("1");
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const stored = await worker.evaluate(async () =>
+      chrome.storage.local.get("zg.latestObservations"),
+    );
+    const serialized = JSON.stringify(stored);
+
+    expect(serialized).toContain("\"retailerId\":\"pyaterochka\"");
+    expect(serialized).toContain("\"sourceProviderId\":\"pyaterochka-browser\"");
+    expect(serialized).toContain("\"fulfillmentContextId\":\"ZG001\"");
+    expect(serialized).toContain("\"sku\":\"25113239\"");
+    expect(serialized).toContain("\"priceMinor\":9999");
+    expect(serialized).toContain("\"adapterVersion\":\"1\"");
+    expect(serialized).not.toContain("SECRET_RESOURCE_QUERY");
+    expect(serialized).not.toContain("SECRET_PYATEROCHKA_COOKIE");
+    expect(serialized).not.toContain("session=");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/src/adapters/pyaterochka-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/pyaterochka-browser-adapter.ts
@@ -1,0 +1,176 @@
+import type { BrowserAvailability } from "../model/browser-observation";
+import type {
+  AdapterResult,
+  RetailerBrowserAdapter,
+} from "./retailer-browser-adapter";
+
+const RETAILER_ID = "pyaterochka";
+const SOURCE_PROVIDER_ID = "pyaterochka-browser";
+const ADAPTER_VERSION = "1";
+const CATALOG_SERVICE_ORIGIN = "https://5d.5ka.ru";
+const STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/([A-Za-z0-9_-]+)(?:\/|$)/;
+const PRODUCT_PATH = /^\/product\/[^/?#]*--(\d+)\/?$/;
+
+const OFFICIAL_PAGE_HOSTS = new Set(["5ka.ru", "www.5ka.ru"]);
+
+type ProductCandidate = Readonly<{
+  sku: string;
+  productName: string;
+  priceMinor: number;
+  availability: BrowserAvailability;
+}>;
+
+function nonBlankString(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isOfficialPageUrl(url: URL): boolean {
+  return url.protocol === "https:" && OFFICIAL_PAGE_HOSTS.has(url.hostname);
+}
+
+function productSkuFromHref(href: string, pageUrl: URL): string | null {
+  try {
+    const productUrl = new URL(href, pageUrl);
+    if (!isOfficialPageUrl(productUrl)) return null;
+    return productUrl.pathname.match(PRODUCT_PATH)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function rubPriceMinor(raw: string): number | null {
+  const normalized = raw.replace(/[\u00a0\u202f]/g, " ").trim();
+  const match = normalized.match(/^(\d[\d ]*)(?:[,.](\d{1,2}))?\s*₽$/);
+  if (!match?.[1]) return null;
+
+  const rubles = Number(match[1].replace(/\s/g, ""));
+  const kopecks = match[2] ? Number(match[2].padEnd(2, "0")) : 0;
+  if (!Number.isSafeInteger(rubles) || !Number.isSafeInteger(kopecks)) return null;
+
+  const priceMinor = rubles * 100 + kopecks;
+  return Number.isSafeInteger(priceMinor) && priceMinor >= 0 ? priceMinor : null;
+}
+
+function currentVisiblePriceMinor(container: Element): number | null {
+  const text = container.textContent?.replace(/[\u00a0\u202f]/g, " ") ?? "";
+  const matches = text.match(/\d[\d ]*(?:[,.]\d{1,2})?\s*₽/g) ?? [];
+  const prices = matches
+    .map(rubPriceMinor)
+    .filter((price): price is number => price !== null);
+  return prices.length > 0 ? prices[prices.length - 1] : null;
+}
+
+function productSkusIn(container: Element, pageUrl: URL): Set<string> {
+  const skus = new Set<string>();
+  container.querySelectorAll<HTMLAnchorElement>('a[href*="/product/"]').forEach((link) => {
+    const href = link.getAttribute("href");
+    if (!href) return;
+    const sku = productSkuFromHref(href, pageUrl);
+    if (sku) skus.add(sku);
+  });
+  return skus;
+}
+
+function productContainer(link: HTMLAnchorElement, sku: string, pageUrl: URL): Element | null {
+  let current: Element | null = link;
+  for (let depth = 0; current && depth < 7; depth += 1, current = current.parentElement) {
+    if (!current.textContent?.includes("₽")) continue;
+    const skus = productSkusIn(current, pageUrl);
+    if (skus.size === 1 && skus.has(sku)) return current;
+  }
+  return null;
+}
+
+function collectDomProducts(document: Document, pageUrl: URL): ProductCandidate[] {
+  const productsBySku = new Map<string, ProductCandidate>();
+
+  document.querySelectorAll<HTMLAnchorElement>('a[href*="/product/"]').forEach((link) => {
+    const href = link.getAttribute("href");
+    if (!href) return;
+
+    const sku = productSkuFromHref(href, pageUrl);
+    if (!sku || productsBySku.has(sku)) return;
+
+    const container = productContainer(link, sku, pageUrl);
+    if (!container) return;
+
+    const productName =
+      nonBlankString(link.getAttribute("aria-label")) ??
+      nonBlankString(link.textContent) ??
+      [...container.querySelectorAll<HTMLAnchorElement>('a[href*="/product/"]')]
+        .map((candidate) => nonBlankString(candidate.getAttribute("aria-label")) ?? nonBlankString(candidate.textContent))
+        .find((candidate): candidate is string => candidate !== null) ??
+      null;
+    const priceMinor = currentVisiblePriceMinor(container);
+    if (!productName || priceMinor === null) return;
+
+    productsBySku.set(sku, {
+      sku,
+      productName,
+      priceMinor,
+      availability: "UNKNOWN",
+    });
+  });
+
+  return [...productsBySku.values()];
+}
+
+function collectStoreContexts(resourceUrls: readonly string[]): Set<string> {
+  const contexts = new Set<string>();
+
+  resourceUrls.forEach((rawUrl) => {
+    try {
+      const resourceUrl = new URL(rawUrl);
+      if (resourceUrl.origin !== CATALOG_SERVICE_ORIGIN) return;
+      const context = resourceUrl.pathname.match(STORE_RESOURCE_PATH)?.[1];
+      if (context) contexts.add(context);
+    } catch {
+      // Ignore malformed resource names and fail closed when no unique context remains.
+    }
+  });
+
+  return contexts;
+}
+
+export const pyaterochkaBrowserAdapter: RetailerBrowserAdapter = {
+  adapterId: "pyaterochka-browser-v1",
+  retailerId: RETAILER_ID,
+
+  supports(url: URL): boolean {
+    return isOfficialPageUrl(url);
+  },
+
+  collect({ document, url, observedAt, resourceUrls = [] }): AdapterResult {
+    const contexts = collectStoreContexts(resourceUrls);
+    if (contexts.size !== 1) {
+      return { status: "missing-context", observations: [] };
+    }
+
+    const products = collectDomProducts(document, url);
+    if (products.length === 0) {
+      return { status: "missing-product", observations: [] };
+    }
+
+    const fulfillmentContextId = [...contexts][0];
+    return {
+      status: "ok",
+      observations: products.map((product) => ({
+        schemaVersion: 1,
+        retailerId: RETAILER_ID,
+        sourceProviderId: SOURCE_PROVIDER_ID,
+        sourceMode: "BROWSER_BRIDGE",
+        fulfillmentContextId,
+        sku: product.sku,
+        productName: product.productName,
+        priceMinor: product.priceMinor,
+        currencyCode: "RUB",
+        availability: product.availability,
+        observedAt,
+        sourceReference: url.toString(),
+        adapterVersion: ADAPTER_VERSION,
+      })),
+    };
+  },
+};

--- a/apps/retailer-bridge/src/adapters/retailer-browser-adapters.ts
+++ b/apps/retailer-bridge/src/adapters/retailer-browser-adapters.ts
@@ -1,0 +1,7 @@
+import { perekrestokBrowserAdapter } from "./perekrestok-browser-adapter";
+import { pyaterochkaBrowserAdapter } from "./pyaterochka-browser-adapter";
+
+export const retailerBrowserAdapters = [
+  perekrestokBrowserAdapter,
+  pyaterochkaBrowserAdapter,
+] as const;

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -4,12 +4,13 @@ import {
   createChromeObservationClearer,
   createChromeObservationSink,
 } from "./collector/chrome-observation-sink";
+import { canonicalObservedResourceUrl } from "./resource-observation-policy";
 
 const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
 const sink = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
-const firstPartyResourceUrls = new Set<string>();
+const observedResourceUrls = new Set<string>();
 
 let collectionInFlight = false;
 let collectionPending = false;
@@ -22,24 +23,19 @@ function publishDiagnostics(status: string, observationCount: number): void {
   document.documentElement.dataset.zgBridgeCount = String(observationCount);
 }
 
-function rememberFirstPartyResource(rawUrl: string): boolean {
-  try {
-    const resourceUrl = new URL(rawUrl, location.href);
-    if (resourceUrl.origin !== location.origin) return false;
+function rememberAllowedResource(rawUrl: string): boolean {
+  const canonical = canonicalObservedResourceUrl(rawUrl, new URL(location.href));
+  if (!canonical) return false;
 
-    const canonical = `${resourceUrl.origin}${resourceUrl.pathname}`;
-    const previousSize = firstPartyResourceUrls.size;
-    firstPartyResourceUrls.add(canonical);
-    return firstPartyResourceUrls.size !== previousSize;
-  } catch {
-    return false;
-  }
+  const previousSize = observedResourceUrls.size;
+  observedResourceUrls.add(canonical);
+  return observedResourceUrls.size !== previousSize;
 }
 
 function rememberResourceEntries(entries: readonly PerformanceEntry[]): boolean {
   let changed = false;
   entries.forEach((entry) => {
-    changed = rememberFirstPartyResource(entry.name) || changed;
+    changed = rememberAllowedResource(entry.name) || changed;
   });
   return changed;
 }
@@ -57,7 +53,7 @@ async function collectCurrentPage(): Promise<void> {
       document,
       new URL(location.href),
       new Date().toISOString(),
-      [...firstPartyResourceUrls],
+      [...observedResourceUrls],
     );
 
     if (result.status === "ok") {

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -1,4 +1,4 @@
-import { perekrestokBrowserAdapter } from "./adapters/perekrestok-browser-adapter";
+import { retailerBrowserAdapters } from "./adapters/retailer-browser-adapters";
 import { BrowserObservationCollector } from "./collector/browser-observation-collector";
 import {
   createChromeObservationClearer,
@@ -8,7 +8,7 @@ import {
 const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
 const sink = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
-const collector = new BrowserObservationCollector([perekrestokBrowserAdapter], sink);
+const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
 const firstPartyResourceUrls = new Set<string>();
 
 let collectionInFlight = false;

--- a/apps/retailer-bridge/src/resource-observation-policy.ts
+++ b/apps/retailer-bridge/src/resource-observation-policy.ts
@@ -1,0 +1,29 @@
+const PYATEROCHKA_PAGE_HOSTS = new Set(["5ka.ru", "www.5ka.ru"]);
+const PYATEROCHKA_SERVICE_ORIGIN = "https://5d.5ka.ru";
+const PYATEROCHKA_STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/[A-Za-z0-9_-]+(?:\/|$)/;
+
+function isOfficialPyaterochkaPage(pageUrl: URL): boolean {
+  return pageUrl.protocol === "https:" && PYATEROCHKA_PAGE_HOSTS.has(pageUrl.hostname);
+}
+
+export function canonicalObservedResourceUrl(rawUrl: string, pageUrl: URL): string | null {
+  try {
+    const resourceUrl = new URL(rawUrl, pageUrl);
+
+    if (resourceUrl.origin === pageUrl.origin) {
+      return `${resourceUrl.origin}${resourceUrl.pathname}`;
+    }
+
+    if (
+      isOfficialPyaterochkaPage(pageUrl) &&
+      resourceUrl.origin === PYATEROCHKA_SERVICE_ORIGIN &&
+      PYATEROCHKA_STORE_RESOURCE_PATH.test(resourceUrl.pathname)
+    ) {
+      return `${resourceUrl.origin}${resourceUrl.pathname}`;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/retailer-bridge/static/manifest.e2e.json
+++ b/apps/retailer-bridge/static/manifest.e2e.json
@@ -11,6 +11,8 @@
     {
       "matches": [
         "https://www.perekrestok.ru/*",
+        "https://5ka.ru/*",
+        "https://www.5ka.ru/*",
         "http://127.0.0.1:4174/*"
       ],
       "js": ["content.js"],

--- a/apps/retailer-bridge/static/manifest.json
+++ b/apps/retailer-bridge/static/manifest.json
@@ -9,7 +9,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.perekrestok.ru/*"],
+      "matches": [
+        "https://www.perekrestok.ru/*",
+        "https://5ka.ru/*",
+        "https://www.5ka.ru/*"
+      ],
       "js": ["content.js"],
       "run_at": "document_idle",
       "world": "ISOLATED"

--- a/apps/retailer-bridge/test/fixtures/pyaterochka-catalog-state.html
+++ b/apps/retailer-bridge/test/fixtures/pyaterochka-catalog-state.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sanitized Pyaterochka catalog fixture</title>
+  </head>
+  <body>
+    <main>
+      <article data-testid="sanitized-product-card">
+        <a href="/product/sanitized-soft-cheese--3165030/" aria-label="Санитизированный сыр 140г">
+          <span aria-hidden="true">image</span>
+        </a>
+        <a href="/product/sanitized-soft-cheese--3165030/">Санитизированный сыр 140г</a>
+        <div data-testid="price">
+          <span>129,99 ₽</span>
+          <span>105,99 ₽</span>
+        </div>
+        <button type="button">В корзину</button>
+      </article>
+
+      <article data-testid="sanitized-product-card">
+        <a href="/product/sanitized-pasta--6788/">Санитизированные макароны 450г</a>
+        <div data-testid="price"><span>59,99 ₽</span></div>
+        <button type="button">В корзину</button>
+      </article>
+    </main>
+  </body>
+</html>

--- a/apps/retailer-bridge/test/fixtures/pyaterochka-live-dom-async-state.html
+++ b/apps/retailer-bridge/test/fixtures/pyaterochka-live-dom-async-state.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sanitized Pyaterochka async catalog fixture</title>
+  </head>
+  <body>
+    <main id="catalog-root"></main>
+    <script>
+      setTimeout(() => {
+        fetch("https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products?session=SECRET_RESOURCE_QUERY").catch(() => {});
+      }, 10);
+
+      setTimeout(() => {
+        document.getElementById("catalog-root").insertAdjacentHTML(
+          "beforeend",
+          '<article class="product-card"><a href="/product/sanitized-product--25113239/" aria-label="Санитизированный продукт">Санитизированный продукт</a><div class="product-card__price">129,99 ₽ 99,99 ₽</div></article>',
+        );
+      }, 30);
+    </script>
+  </body>
+</html>

--- a/apps/retailer-bridge/test/manifest-security.test.ts
+++ b/apps/retailer-bridge/test/manifest-security.test.ts
@@ -12,7 +12,11 @@ describe("retailer bridge manifest", () => {
     expect(manifest.host_permissions ?? []).toEqual([]);
     expect(manifest.content_scripts).toEqual([
       expect.objectContaining({
-        matches: ["https://www.perekrestok.ru/*"],
+        matches: [
+          "https://www.perekrestok.ru/*",
+          "https://5ka.ru/*",
+          "https://www.5ka.ru/*",
+        ],
         js: ["content.js"],
         run_at: "document_idle",
         world: "ISOLATED",

--- a/apps/retailer-bridge/test/pyaterochka-browser-adapter.test.ts
+++ b/apps/retailer-bridge/test/pyaterochka-browser-adapter.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { pyaterochkaBrowserAdapter } from "../src/adapters/pyaterochka-browser-adapter";
+
+const OBSERVED_AT = "2026-08-11T08:15:00Z";
+const PAGE_URL = new URL("https://5ka.ru/catalog/sanitized--251C13239/?session=secret#fragment");
+
+function fixture(name: string): Document {
+  const path = resolve(process.cwd(), "../retailer-bridge/test/fixtures", name);
+  return new DOMParser().parseFromString(readFileSync(path, "utf8"), "text/html");
+}
+
+describe("pyaterochkaBrowserAdapter", () => {
+  it("extracts store-scoped visible products from official catalog DOM and service resource path", () => {
+    const result = pyaterochkaBrowserAdapter.collect({
+      document: fixture("pyaterochka-catalog-state.html"),
+      url: PAGE_URL,
+      observedAt: OBSERVED_AT,
+      resourceUrls: [
+        "https://analytics.example.test/api/catalog/v2/stores/EVIL/products",
+        "https://5d.5ka.ru/api/catalog/v2/stores/3CRL/categories/251C13239/products?mode=delivery&cookie=SECRET#fragment",
+      ],
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    expect(result.observations).toEqual([
+      expect.objectContaining({
+        schemaVersion: 1,
+        retailerId: "pyaterochka",
+        sourceProviderId: "pyaterochka-browser",
+        sourceMode: "BROWSER_BRIDGE",
+        fulfillmentContextId: "3CRL",
+        sku: "3165030",
+        productName: "Санитизированный сыр 140г",
+        priceMinor: 10599,
+        currencyCode: "RUB",
+        availability: "UNKNOWN",
+        observedAt: OBSERVED_AT,
+        adapterVersion: "1",
+      }),
+      expect.objectContaining({
+        fulfillmentContextId: "3CRL",
+        sku: "6788",
+        productName: "Санитизированные макароны 450г",
+        priceMinor: 5999,
+        availability: "UNKNOWN",
+        adapterVersion: "1",
+      }),
+    ]);
+  });
+
+  it("requires one unique official store context", () => {
+    expect(
+      pyaterochkaBrowserAdapter.collect({
+        document: fixture("pyaterochka-catalog-state.html"),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: [
+          "https://5d.5ka.ru/api/catalog/v2/stores/3CRL/products",
+          "https://5d.5ka.ru/api/catalog/v2/stores/4ABC/products",
+        ],
+      }),
+    ).toEqual({ status: "missing-context", observations: [] });
+  });
+
+  it("does not accept a lookalike service origin as fulfillment context", () => {
+    expect(
+      pyaterochkaBrowserAdapter.collect({
+        document: fixture("pyaterochka-catalog-state.html"),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: [
+          "https://5d.5ka.ru.evil.example/api/catalog/v2/stores/3CRL/products",
+        ],
+      }),
+    ).toEqual({ status: "missing-context", observations: [] });
+  });
+
+  it("supports only official Pyaterochka HTTPS page origins", () => {
+    expect(pyaterochkaBrowserAdapter.supports(new URL("https://5ka.ru/catalog/fixture"))).toBe(true);
+    expect(pyaterochkaBrowserAdapter.supports(new URL("https://www.5ka.ru/product/fixture--1/"))).toBe(true);
+    expect(pyaterochkaBrowserAdapter.supports(new URL("http://5ka.ru/catalog/fixture"))).toBe(false);
+    expect(pyaterochkaBrowserAdapter.supports(new URL("https://5ka.ru.evil.example/catalog/fixture"))).toBe(false);
+  });
+});

--- a/apps/retailer-bridge/test/resource-observation-policy.test.ts
+++ b/apps/retailer-bridge/test/resource-observation-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { canonicalObservedResourceUrl } from "../src/resource-observation-policy";
+
+describe("canonicalObservedResourceUrl", () => {
+  it("keeps same-origin pathname evidence and strips query/hash", () => {
+    expect(
+      canonicalObservedResourceUrl(
+        "https://www.perekrestok.ru/api/customer/1.4.1.0/shop/656?session=SECRET#fragment",
+        new URL("https://www.perekrestok.ru/cat/1"),
+      ),
+    ).toBe("https://www.perekrestok.ru/api/customer/1.4.1.0/shop/656");
+  });
+
+  it("allows only the Pyaterochka catalog service store path for official 5ka pages", () => {
+    const page = new URL("https://5ka.ru/catalog/fixture");
+
+    expect(
+      canonicalObservedResourceUrl(
+        "https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products?session=SECRET#fragment",
+        page,
+      ),
+    ).toBe("https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products");
+
+    expect(
+      canonicalObservedResourceUrl("https://5d.5ka.ru/api/profile/v1/me", page),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://5d.5ka.ru.evil.example/api/catalog/v2/stores/ZG001/products",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products",
+        new URL("https://www.perekrestok.ru/cat/1"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/retailer-bridge/test/retailer-browser-adapters.test.ts
+++ b/apps/retailer-bridge/test/retailer-browser-adapters.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { retailerBrowserAdapters } from "../src/adapters/retailer-browser-adapters";
+
+describe("retailerBrowserAdapters", () => {
+  it("registers each supported retailer exactly once", () => {
+    expect(retailerBrowserAdapters.map((adapter) => adapter.retailerId)).toEqual([
+      "perekrestok",
+      "pyaterochka",
+    ]);
+
+    expect(new Set(retailerBrowserAdapters.map((adapter) => adapter.retailerId)).size).toBe(
+      retailerBrowserAdapters.length,
+    );
+    expect(new Set(retailerBrowserAdapters.map((adapter) => adapter.adapterId)).size).toBe(
+      retailerBrowserAdapters.length,
+    );
+  });
+});

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0A closure + M0B Universal Retailer Connectivity**  
-Current focus: **reuse the now-proven Perekrestok browser transport for Pyaterochka, prove an independent non-X5 retailer path, harden persistent-session behavior, and keep the outstanding `v0.1.0-rc.3` release proof explicit**
+Current focus: **finish Pyaterochka Browser Bridge Phase A through the real first-party browser gate, then resolve bridge workspace debt before any third substantial browser adapter, prove an independent non-X5 path, and keep the outstanding `v0.1.0-rc.3` release proof explicit**
 
 ## Product connectivity invariant
 
@@ -31,7 +31,11 @@ The initial priority registry includes Pyaterochka, Perekrestok, Chizhik, Magnit
 
 The platform foundation is executable and automatically verified. The core multi-retailer basket-comparison user flow is **not implemented yet**. The web surface intentionally does not fake retailer prices or availability.
 
-**Perekrestok now has one accepted acquisition path: `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition.** Other target retailers remain in discovery/unimplemented states until their own evidence gates pass.
+**Perekrestok has one accepted acquisition path: `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition.**
+
+**Pyaterochka Browser Bridge Phase A is deterministic-ready but remains `BROWSER_BRIDGE_LIVE_PENDING`.** PR #58 introduces the second browser adapter with distinct provenance, deterministic fixtures, exact official service-resource allow-listing, and persistent-Chromium async-context/DOM evidence. A real first-party browser PASS is still required before availability can be claimed.
+
+Other target retailers remain in discovery/unimplemented states until their own evidence gates pass.
 
 ## M0B verified foundation
 
@@ -41,7 +45,7 @@ PR #37 was squash-merged to `main` as `e318c8ee92ab5f62dd593f4fd214735eb8c59750`
 
 ## Retailer evidence
 
-### Pyaterochka / 5ka
+### Pyaterochka / 5ka direct path
 
 Final direct live evidence on `main` SHA `73d9f18d714bd1eafc165e7f5941405a0ce10b5b`:
 
@@ -51,8 +55,42 @@ Interpretation:
 
 - direct anonymous server-side path: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`;
 - Pyaterochka product coverage: still mandatory;
-- next preferred technical fallback: reuse the proven user-assisted browser bridge contract from Perekrestok;
+- selected technical fallback: user-assisted first-party browser bridge;
 - supported X5/partner access and aggregator-backed coverage remain valid parallel tracks.
+
+### Pyaterochka Browser Bridge Phase A — deterministic ready, live pending
+
+Issue #57 / PR #58 reuse the retailer-neutral browser transport already proven for Perekrestok without sharing retailer provenance.
+
+Deterministic implementation:
+
+- production MV3 routing includes `https://5ka.ru/*` and `https://www.5ka.ru/*` while keeping `storage` as the only extension permission;
+- `pyaterochkaBrowserAdapter` uses `retailerId=pyaterochka`, `sourceProviderId=pyaterochka-browser`, `adapterVersion=1`;
+- product identity is derived only from official `/product/<slug>--<numeric-id>/` links;
+- product-local visible RUB price is normalized to integer `priceMinor`;
+- catalog DOM emits `availability=UNKNOWN` unless a supported stock semantic is actually present;
+- fulfillment context is accepted only from canonical `https://5d.5ka.ru/api/catalog/v2/stores/<store-id>/...` resource pathname metadata;
+- runtime rejects other 5d paths, lookalike origins and cross-retailer use;
+- query strings/fragments are removed before resource evidence reaches adapters;
+- a retailer-neutral adapter registry now contains Perekrestok and Pyaterochka;
+- shared `PerformanceObserver` + `MutationObserver` behavior handles late store context and late product DOM;
+- fail-closed stale clearing remains in place;
+- no cookies, tokens, request headers, response bodies, arbitrary storage values or raw production HTML are captured.
+
+TDD proof is recorded in [`integrations/pyaterochka-browser-bridge-phase-a.md`](integrations/pyaterochka-browser-bridge-phase-a.md).
+
+Key executable GREEN head before final docs synchronization: `73b73f1049c9e3b5f6c5000644ead07e1b0754b4`:
+
+- 23 unit tests PASS;
+- TypeScript PASS;
+- production bridge build PASS;
+- all 3 persistent-Chromium E2E scenarios PASS;
+- Pyaterochka async cross-origin store-context + delayed-DOM scenario PASS;
+- resource-query and browser-cookie sentinels do not reach extension storage.
+
+The implementation was built through explicit RED→GREEN gates for manifest routing, adapter creation, retailer-neutral registry wiring, async cross-origin context, and the resource observation security policy.
+
+Current decision: **`BROWSER_BRIDGE_LIVE_PENDING`**. Deterministic success is not a retailer support claim. After PR #58 is merged, the rebuilt extension must pass the documented real first-party browser gate before Pyaterochka may advance to `AVAILABLE_BROWSER_BRIDGE`.
 
 ### Perekrestok direct path
 
@@ -126,6 +164,20 @@ PR #46 remains an independent non-X5 path candidate using public SSR product pag
 
 Issue #36 remains active for supported aggregator-backed access. Any Kuper observation must preserve aggregator provider provenance separately from the underlying retailer/banner identity.
 
+## Bridge maintenance threshold
+
+Issue #50 was intentionally created when Perekrestok Phase A reused TypeScript/Vitest/Playwright tooling from `apps/web` rather than making `apps/retailer-bridge` a first-class pnpm workspace importer.
+
+PR #58 introduces the second substantial browser adapter, so that maintenance threshold is now reached. To keep the maintenance refactor behavior-neutral as issue #50 requires, it remains separate from PR #58 but becomes a **hard precondition before any third substantial browser adapter or bridge-owned dependency**.
+
+Issue #50 must:
+
+- add `apps/retailer-bridge` to the root pnpm workspace;
+- give the bridge explicit pinned devDependencies;
+- regenerate the lockfile normally;
+- remove `../web` tooling/node_modules coupling;
+- preserve frozen-install/supply-chain checks and all bridge security/E2E gates.
+
 ## Verified platform baseline
 
 ### Backend
@@ -173,21 +225,23 @@ A successful real **`v0.1.0-rc.3` GitHub Release published event remains outstan
 
 ## Immediate next work
 
-1. Reuse the proven browser-bridge transport contract for Pyaterochka and drive it through the same deterministic + real-browser acceptance process.
-2. Run Perekrestok fixed-corpus/second-context validation as hardening and product-quality evidence; it is no longer the Phase A connectivity blocker.
-3. Resolve at least one independent non-X5 retailer path, with Magnit currently the nearest existing candidate.
-4. Complete issue #50 before the bridge gains its own external dependencies or multiple substantial retailer adapters: make `apps/retailer-bridge` a first-class pnpm workspace importer and remove the temporary tooling coupling to `apps/web`.
-5. Resolve issue #54 before treating the bridge as a persistent-session transport across post-success store changes / SPA navigation.
-6. Continue Kuper/X5 supported-access work in parallel.
-7. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional chains through the same registry/adapter process.
-8. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
+1. Finish PR #58 through exact-final-head repository CI/security verification and read-only review, then merge the deterministic Pyaterochka Browser Bridge implementation.
+2. Run the real first-party Pyaterochka browser gate from merged `main`; on PASS, commit sanitized live evidence and advance Pyaterochka to `AVAILABLE_BROWSER_BRIDGE`. On mismatch, add the minimum sanitized fixture and a failing regression test before any adapter change.
+3. Resolve issue #50 in a separate behavior-neutral maintenance PR before a third substantial browser adapter or bridge-owned dependency.
+4. Resolve at least one independent non-X5 retailer path, with Magnit currently the nearest existing candidate.
+5. Prove a second accepted acquisition mode so M0 does not depend only on browser-assisted acquisition.
+6. Run Perekrestok fixed-corpus/second-context validation as hardening and product-quality evidence; it is no longer the Phase A connectivity blocker.
+7. Resolve issue #54 before treating the bridge as a persistent-session transport across post-success store changes / SPA navigation.
+8. Continue Kuper/X5 supported-access work in parallel.
+9. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional chains through the same registry/adapter process after the issue #50 maintenance gate.
+10. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
 
 ## Definition of M0 success
 
 M0 is complete only when:
 
-- Pyaterochka has at least one reproducible accepted path;
-- Perekrestok has at least one reproducible accepted path — **now satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
+- Pyaterochka has at least one reproducible accepted path — **deterministic browser implementation exists; real-browser acceptance remains outstanding**;
+- Perekrestok has at least one reproducible accepted path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - at least one independent non-X5 retailer has a reproducible accepted path;
 - at least two acquisition modes are proven end to end;
 - deterministic sanitized fixtures/tests preserve retailer/provider/store provenance;

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory is the durable documentation entry point for Zakup Gotov. Documen
 | Universal retailer connectivity design | [`superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`](superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md) |
 | Retailer integration feasibility evidence | [`integrations/retailer-feasibility.md`](integrations/retailer-feasibility.md) |
 | Mandatory Pyaterochka/Perekrestok strategy | [`integrations/x5-mandatory-coverage.md`](integrations/x5-mandatory-coverage.md) |
+| Pyaterochka browser-bridge Phase A decision | [`integrations/pyaterochka-browser-bridge-phase-a.md`](integrations/pyaterochka-browser-bridge-phase-a.md) |
 | Perekrestok browser-bridge Phase A decision | [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md) |
 | Perekrestok v1 live failure/root-cause evidence | [`integrations/perekrestok-browser-bridge-live-2026-08-10.md`](integrations/perekrestok-browser-bridge-live-2026-08-10.md) |
 | Perekrestok v2 real-browser PASS evidence | [`integrations/perekrestok-browser-bridge-live-2026-08-11.md`](integrations/perekrestok-browser-bridge-live-2026-08-11.md) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@ Goal: prove that the core product promise and the universal retailer-connectivit
 Current evidence status:
 
 - **Perekrestok retailer-path criterion: satisfied** through `AVAILABLE_BROWSER_BRIDGE` page-snapshot acquisition after the real adapter-v2 browser PASS on 2026-08-11;
-- **Pyaterochka retailer-path criterion: outstanding**; direct anonymous HTTP is unsuitable and the proven browser-bridge contract is the next technical path;
+- **Pyaterochka retailer-path criterion: live acceptance outstanding**; direct anonymous HTTP is unsuitable, while Browser Bridge Phase A is now deterministic-ready with adapter v1, distinct provenance, exact official service-resource allow-listing, and persistent-Chromium async-context/DOM proof. It remains `BROWSER_BRIDGE_LIVE_PENDING` until the real first-party browser gate passes;
 - **independent non-X5 retailer criterion: outstanding**;
 - **second distinct acquisition-mode criterion: outstanding** until another accepted path proves a non-browser mode end to end.
 
@@ -43,7 +43,7 @@ Accepted provider paths may be direct retailer APIs, supported aggregator integr
 
 Exit criteria:
 
-- **Pyaterochka** can return usable location/store-specific product/offer data through at least one acceptable path;
+- **Pyaterochka** can return usable location/store-specific product/offer data through at least one acceptable path — deterministic browser implementation exists, **real browser acceptance still required**;
 - **Perekrestok** can return usable location/store-specific product/offer data through at least one acceptable path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - at least one independent non-X5 retailer can return usable location-specific product/offer data through an acceptable path;
 - at least two acquisition modes have been proven end to end so M0 does not depend on a single transport assumption;
@@ -53,6 +53,15 @@ Exit criteria:
 - known limitations are documented rather than hidden.
 
 Detailed X5 strategy: [`integrations/x5-mandatory-coverage.md`](integrations/x5-mandatory-coverage.md).
+
+Immediate M0 sequencing after the current Pyaterochka Phase A implementation:
+
+1. complete the exact-head CI/security/review gate and merge the deterministic Pyaterochka bridge;
+2. run the real first-party Pyaterochka browser gate and record sanitized PASS/FAIL evidence;
+3. resolve issue #50 in a separate no-behavior-change maintenance PR before a third substantial browser adapter;
+4. prove at least one independent non-X5 retailer path, with the existing Magnit path currently the nearest candidate;
+5. prove a second accepted acquisition mode so M0 is not browser-transport-only;
+6. keep Perekrestok corpus/second-context and persistent-session work as hardening rather than reopening its Phase A acceptance.
 
 ## M1 — Shopping Core
 

--- a/docs/integrations/pyaterochka-browser-bridge-phase-a.md
+++ b/docs/integrations/pyaterochka-browser-bridge-phase-a.md
@@ -1,0 +1,242 @@
+# Pyaterochka Browser Bridge — Phase A
+
+Status: `DETERMINISTIC_READY_LIVE_PENDING`
+Tracking: issue #57 / umbrella #47 / PR #58
+
+## Goal
+
+Provide one reproducible Pyaterochka acquisition path through the existing user-assisted first-party browser bridge after the direct anonymous server-side 5ka path failed closed with `store-403`.
+
+This Phase A proves deterministic parsing, provenance, privacy boundaries, async browser timing, and extension wiring. It does **not** advance Pyaterochka to `AVAILABLE_BROWSER_BRIDGE` until a real first-party browser gate passes.
+
+## Browser contract
+
+The user remains in control of the official retailer session:
+
+1. open the official `https://5ka.ru` or `https://www.5ka.ru` surface in the normal browser profile;
+2. manually select location/store and manually complete login/CAPTCHA when required;
+3. let the bridge observe only rendered page evidence and allow-listed resource URL metadata already visible to that browser context;
+4. normalize observations locally;
+5. persist only the sanitized `BrowserObservation` projection in extension-local storage.
+
+The bridge does not automate CAPTCHA, spoof browser/device identity, rotate proxies, replay credentials, export cookies/tokens/auth headers, or persist response bodies/raw production HTML.
+
+## Deterministic implementation
+
+### Manifest routing
+
+The production MV3 content script now runs on:
+
+- `https://5ka.ru/*`;
+- `https://www.5ka.ru/*`;
+- the previously supported Perekrestok origin.
+
+The production permission surface remains exactly:
+
+- `storage`.
+
+No `host_permissions`, `cookies`, `webRequest`, `debugger`, proxy control, or `declarativeNetRequest` permission was added.
+
+### Pyaterochka adapter v1
+
+`pyaterochkaBrowserAdapter` has distinct provenance:
+
+- `retailerId = pyaterochka`;
+- `sourceProviderId = pyaterochka-browser`;
+- `sourceMode = BROWSER_BRIDGE`;
+- `adapterVersion = 1`.
+
+The adapter:
+
+- supports only HTTPS `5ka.ru` / `www.5ka.ru` pages;
+- derives SKU only from official product links shaped as `/product/<slug>--<numeric-id>/`;
+- derives product name from semantic link text/`aria-label` evidence;
+- derives current visible RUB price from the product-local DOM container and emits integer `priceMinor`;
+- emits `availability = UNKNOWN` unless a future supported rendered semantic proves stock state;
+- requires exactly one fulfillment context before emitting observations.
+
+### Store / fulfillment context
+
+The store context is accepted only from canonical resource URL metadata on the exact official service origin:
+
+`https://5d.5ka.ru`
+
+and only when the pathname matches:
+
+`/api/catalog/v2/stores/<store-id>/...`
+
+The runtime resource policy:
+
+- still accepts same-origin pathname evidence used by Perekrestok;
+- additionally accepts only the Pyaterochka catalog-store path above when the active page is an official 5ka page;
+- rejects other `5d.5ka.ru` paths;
+- rejects lookalike origins;
+- rejects the Pyaterochka service origin while browsing another retailer;
+- strips query strings and fragments before the resource evidence reaches an adapter.
+
+No request headers or response bodies are inspected.
+
+### Async browser timing
+
+The shared bridge runtime continues to use:
+
+- `PerformanceObserver` for late resource evidence;
+- `MutationObserver` for late rendered product DOM;
+- serialized recollection when evidence arrives concurrently;
+- fail-closed clearing of stale observations until one valid snapshot reaches `ok`.
+
+The runtime still disconnects observers after the first successful page snapshot. Issue #54 separately tracks persistent-session refresh after success.
+
+## TDD evidence
+
+### RED 1 — official-page manifest routing
+
+Head `b4fbbdc12ed157c9c2e89e1ab065bbe5db8b9393` changed only the manifest-security test.
+
+Result:
+
+- 15 pre-existing tests PASS;
+- 1 new test FAIL;
+- expected 5ka production matches were absent.
+
+GREEN: `779730cc3da92a4335c02d51bbf6072aa57c8030` added only the minimum production manifest matches. Unit/type/build and existing Chromium E2E returned GREEN.
+
+### RED 2 — dedicated retailer adapter
+
+Head `122b39cf794f35a1d0ba3a4aac23928d613a2d53` contained sanitized Pyaterochka fixture/test evidence before the production adapter existed.
+
+Result:
+
+- all 16 pre-existing tests PASS;
+- the new suite failed only because `pyaterochka-browser-adapter` did not exist.
+
+GREEN: `1d57c3907356a53bd4d4a7519548f2523a658bda` added the minimum adapter. Pyaterochka adapter tests, existing Perekrestok tests, typecheck, build and Chromium E2E passed.
+
+### RED 3 — retailer-neutral adapter registry
+
+Head `43ba78ac0d2549125b81e6adffc3908b0d60a2f7` required a single registry containing both Perekrestok and Pyaterochka with unique adapter and retailer identities.
+
+Result:
+
+- 20 behavior tests PASS;
+- the new registry suite failed only because the registry module did not exist.
+
+GREEN: `e26b726d6928cf93d1c7abbc0cb83bd12a4d9cbb` added the registry and switched `content.ts` from a hard-coded Perekrestok adapter to the registry. The complete repository workflow set on that head was GREEN.
+
+### RED 4 — async cross-origin store context
+
+Head `447cf19e3806175165d9ca493bb90d747326c5f1` added a persistent-Chromium scenario with:
+
+- an official `5ka.ru` page;
+- delayed product DOM;
+- delayed `https://5d.5ka.ru/api/catalog/v2/stores/ZG001/...` resource evidence;
+- a query sentinel `SECRET_RESOURCE_QUERY`;
+- a browser cookie sentinel `SECRET_PYATEROCHKA_COOKIE`.
+
+Result:
+
+- 21 unit tests PASS;
+- typecheck PASS;
+- build PASS;
+- both pre-existing Perekrestok Chromium E2E scenarios PASS;
+- new Pyaterochka Chromium E2E FAIL;
+- expected `ok`, received `missing-context`.
+
+This proved the remaining gap was runtime resource filtering rather than adapter parsing or extension routing.
+
+### RED 4b — cross-origin resource security policy
+
+Head `37923e2d318cf1eadc41e023fd05e25c8ddc5065` added a focused security contract before production policy code existed.
+
+Result:
+
+- 21 existing tests PASS;
+- the new suite failed only because `resource-observation-policy` did not exist.
+
+The contract requires:
+
+- same-origin path canonicalization;
+- exact Pyaterochka service-origin/path allow-listing;
+- query/hash stripping;
+- lookalike-origin rejection;
+- cross-retailer rejection.
+
+### GREEN 4 — allow-listed runtime resource evidence
+
+Executable head `73b73f1049c9e3b5f6c5000644ead07e1b0754b4` introduced the minimal resource policy and routed observed resources through it.
+
+Verified on Retailer Bridge CI:
+
+- 23 unit tests PASS;
+- TypeScript PASS;
+- production build PASS;
+- all 3 persistent-Chromium E2E scenarios PASS;
+- Pyaterochka E2E stores the expected retailer/provider/context/SKU/price/version projection;
+- neither the resource-query sentinel nor browser-cookie sentinel reaches extension storage.
+
+Ordinary CI performs no live retailer request; all browser network interactions are intercepted deterministic fixtures.
+
+## Security / privacy decision
+
+Phase A preserves the existing browser-bridge trust boundary:
+
+- user session remains in the first-party browser profile;
+- no credential/session export or replay;
+- no CAPTCHA bypass or anti-bot evasion;
+- no proxy/IP rotation intended to defeat access controls;
+- no broad cross-origin resource capture;
+- no response-body interception;
+- no arbitrary browser-storage reads;
+- only canonical allow-listed resource `origin + pathname` metadata is passed to adapters;
+- collector allow-list projection remains authoritative before storage;
+- stale observations are cleared on failed collection;
+- normal CI is live-retailer-free.
+
+## Real-browser gate
+
+After PR #58 is merged, build the current extension from `main`:
+
+```bash
+git checkout main
+git pull
+pnpm install --frozen-lockfile
+pnpm --dir apps/retailer-bridge build
+```
+
+Then in a Chromium-compatible normal user browser profile:
+
+1. load/reload unpacked `apps/retailer-bridge/dist`;
+2. open the official Pyaterochka web catalog;
+3. manually select the intended location/store and complete any first-party login/CAPTCHA manually if required;
+4. fully reload the catalog page;
+5. inspect only:
+   - `document.documentElement.dataset.zgBridgeStatus`;
+   - `document.documentElement.dataset.zgBridgeCount`.
+
+Expected first gate:
+
+- status `ok`;
+- count greater than `0`.
+
+If the first gate passes, inspect only the normalized extension-local observations and validate:
+
+- `retailerId = pyaterochka`;
+- `sourceProviderId = pyaterochka-browser`;
+- `adapterVersion = 1`;
+- exactly one nonblank fulfillment context for the page snapshot;
+- nonblank SKU;
+- integer `priceMinor >= 0`;
+- `currencyCode = RUB`;
+- availability in `AVAILABLE`, `UNAVAILABLE`, `UNKNOWN`;
+- canonical `sourceReference` without query/hash;
+- zero invalid observations under that predicate.
+
+Do not export cookies, tokens, request headers, storage values, exact address, response bodies, or raw HTML for evidence.
+
+## Decision rule
+
+Current Phase A decision: **`BROWSER_BRIDGE_LIVE_PENDING`**.
+
+Advance Pyaterochka to `AVAILABLE_BROWSER_BRIDGE` only after the real first-party browser gate above passes and sanitized evidence is committed.
+
+If the live shape differs, record only the minimum sanitized structural evidence required, add a failing regression fixture/test first, then change the adapter through another RED → GREEN cycle.

--- a/docs/integrations/x5-mandatory-coverage.md
+++ b/docs/integrations/x5-mandatory-coverage.md
@@ -15,9 +15,9 @@ The goal is not necessarily a direct retailer API. The goal is reliable banner- 
 ## Current X5 state
 
 - **Perekrestok:** `AVAILABLE_BROWSER_BRIDGE` for page-snapshot acquisition. Adapter v2 passed the repeated real first-party browser gate on 2026-08-11 with `status=ok`, 90 normalized observations, one fulfillment context, adapter version `2`, and zero validation failures.
-- **Pyaterochka:** direct anonymous JDK path remains `DIRECT_ANONYMOUS_HTTP_UNSUITABLE` after `store-403`; accepted coverage is still outstanding.
+- **Pyaterochka:** direct anonymous JDK path remains `DIRECT_ANONYMOUS_HTTP_UNSUITABLE` after `store-403`; Browser Bridge Phase A is now deterministic-ready with adapter v1, retailer-neutral registry wiring, exact `5d.5ka.ru` store-resource allow-listing, and persistent-Chromium async-context/DOM coverage. Real first-party browser evidence is still required before acceptance.
 
-Perekrestok therefore satisfies its M0 per-retailer connectivity requirement. Pyaterochka is now the remaining mandatory X5 connectivity blocker.
+Perekrestok therefore satisfies its M0 per-retailer connectivity requirement. Pyaterochka remains the mandatory X5 connectivity blocker until the real browser gate advances it from `BROWSER_BRIDGE_LIVE_PENDING` to an accepted state.
 
 ## Required observation contract
 
@@ -50,13 +50,13 @@ Issue #36 continues to investigate supported Kuper Client apps API coverage.
 
 ## Track C — user-assisted first-party browser bridge
 
-This path is now **proven for Perekrestok page snapshots**.
+This path is **proven for Perekrestok page snapshots** and **deterministic-ready/live-pending for Pyaterochka**.
 
 Architecture/boundary:
 
 1. user opens the official retailer page in their own browser/profile;
 2. user manually resolves login/CAPTCHA/store selection when required;
-3. bridge reads semantic DOM, embedded structured state, and/or first-party resource evidence already visible in that legitimate browser context;
+3. bridge reads semantic DOM, embedded structured state, and/or explicitly allow-listed resource URL metadata already visible in that legitimate browser context;
 4. bridge normalizes observations locally;
 5. only sanitized normalized observations leave the page context when needed.
 
@@ -92,15 +92,39 @@ Live evidence: [`perekrestok-browser-bridge-live-2026-08-11.md`](perekrestok-bro
 
 Issue #54 tracks persistent-session refresh after the first successful snapshot; it does not invalidate the accepted reload-based page-snapshot path.
 
+### Pyaterochka deterministic proof
+
+Issue #57 / PR #58 reuse the same transport without conflating banner provenance.
+
+Current deterministic behavior:
+
+- production MV3 routing includes official `5ka.ru` / `www.5ka.ru` pages with no new privileged permissions;
+- `pyaterochkaBrowserAdapter` emits `retailerId=pyaterochka`, `sourceProviderId=pyaterochka-browser`, `adapterVersion=1`;
+- SKU comes from official `/product/<slug>--<numeric-id>/` links;
+- current visible RUB price is normalized to integer minor units;
+- catalog-only presence emits `availability=UNKNOWN` rather than invented stock semantics;
+- store context is accepted only from canonical `https://5d.5ka.ru/api/catalog/v2/stores/<store-id>/...` resource pathname metadata;
+- other service paths, lookalike origins, cross-retailer use, query strings and fragments are rejected before adapter input;
+- retailer-neutral adapter registry now routes Perekrestok and Pyaterochka separately;
+- async cross-origin context and delayed product DOM are covered in persistent Chromium;
+- sentinel query/cookie data is proven absent from extension storage;
+- ordinary CI has zero live retailer dependency.
+
+TDD includes separate RED→GREEN gates for manifest routing, adapter creation, adapter registry, async cross-origin context, and resource-policy security.
+
+Current decision: **Pyaterochka = `BROWSER_BRIDGE_LIVE_PENDING`**. Deterministic success is not a support claim.
+
+Procedure/evidence contract: [`pyaterochka-browser-bridge-phase-a.md`](pyaterochka-browser-bridge-phase-a.md).
+
 ## Previously tested direct paths
 
 ### Pyaterochka
 
 The transparent JDK HTTP probe received `store-403` on the first coordinate-to-store request.
 
-Current state: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`.
+Current direct-path state: `DIRECT_ANONYMOUS_HTTP_UNSUITABLE`.
 
-Next technical priority is to reuse the proven Perekrestok browser-bridge transport contract for Pyaterochka, while supported/aggregator access work continues in parallel.
+The selected technical fallback is now the deterministic-ready user-assisted browser bridge while supported/aggregator access work continues in parallel.
 
 ### Perekrestok
 
@@ -109,11 +133,13 @@ The transparent first-party-cookie probe received `store-403` before store selec
 ## Execution order
 
 1. Treat issue #47 as the umbrella mandatory-X5 requirement.
-2. Reuse the proven Perekrestok browser transport for Pyaterochka with the same privacy boundary, deterministic TDD and real-browser gate.
-3. Continue Kuper issue #36 and supported X5 partnership work in parallel.
-4. Keep direct anonymous 403 probes as regression/evidence only; do not turn them into stealth automation.
-5. Run Perekrestok fixed-corpus/second-context validation as hardening, not as a Phase A acceptance blocker.
-6. M0 GO still requires Pyaterochka plus at least one independent non-X5 retailer path and the remaining cross-mode criteria.
+2. Merge the deterministic Pyaterochka Browser Bridge Phase A only after the complete repository CI/security gate and read-only review.
+3. Run the real first-party Pyaterochka browser gate; advance to `AVAILABLE_BROWSER_BRIDGE` only on sanitized PASS evidence.
+4. Resolve issue #50 as a separate maintenance PR before any third substantial browser adapter so the bridge becomes a first-class pnpm workspace package without mixing the refactor into retailer behavior.
+5. Continue Kuper issue #36 and supported X5 partnership work in parallel.
+6. Keep direct anonymous 403 probes as regression/evidence only; do not turn them into stealth automation.
+7. Run Perekrestok fixed-corpus/second-context validation as hardening, not as a Phase A acceptance blocker.
+8. M0 GO still requires Pyaterochka live acceptance plus at least one independent non-X5 retailer path and the remaining cross-mode criteria.
 
 ## M0 decision rule
 
@@ -122,6 +148,6 @@ Zakup Gotov must not enter M1 on the assumption that X5 can be omitted.
 Current per-banner state:
 
 - Perekrestok usable through Track C: **satisfied**;
-- Pyaterochka usable through Track A, B or C: **outstanding**.
+- Pyaterochka deterministic Track C implementation: **ready, real-browser acceptance outstanding**.
 
 M0 additionally requires at least one independent non-X5 provider path, deterministic fixture tests for accepted paths, operational limitations/provenance visible in the product model, and the architecture-level multi-mode criteria defined in `ROADMAP.md` / `PROJECT_STATE.md`.


### PR DESCRIPTION
## Goal
Add **Pyaterochka Browser Bridge Phase A** by reusing the retailer-neutral browser transport already proven for Perekrestok while preserving distinct retailer/provider provenance and the existing privacy/security boundary.

Tracking: #57, umbrella #47.

## Delivered
- Production MV3 routing for `https://5ka.ru/*` and `https://www.5ka.ru/*`; permission surface remains `storage` only and no `host_permissions` were added.
- Dedicated `pyaterochkaBrowserAdapter`:
  - `retailerId=pyaterochka`;
  - `sourceProviderId=pyaterochka-browser`;
  - `adapterVersion=1`;
  - SKU from official `/product/<slug>--<numeric-id>/` links;
  - product-local visible RUB price normalized to integer `priceMinor`;
  - `availability=UNKNOWN` unless rendered evidence proves a supported stock semantic.
- Fulfillment context only from canonical resource URL metadata on exact official service origin `https://5d.5ka.ru`, path `/api/catalog/v2/stores/<store-id>/...`.
- Retailer-neutral adapter registry containing Perekrestok and Pyaterochka instead of hard-coded Perekrestok wiring.
- Explicit resource-observation security policy:
  - same-origin pathname evidence remains allowed;
  - only official 5ka page -> exact 5d catalog-store pathname is additionally accepted;
  - other 5d paths, lookalike origins and cross-retailer use are rejected;
  - query/hash are stripped before adapter input.
- Existing `PerformanceObserver` + `MutationObserver` recollection handles late store context and late product DOM.
- Deterministic sanitized fixtures and persistent-Chromium Pyaterochka E2E with resource-query and browser-cookie sentinels.
- Documentation synchronized: Phase A procedure/evidence, X5 strategy, roadmap, project state, docs index and changelog.

## TDD evidence
### RED 1 — manifest routing
Head `b4fbbdc12ed157c9c2e89e1ab065bbe5db8b9393` changed only the manifest-security test.
- 15 pre-existing tests PASS.
- 1 new test FAIL because production manifest lacked 5ka matches.

GREEN `779730cc3da92a4335c02d51bbf6072aa57c8030` added only the minimum official 5ka production matches; unit/type/build/existing Chromium E2E returned GREEN.

### RED 2 — dedicated Pyaterochka adapter
Head `122b39cf794f35a1d0ba3a4aac23928d613a2d53` added sanitized fixture/tests before production adapter code.
- all 16 pre-existing tests PASS;
- new suite failed only because `pyaterochka-browser-adapter` did not exist.

GREEN `1d57c3907356a53bd4d4a7519548f2523a658bda` added the minimal adapter; adapter/unit/type/build/existing Chromium E2E were GREEN.

### RED 3 — retailer-neutral adapter registry
Head `43ba78ac0d2549125b81e6adffc3908b0d60a2f7` required one registry with both banner adapters and unique identities.
- 20 behavior tests PASS;
- registry suite failed only because the registry module did not exist.

GREEN through `e26b726d6928cf93d1c7abbc0cb83bd12a4d9cbb` added the registry and switched runtime collector wiring to it. All 9 repository workflow groups on that head passed.

### RED 4 — async official service context
Head `447cf19e3806175165d9ca493bb90d747326c5f1` added persistent-Chromium Pyaterochka behavior before cross-origin resource policy changed.
- 21 unit tests PASS;
- typecheck/build PASS;
- both existing Perekrestok Chromium E2E PASS;
- Pyaterochka E2E FAIL: expected `ok`, received `missing-context`.

This proved the gap was runtime resource filtering, not adapter parsing.

### RED 4b — resource-policy security contract
Head `37923e2d318cf1eadc41e023fd05e25c8ddc5065` added the allow-list contract before production policy code.
- 21 existing tests PASS;
- new suite failed only because `resource-observation-policy` did not exist.

### GREEN 4
Executable head `73b73f1049c9e3b5f6c5000644ead07e1b0754b4` introduced the minimum resource policy and runtime integration.
- 23 unit tests PASS;
- TypeScript PASS;
- production build PASS;
- all 3 persistent-Chromium E2E scenarios PASS;
- Pyaterochka stored retailer/provider/context/SKU/price/version contract correctly;
- resource-query and browser-cookie sentinels did not reach extension storage.

A final consistency update also aligned the E2E manifest retailer match set with production routing; it did not widen the production permission surface.

## Security/privacy boundary
- user manually controls login/location/store/CAPTCHA in the official first-party browser profile;
- no CAPTCHA bypass, anti-bot/fingerprint evasion or proxy rotation;
- no cookie/token/auth-header export or replay;
- no response-body interception or raw production HTML persistence;
- no arbitrary browser-storage reads;
- no broad cross-origin resource capture;
- only canonical allow-listed resource `origin + pathname` metadata reaches adapters;
- collector allow-list projection and stale-observation clearing remain authoritative;
- ordinary CI performs zero live retailer requests.

## Documentation
- `docs/integrations/pyaterochka-browser-bridge-phase-a.md`
- `docs/integrations/x5-mandatory-coverage.md`
- `docs/PROJECT_STATE.md`
- `docs/ROADMAP.md`
- `docs/README.md`
- `CHANGELOG.md`

## Current status / merge decision
Pyaterochka remains **`BROWSER_BRIDGE_LIVE_PENDING`**. Deterministic success in this PR is not a support claim.

After merge, the rebuilt extension must pass the documented real first-party browser gate before Pyaterochka can advance to `AVAILABLE_BROWSER_BRIDGE`.

Issue #50 is intentionally not mixed into this functional PR because its acceptance requires a behavior-neutral workspace/tooling refactor. With this second substantial browser adapter, #50 becomes a hard maintenance gate before a third substantial browser adapter or bridge-owned dependency.

Merge only after the exact final head passes the complete repository CI/security gate and final read-only review.