### PR TITLE
docs(integrations): record Magnit public-page live pass

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-11
+Updated: 2026-08-12
 
 ## Project
 
@@ -10,7 +10,7 @@ Repository: `True-Ruslan/zakup-gotov`
 Visibility: Public  
 Current phase: **M0 — Product & Integration Discovery**  
 Current execution stage: **M0B Universal Retailer Connectivity**  
-Current focus: **prove an independent non-X5 retailer path and a second acquisition mode, then make the M0 → M1 go/no-go decision**
+Current focus: **execute Magnit Phase B on the fixed 20-item corpus and deterministic fixtures; if accepted, evaluate closure of the independent non-X5 and second-acquisition-mode M0 gates**
 
 ## Product connectivity invariant
 
@@ -36,13 +36,15 @@ The platform foundation is executable and automatically verified. The core multi
 - **Perekrestok:** `AVAILABLE_BROWSER_BRIDGE`, adapter v2;
 - **Pyaterochka:** `AVAILABLE_BROWSER_BRIDGE`, adapter v1.
 
-The retailer-bridge maintenance threshold is now satisfied: `apps/retailer-bridge` is a first-class pnpm workspace importer with its own pinned TypeScript/Vitest/jsdom/Playwright toolchain and no `apps/web/node_modules` coupling.
+The retailer-bridge maintenance threshold is satisfied: `apps/retailer-bridge` is a first-class pnpm workspace importer with its own pinned TypeScript/Vitest/jsdom/Playwright toolchain and no `apps/web/node_modules` coupling.
+
+**Magnit public-web Phase A now has a real live PASS** on merged `main`, proving that the same fixed SKU can expose SKU and RUB price evidence under two explicit `shopCode` contexts without login, cookies, partner credentials, browser automation or anti-bot bypass. Phase B is still required before Magnit becomes an accepted M0 path.
 
 The remaining M0 blockers are:
 
-- at least one independent non-X5 retailer with a reproducible accepted path;
-- at least two distinct acquisition modes proven end to end;
-- preservation of explicit retailer/provider/store provenance and deterministic sanitized verification as coverage expands.
+- at least one independent non-X5 retailer with a reproducible **accepted** path — Magnit is the active Phase B candidate;
+- at least two distinct acquisition modes proven end to end — browser bridge is accepted; Magnit public web is the active candidate for mode two;
+- deterministic sanitized fixture evidence and explicit price/availability semantics for the Magnit fixed corpus before its path is accepted.
 
 ## M0B verified foundation
 
@@ -159,23 +161,53 @@ Evidence:
 
 Issue #54 remains a non-blocking lifecycle-hardening item: after the first successful snapshot, same-document store changes or SPA navigation are not yet automatically refreshed. The accepted current path therefore assumes intended store selection followed by page reload.
 
-### Magnit
+### Magnit public web — Phase A LIVE PASS
 
-PR #46 remains the nearest independent non-X5 path candidate using public SSR product pages under explicit `shopCode` contexts without cookies/auth/API keys.
+PR #46 was brought up to the then-current `main`, retained the failing-before price/SKU binding regression, passed the full CI/security gate, and was squash-merged as:
 
-Its current branch is **not merge-ready** because `API CI` is failing. The failure must be diagnosed against current `main` before the path can be accepted. No support claim is made until the complete evidence path and CI gate pass.
+`295c82cf95ecf23aa6e5ca851a977d96d89c3f9f`
+
+The probe uses ordinary public SSR product pages, JDK `HttpClient`, fixed timeouts and two explicit `shopCode` contexts. It sends no Cookie, Authorization header or partner API key and performs no browser automation, CAPTCHA handling, proxy rotation, fingerprint evasion or retry/evasion loop.
+
+The real issue-gated workflow then ran from merged `main` and emitted:
+
+```text
+MAGNIT_PHASE_A first_status=200 first_sku_evidence=true first_price_present=true second_status=200 second_sku_evidence=true second_price_present=true prices_equal=true
+```
+
+Published status:
+
+**`Provider Live Probe / Magnit / pass-same-price` → success**
+
+The live Maven run completed 4 tests with 0 failures, 0 errors and 0 skipped tests.
+
+Current Magnit decision: **`PUBLIC_WEB_PHASE_A_PASS / PHASE_B_REQUIRED`**.
+
+This proves viability of the public-web acquisition hypothesis for the fixed Phase A product under two explicit contexts, but it does **not** yet claim an accepted M0 provider path. The following remain mandatory before acceptance:
+
+- fixed 20-item corpus coverage under two explicit contexts;
+- stable product identity;
+- representative regular/current/promo price semantics;
+- availability semantics without guessing stock from presence alone;
+- deterministic sanitized fixture replay;
+- documented freshness and location→`shopCode` limitations.
+
+Evidence:
+
+- Phase A design/procedure: [`integrations/magnit-phase-a.md`](integrations/magnit-phase-a.md);
+- live PASS: [`integrations/magnit-public-page-live-2026-08-12.md`](integrations/magnit-public-page-live-2026-08-12.md).
 
 ### Kuper
 
 Issue #36 remains active for supported aggregator-backed access. Any Kuper observation must preserve aggregator provider provenance separately from the underlying retailer/banner identity.
 
-Kuper remains strategically important because an accepted aggregator-backed path could satisfy the outstanding second-acquisition-mode criterion while broadening retailer coverage.
+Kuper remains strategically important because an accepted aggregator-backed path could satisfy the outstanding second-acquisition-mode criterion while broadening retailer coverage if Magnit Phase B does not close that gate first.
 
 ## Retailer Bridge workspace — maintenance gate satisfied
 
 Issue #50 tracked the temporary tooling debt created when early bridge work reused TypeScript/Vitest/Playwright from `apps/web`.
 
-PR #60 resolves that boundary without changing retailer behavior:
+PR #60 resolved that boundary without changing retailer behavior:
 
 - `apps/retailer-bridge` is registered in the root pnpm workspace;
 - the bridge owns explicit pinned devDependencies for `typescript`, `vitest`, `jsdom`, `@playwright/test` and `@types/node`;
@@ -192,7 +224,7 @@ TDD/refactoring evidence:
 - RED: the intentionally stale lockfile failed `pnpm install --frozen-lockfile` with `ERR_PNPM_OUTDATED_LOCKFILE` and named exactly the five newly owned bridge dependencies;
 - GREEN: pnpm `11.4.0` regenerated the lockfile, a fresh frozen install passed, and the complete bridge behavior suite returned green.
 
-No adapter, manifest, observation-model, resource-policy or permission behavior is changed by this maintenance gate.
+No adapter, manifest, observation-model, resource-policy or permission behavior was changed by this maintenance gate.
 
 ## Verified platform baseline
 
@@ -242,14 +274,15 @@ A successful real **`v0.1.0-rc.3` GitHub Release published event remains outstan
 
 ## Immediate next work
 
-1. Resolve at least one independent non-X5 retailer path, with Magnit PR #46 currently the nearest existing candidate after its failing API CI is diagnosed/fixed against current `main`.
-2. Prove a second accepted acquisition mode so M0 does not depend only on browser-assisted acquisition; Kuper/another supported aggregator or a stable public-web path are preferred candidates.
-3. Run additional Perekrestok/Pyaterochka corpus/context validation as hardening and product-quality evidence; neither is now a Phase A connectivity blocker.
-4. Resolve issue #54 before treating the browser bridge as a persistent-session transport across post-success store changes / SPA navigation.
-5. Continue Kuper/X5 supported-access work in parallel.
-6. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional chains through the same registry/adapter process.
-7. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
-8. Once the non-X5 and second-mode criteria are satisfied, make the explicit M0 → M1 go/no-go decision instead of starting Shopping Core prematurely.
+1. Execute Magnit Phase B against the fixed 20-item corpus in two explicit `shopCode` contexts and preserve sanitized deterministic fixtures.
+2. Prove stable SKU identity, representative current/regular/promo price distinction and availability semantics; keep unknown availability explicit when stock is not proven.
+3. If Phase B passes, decide whether Magnit can advance to an accepted public-web acquisition path and therefore satisfy both the independent non-X5 and second-acquisition-mode M0 criteria.
+4. If Magnit Phase B fails an acceptance gate, record the failure fail-closed and continue Kuper/another supported aggregator or stable public-web path rather than weakening the criteria.
+5. Run additional Perekrestok/Pyaterochka corpus/context validation as hardening and product-quality evidence; neither is now a Phase A connectivity blocker.
+6. Resolve issue #54 before treating the browser bridge as a persistent-session transport across post-success store changes / SPA navigation.
+7. Continue Kuper/X5 supported-access work in parallel and continue remaining retailer-registry onboarding through the same architecture.
+8. Publish `v0.1.0-rc.3` through the real GitHub Release event when a release-capable path is available.
+9. Once the non-X5 and second-mode criteria are satisfied, make the explicit M0 → M1 go/no-go decision instead of starting Shopping Core prematurely.
 
 ## Definition of M0 success
 
@@ -257,8 +290,8 @@ M0 is complete only when:
 
 - Pyaterochka has at least one reproducible accepted path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - Perekrestok has at least one reproducible accepted path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
-- at least one independent non-X5 retailer has a reproducible accepted path — **outstanding**;
-- at least two acquisition modes are proven end to end — **outstanding; browser bridge is currently the only accepted mode**;
+- at least one independent non-X5 retailer has a reproducible accepted path — **outstanding; Magnit Phase A passed and Phase B is now the active acceptance gate**;
+- at least two acquisition modes are proven end to end — **outstanding; browser bridge is accepted and Magnit public web is the active candidate for mode two**;
 - deterministic sanitized fixtures/tests preserve retailer/provider/store provenance;
 - the registry/adapter architecture can add another chain without retailer-specific changes to shopping/basket domain logic.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Updated: 2026-08-11
+Updated: 2026-08-12
 
 The roadmap is evidence-driven. Milestones may change when retailer integration feasibility or product usage contradicts current assumptions.
 
@@ -22,8 +22,9 @@ Current evidence status:
 - **Pyaterochka retailer-path criterion: satisfied** through `AVAILABLE_BROWSER_BRIDGE` page-snapshot acquisition after adapter v1 passed the real first-party browser gate on 2026-08-11 from merged `main` SHA `95e83c1c2d3e8217de10bf9c2bb160735ba17f94` with 12 normalized observations, one fulfillment context and zero validation failures;
 - **mandatory X5 per-banner connectivity criterion: satisfied** for both Pyaterochka and Perekrestok through the browser-assisted acquisition mode;
 - **retailer-bridge workspace maintenance gate: satisfied** by making `apps/retailer-bridge` an independent pnpm workspace importer with pinned bridge-owned tooling and unchanged deterministic browser behavior;
-- **independent non-X5 retailer criterion: outstanding**;
-- **second distinct acquisition-mode criterion: outstanding** until another accepted path proves a non-browser mode end to end.
+- **Magnit public-web Phase A: satisfied** on merged `main` SHA `295c82cf95ecf23aa6e5ca851a977d96d89c3f9f`; both explicit `shopCode` contexts returned HTTP 200 with expected SKU and price evidence, publishing `Provider Live Probe / Magnit / pass-same-price`;
+- **independent non-X5 retailer criterion: outstanding until Magnit Phase B** proves the fixed 20-item corpus and deterministic sanitized fixtures or another non-X5 path reaches acceptance;
+- **second distinct acquisition-mode criterion: outstanding until Magnit Phase B** proves the public-web mode end to end or another non-browser mode reaches acceptance.
 
 Deliverables:
 
@@ -47,8 +48,8 @@ Exit criteria:
 
 - **Pyaterochka** can return usable location/store-specific product/offer data through at least one acceptable path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
 - **Perekrestok** can return usable location/store-specific product/offer data through at least one acceptable path — **satisfied via `AVAILABLE_BROWSER_BRIDGE`**;
-- at least one independent non-X5 retailer can return usable location-specific product/offer data through an acceptable path;
-- at least two acquisition modes have been proven end to end so M0 does not depend on a single transport assumption;
+- at least one independent non-X5 retailer can return usable location-specific product/offer data through an acceptable path — **Magnit is the active Phase B candidate after a successful public-web Phase A live gate**;
+- at least two acquisition modes have been proven end to end so M0 does not depend on a single transport assumption — **browser bridge is accepted; Magnit public-web is the active Phase B candidate for mode two**;
 - accepted results are reproducible through automated tests/sanitized fixtures;
 - direct, aggregator-backed, public-web, and browser-assisted provenance cannot be confused in the product model;
 - the retailer registry and onboarding contract can add another chain without changes to shopping-list/basket domain logic;
@@ -56,15 +57,18 @@ Exit criteria:
 
 Detailed X5 strategy: [`integrations/x5-mandatory-coverage.md`](integrations/x5-mandatory-coverage.md).
 
-Immediate M0 sequencing after the retailer-bridge workspace gate:
+Magnit Phase A evidence: [`integrations/magnit-public-page-live-2026-08-12.md`](integrations/magnit-public-page-live-2026-08-12.md).
 
-1. prove at least one independent non-X5 retailer path, with Magnit PR #46 currently the nearest candidate after its failing API CI is diagnosed/fixed against current `main`;
-2. prove a second accepted acquisition mode so M0 is not browser-transport-only;
-3. keep Perekrestok/Pyaterochka additional corpus/context validation and issue #54 persistent-session work as hardening rather than reopening their Phase A acceptance;
-4. continue Kuper/X5 supported-access work in parallel, with an accepted aggregator-backed path also able to satisfy the second-mode criterion;
-5. continue remaining retailer-registry onboarding through the now independent bridge/provider architecture;
-6. publish the outstanding `v0.1.0-rc.3` release proof when a release-capable path is available;
-7. once the independent non-X5 and second-mode criteria are satisfied, make the explicit M0 → M1 go/no-go decision.
+Immediate M0 sequencing after the Magnit Phase A live PASS:
+
+1. execute Magnit Phase B using the fixed 20-item corpus against two explicit `shopCode` contexts; prove stable identity, representative current/promo price semantics, availability semantics, sanitized deterministic fixtures and public-path repeatability;
+2. if Magnit Phase B passes, advance it to an accepted public-web path and evaluate whether the independent non-X5 plus second-acquisition-mode exit criteria are both satisfied;
+3. if Magnit Phase B exposes a blocker, record it fail-closed and continue Kuper/another supported aggregator or stable public-web path for the second acquisition mode while keeping Magnit in the registry;
+4. keep Perekrestok/Pyaterochka additional corpus/context validation and issue #54 persistent-session work as hardening rather than reopening their Phase A acceptance;
+5. continue Kuper/X5 supported-access work in parallel;
+6. continue remaining retailer-registry onboarding through the independent bridge/provider architecture;
+7. publish the outstanding `v0.1.0-rc.3` release proof when a release-capable path is available;
+8. once the independent non-X5 and second-mode criteria are satisfied, make the explicit M0 → M1 go/no-go decision.
 
 ## M1 — Shopping Core
 

--- a/docs/integrations/magnit-phase-a.md
+++ b/docs/integrations/magnit-phase-a.md
@@ -1,7 +1,7 @@
 # Magnit Phase A — public-page store-price feasibility
 
-Updated: 2026-08-10
-Status: `PHASE_A_IMPLEMENTATION_READY_LIVE_PENDING`
+Updated: 2026-08-12
+Status: `PUBLIC_WEB_PHASE_A_PASS / PHASE_B_REQUIRED`
 Tracking: issue #45 / PR #46
 
 ## Purpose
@@ -10,7 +10,7 @@ Prove an independent non-X5 provider path using Magnit's ordinary public SSR pag
 
 ## Research evidence
 
-Magnit's public product/catalog pages accept `shopCode` and expose prices for a selected store context. Publicly indexed product pages for the same SKU/article `1000379971` have appeared under multiple Moscow `shopCode` values with different displayed prices, which is sufficient evidence to test store-context price observation directly from the public page.
+Magnit's public product/catalog pages accept `shopCode` and expose prices for a selected store context. Publicly indexed product pages for the same SKU/article `1000379971` have appeared under multiple Moscow `shopCode` values, which is sufficient evidence to test store-context price observation directly from the public page.
 
 The official Magnit Market partner API is a different seller/partner surface requiring `X-Api-Key`; it is not used by this spike.
 
@@ -42,6 +42,16 @@ The probe requests the same public product page for both contexts with `shopType
 - no proxy/IP rotation or fingerprint evasion;
 - no retry loop.
 
+## TDD / parser evidence
+
+PR #46 retained a deterministic regression test that binds price evidence to the expected SKU/article rather than accepting the first or nearest unrelated page price.
+
+The failing implementation selected an unrelated footer price after the SKU because it minimized flattened-text distance. The accepted implementation prefers the nearest price preceding the SKU and uses a following price only as a fallback when no preceding price exists. The regression test was not weakened.
+
+PR #46 was updated onto the then-current `main`, passed the complete repository CI/security gate, and was squash-merged as:
+
+`295c82cf95ecf23aa6e5ca851a977d96d89c3f9f`
+
 ## Phase A acceptance
 
 Each public page must return:
@@ -50,11 +60,31 @@ Each public page must return:
 2. expected SKU/article evidence;
 3. ruble price evidence.
 
-Both contexts must pass. The observed prices may be equal or different; either result proves the same SKU is observable under two explicit store contexts. A difference is additional store-specific pricing evidence.
+Both contexts must pass. The observed prices may be equal or different; either result proves the same SKU is observable under two explicit store contexts. A difference would be additional store-specific pricing evidence but is not required for Phase A.
 
 Location → `shopCode` resolution is deliberately **not** claimed by this slice and remains a separate capability gate.
 
-## Sanitized evidence
+## Real live gate — PASS
+
+The dedicated issue-gated workflow was run from merged `main` SHA `295c82cf95ecf23aa6e5ca851a977d96d89c3f9f`.
+
+Sanitized evidence:
+
+```text
+MAGNIT_PHASE_A first_status=200 first_sku_evidence=true first_price_present=true second_status=200 second_sku_evidence=true second_price_present=true prices_equal=true
+```
+
+Published status:
+
+```text
+Provider Live Probe / Magnit / pass-same-price
+```
+
+The Maven live test run completed with 4 tests, 0 failures, 0 errors and 0 skipped tests.
+
+Evidence record: [`magnit-public-page-live-2026-08-12.md`](magnit-public-page-live-2026-08-12.md).
+
+## Sanitized evidence boundary
 
 Live evidence contains only:
 
@@ -63,12 +93,39 @@ Live evidence contains only:
 - price-present boolean for each page;
 - whether the two parsed prices are equal.
 
-No numeric price, street address, response body, cookie, token, or hidden identifier is emitted.
+No numeric price, street address, response body, cookie, token, hidden identifier, or arbitrary production HTML is persisted in the evidence record.
 
-The dedicated live workflow publishes:
+## Decision
 
-`Provider Live Probe / Magnit / <outcome>`
+Phase A is **PASS** and the ordinary public-web hypothesis is viable enough to enter Phase B.
 
-Possible outcomes include `pass-same-price`, `pass-different-price`, `first-<status>`, `first-sku-missing`, `first-price-missing`, corresponding second-page failures, `no-evidence`, or `failed`.
+Current decision: **`PUBLIC_WEB_PHASE_A_PASS / PHASE_B_REQUIRED`**.
 
-Only a pass outcome permits Phase B fixture/corpus work.
+This is intentionally not yet `AVAILABLE_PUBLIC_WEB`. Phase B must prove the fixed 20-item corpus, stable identity, representative price/promo semantics, availability semantics, deterministic sanitized fixtures, and repeatability across two explicit contexts before Magnit can count as an accepted independent non-X5 path or as the second M0 acquisition mode.
+
+## Phase B gate
+
+Use the fixed M0B 20-item corpus:
+
+- milk;
+- eggs;
+- bread;
+- bananas;
+- potatoes;
+- onions;
+- tomatoes;
+- cucumbers;
+- chicken;
+- beef/mince;
+- rice;
+- buckwheat;
+- pasta;
+- sunflower oil;
+- butter;
+- cheese;
+- kefir;
+- sugar;
+- salt;
+- tea.
+
+For two explicit `shopCode` contexts, record aggregate coverage and sanitized deterministic fixtures. Explicitly distinguish current/promo/regular price when evidence supports it; do not infer availability from catalog presence when an explicit stock semantic is absent. Record freshness and location-resolution limitations instead of hiding them.

--- a/docs/integrations/magnit-public-page-live-2026-08-12.md
+++ b/docs/integrations/magnit-public-page-live-2026-08-12.md
@@ -1,0 +1,66 @@
+# Magnit public-page Phase A — live evidence
+
+Date: 2026-08-12 (+03:00)  
+Workflow run timestamp: 2026-08-11T21:29Z  
+Tracking: issue #45 / PR #46  
+Merged `main` SHA: `295c82cf95ecf23aa6e5ca851a977d96d89c3f9f`  
+Workflow run: `31538076809`
+
+## Result
+
+The issue-gated Magnit Phase A workflow exercised two ordinary public `magnit.ru` product-page requests for the same fixed product under two explicit `shopCode` contexts.
+
+Sanitized evidence emitted by the test:
+
+```text
+MAGNIT_PHASE_A first_status=200 first_sku_evidence=true first_price_present=true second_status=200 second_sku_evidence=true second_price_present=true prices_equal=true
+```
+
+Published commit status:
+
+```text
+Provider Live Probe / Magnit / pass-same-price
+```
+
+Result: **PASS**.
+
+## What this proves
+
+- both explicit store contexts returned HTTP 2xx;
+- the expected product article/SKU was observable in both responses;
+- a RUB price was observable in both responses;
+- the two parsed prices were equal in this run;
+- the path required no login, Cookie, Authorization header, partner API key, browser automation, CAPTCHA handling, proxy rotation, fingerprint evasion, or retry/evasion loop;
+- the live workflow ran from merged `main`, not from an unmerged feature branch.
+
+Equal prices are an accepted Phase A outcome. Phase A requires reproducible observation of the same SKU and price evidence under both explicit store contexts; it does not require those two prices to differ on every run.
+
+## Privacy and evidence boundary
+
+The persisted evidence intentionally excludes:
+
+- numeric prices;
+- response bodies;
+- street addresses;
+- cookies, tokens, headers, or partner credentials;
+- arbitrary production HTML.
+
+The workflow publishes only HTTP status, SKU-evidence booleans, price-presence booleans, price-equality state, and a finite outcome label.
+
+## Non-claims
+
+This PASS does **not** yet establish:
+
+- location/address → `shopCode` resolution;
+- 20-item corpus coverage;
+- stable product identity across the full target corpus;
+- regular/promo price distinction across representative products;
+- explicit availability semantics across representative products;
+- deterministic sanitized fixture replay for Magnit;
+- a production-ready Magnit provider adapter.
+
+Therefore Magnit is currently **`PUBLIC_WEB_PHASE_A_PASS / PHASE_B_REQUIRED`**, not yet an accepted M0 retailer path.
+
+## Next gate
+
+Phase B must run the fixed 20-item corpus against two explicit contexts and preserve sanitized deterministic fixtures. It must measure coverage, SKU stability, current/promo price semantics where present, availability semantics, freshness limitations, and public-path stability. Only a successful Phase B decision may advance Magnit to an accepted public-web acquisition path and count it toward the independent non-X5 / second-acquisition-mode M0 exit criteria.


### PR DESCRIPTION
## Goal
Record the real Magnit public-web Phase A live PASS from merged `main` and advance the M0B execution focus to Phase B without overstating acceptance.

## Evidence
PR #46 was squash-merged as `295c82cf95ecf23aa6e5ca851a977d96d89c3f9f` after exact-head full CI/security verification.

The issue-gated live workflow then emitted:

`MAGNIT_PHASE_A first_status=200 first_sku_evidence=true first_price_present=true second_status=200 second_sku_evidence=true second_price_present=true prices_equal=true`

and published:

`Provider Live Probe / Magnit / pass-same-price`

The live Maven run completed 4 tests with 0 failures/errors/skips.

## Scope
- add a sanitized live evidence record;
- advance `magnit-phase-a.md` to `PUBLIC_WEB_PHASE_A_PASS / PHASE_B_REQUIRED`;
- synchronize `PROJECT_STATE.md` and `ROADMAP.md`;
- keep independent non-X5 and second-acquisition-mode M0 criteria explicitly outstanding until Phase B proves the 20-item corpus and deterministic fixtures.

## Non-claims
This PR does not claim location→`shopCode` resolution, 20-item coverage, production adapter readiness, or accepted public-web mode yet.

Tracking: #45.