### PR TITLE
fix(provider): support Magnit embedded current-price evidence

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -190,7 +190,9 @@ final class MagnitCorpusProbe {
         var text = visibleText(scope);
         var lowerText = text.toLowerCase(Locale.ROOT);
         var prices = distinctPrices(text);
-        var currentPrice = prices.isEmpty() ? Optional.<BigDecimal>empty() : Optional.of(prices.getFirst());
+        var currentPrice = prices.isEmpty()
+                ? MagnitPublicPageProbe.closestPriceToSku(html, expectedSku)
+                : Optional.of(prices.getFirst());
 
         Optional<BigDecimal> regularPrice = Optional.empty();
         var promoMarker = lowerText.contains("финальная цена") || DISCOUNT.matcher(text).find();

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -58,6 +58,17 @@ class MagnitCorpusProbeTest {
     }
 
     @Test
+    void fallsBackToSkuBoundEmbeddedCurrentPriceWhenRenderedScopeHasNoPrice() throws Exception {
+        var observation = MagnitCorpusProbe.parseProductPage(fixture("embedded-current-price.html"), "9072651501");
+
+        assertThat(observation.skuEvidence()).isTrue();
+        assertThat(observation.currentPrice()).contains(new BigDecimal("123.45"));
+        assertThat(observation.regularPrice()).isEmpty();
+        assertThat(observation.promo()).isFalse();
+        assertThat(observation.availability()).isEqualTo(MagnitCorpusProbe.Availability.AVAILABLE);
+    }
+
+    @Test
     void treatsExplicitProductUnavailabilityAsUnavailable() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("regular-unavailable.html"), "1000135280");
 

--- a/apps/api/src/test/resources/provider/magnit/embedded-current-price.html
+++ b/apps/api/src/test/resources/provider/magnit/embedded-current-price.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <script type="application/json">
+      {"cards":["<div>999 ₽ Артикул 1111111111</div>","<div>123,45 ₽ Артикул 9072651501</div>"]}
+    </script>
+  </head>
+  <body>
+    <h1>Санитизированный товар с embedded current price</h1>
+    <button>Добавить в корзину</button>
+    <section>Характеристики Артикул 9072651501</section>
+  </body>
+</html>


### PR DESCRIPTION
## Goal
Fix the real Magnit Phase B live-shape mismatch without weakening the corpus gate.

Tracking: #45.

## Live evidence that triggered this fix
Merged-main Phase B run `31539718199` emitted:

`MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=19 second_http_2xx=19 first_usable=0 second_usable=0 stable_identity=19 known_availability=6 promo_observations=0 failed_count=20`

Interpretation: the ordinary public path and expected-SKU identity worked for 19/20 products in both contexts, but the Phase B parser's rendered-scope price extraction failed for all accessible products.

## RED → GREEN evidence
### RED
Head `f2273f9945a1ab3fa49f0beeefef70bec9bd1f1d` added a sanitized `embedded-current-price.html` fixture plus `fallsBackToSkuBoundEmbeddedCurrentPriceWhenRenderedScopeHasNoPrice`.

`API CI` ran 39 tests and failed exactly one assertion: expected current price `123.45`, actual `Optional.empty`. The fixture deliberately contains an unrelated SKU/price pair before the expected pair, proving that a non-SKU-bound first-price fallback would be incorrect.

### GREEN
Head `4d68815a1835b541bb6731499ae827cfd6cf80ae` keeps rendered identity and availability rules unchanged. If the rendered product scope has no current price, it reuses the already-tested Phase A `MagnitPublicPageProbe.closestPriceToSku(html, expectedSku)` fallback for **current price only**.

The regression test is unchanged and `API CI` now completes the full backend verification successfully.

## Trust boundary
- visible `<h1>` → expected SKU identity remains mandatory before any fallback;
- rendered product-scope current price remains preferred when present;
- embedded public-page state may fill only current price for an already confirmed SKU;
- regular/promo price is still derived only from rendered product-scope evidence;
- rendered availability semantics are unchanged;
- missing expected SKU still yields no price and `UNKNOWN` availability;
- live corpus acceptance thresholds are unchanged.

## Safety
No new network path, credential, browser, anti-bot, proxy, retry, persistence, or workflow permission is introduced. The added fixture is synthetic/sanitized and contains no production payload or numeric live price.

## Post-merge gate
After full exact-head CI/security verification and merge, rerun `/provider-probe magnit-corpus` on issue #45. Only that merged-main result may determine whether the price-shape mismatch is resolved and what Phase B blocker remains.