### PR TITLE
fix(provider): refresh Magnit eggs corpus candidate

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -34,7 +34,7 @@ final class MagnitCorpusProbe {
                     "milk",
                     "1000013732",
                     "1000013732-moloko_selo_zelenoe_ultrapasterizovannoe_2_5_950ml"),
-            new CorpusItem("eggs", "1000135280", "1000135280-yaytso_kurinoe_s1_15sht_up_20"),
+            new CorpusItem("eggs", "2047000014", "2047000014-yaytso_kurinoe_stolovoe_so_10sht"),
             new CorpusItem(
                     "bread",
                     "1000134831",

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -48,6 +48,17 @@ class MagnitCorpusProbeTest {
     }
 
     @Test
+    void usesCurrentOfficialEggCandidate() {
+        var eggs = MagnitCorpusProbe.fixedCorpus().stream()
+                .filter(item -> item.requirement().equals("eggs"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(eggs.sku()).isEqualTo("2047000014");
+        assertThat(eggs.productSlug()).isEqualTo("2047000014-yaytso_kurinoe_stolovoe_so_10sht");
+    }
+
+    @Test
     void parsesCurrentAndRegularPromoPriceBoundToExpectedSku() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("promo-available.html"), "9072651501");
 


### PR DESCRIPTION
## Goal
Replace the single stale Magnit Phase B `eggs` corpus candidate identified by merged-main sanitized diagnostics, without changing parser or acceptance behavior.

Tracking: #45.

## Evidence
Merged-main corpus run `31541050845` on SHA `02897da1325619b324900bd39903db35cb469c05` emitted:

`MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=19 second_http_2xx=19 first_usable=19 second_usable=19 stable_identity=19 known_availability=6 promo_observations=0 failed_count=1 failed_requirements=eggs`

Current official Magnit pages expose the alternative public egg candidate `2047000014-yaytso_kurinoe_stolovoe_so_10sht` with article `2047000014`, including ordinary public product/price semantics.

## RED → GREEN evidence
### RED
Head `ec3be0965bbde42b97f2190487717be78e43f5f2` added `usesCurrentOfficialEggCandidate` only.

`API CI` ran 41 tests and failed exactly that new assertion:
- expected SKU `2047000014`;
- actual stale SKU `1000135280`.

All other backend tests remained green.

### GREEN
Head `16126a12006179ca8b74f3a4e7c521dd763c444a` changes exactly one corpus item:
- `eggs` SKU/article → `2047000014`;
- slug → `2047000014-yaytso_kurinoe_stolovoe_so_10sht`.

The regression test is unchanged and full API verification now passes.

## Non-goals
- no parser change;
- no request-policy change;
- no workflow permission change;
- no acceptance-threshold change;
- no support-status promotion before a merged-main 40-request rerun proves the replacement in both fixed contexts.

## Post-merge gate
Rerun `/provider-probe magnit-corpus` on issue #45. Only the merged-main live result may determine whether corpus coverage reaches 20/20.