### PR TITLE
chore(provider): expose sanitized Magnit corpus failures

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -304,7 +304,8 @@ final class MagnitCorpusProbe {
                     + " stable_identity=" + stableIdentity
                     + " known_availability=" + knownAvailability
                     + " promo_observations=" + promoObservations
-                    + " failed_count=" + failedRequirements.size();
+                    + " failed_count=" + failedRequirements.size()
+                    + " failed_requirements=" + String.join(",", failedRequirements);
         }
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +95,15 @@ class MagnitCorpusProbeTest {
         assertThat(observation.currentPrice()).isEmpty();
         assertThat(observation.regularPrice()).isEmpty();
         assertThat(observation.availability()).isEqualTo(MagnitCorpusProbe.Availability.UNKNOWN);
+    }
+
+    @Test
+    void evidenceLineIncludesOnlyApprovedFailedRequirementNames() {
+        var result = new MagnitCorpusProbe.CorpusResult(
+                20, 40, 19, 19, 19, 19, 19, 6, 0, List.of("tea", "beef/mince"));
+
+        assertThat(result.toEvidenceLine())
+                .endsWith("failed_count=2 failed_requirements=tea,beef/mince");
     }
 
     @Test


### PR DESCRIPTION
## Goal
Identify the single remaining Magnit Phase B corpus failure without exposing SKU, URL, price, HTML, address, or any other retailer payload.

Tracking: #45.

## Live evidence
Merged-main run `31540422755` after the current-price fallback produced:

`MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=19 second_http_2xx=19 first_usable=19 second_usable=19 stable_identity=19 known_availability=6 promo_observations=0 failed_count=1`

The remaining blocker is therefore exactly one approved abstract requirement name.

## RED → GREEN evidence
### RED
Head `aba3931aeff4d2968fa4148caf18abd47983bd7d` added `evidenceLineIncludesOnlyApprovedFailedRequirementNames` and required `CorpusResult.toEvidenceLine()` to append only the already-held approved taxonomy names, for example:

`failed_count=2 failed_requirements=tea,beef/mince`

`API CI` ran 40 tests and failed exactly this one new assertion. The existing implementation stopped at `failed_count=2`; all parser/live behavior tests remained green.

### GREEN
Head `3afd1924bc333493d669e746c6c3c9799ca35417` changes only evidence serialization:

`failed_requirements=` + the comma-joined existing `failedRequirements` list.

The regression test is unchanged and full API verification now passes.

## Privacy boundary
Only fixed taxonomy names from the approved 20-item corpus may be emitted. No SKU/article, slug, URL, HTTP payload, numeric price, response body, location, cookie, token, or header is added to evidence.

## Non-goals
- no parser change;
- no live request change;
- no acceptance-threshold change;
- no new workflow permission;
- no Magnit support-status promotion.

## Post-merge
Rerun `/provider-probe magnit-corpus` on issue #45 and use the sanitized failed requirement name to repair the stale corpus candidate if appropriate.