### PR TITLE
spike(provider): diagnose Magnit promo shape safely

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -21,6 +21,8 @@ final class MagnitCorpusProbe {
     private static final String ORIGIN = "https://magnit.ru";
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(8);
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(12);
+    private static final int NEAR_SKU_WINDOW = 900;
+    private static final String ARTICLE_MARKER = "Артикул ";
     private static final Map<String, String> REQUEST_HEADERS = Map.of(
             "Accept", "text/html,application/xhtml+xml",
             "User-Agent", "ZakupGotov-M0B-PublicPageProbe/0.1 (+https://github.com/True-Ruslan/zakup-gotov)");
@@ -104,6 +106,8 @@ final class MagnitCorpusProbe {
         var stableIdentity = 0;
         var knownAvailability = 0;
         var promoObservations = 0;
+        var nearSkuMultiplePriceObservations = 0;
+        var nearSkuPromoMarkerObservations = 0;
         var failedRequirements = new ArrayList<String>();
 
         for (var item : FIXED_CORPUS) {
@@ -139,6 +143,18 @@ final class MagnitCorpusProbe {
             if (second.observation().promo()) {
                 promoObservations++;
             }
+            if (first.rawShape().multiplePriceCandidates()) {
+                nearSkuMultiplePriceObservations++;
+            }
+            if (second.rawShape().multiplePriceCandidates()) {
+                nearSkuMultiplePriceObservations++;
+            }
+            if (first.rawShape().promoMarker()) {
+                nearSkuPromoMarkerObservations++;
+            }
+            if (second.rawShape().promoMarker()) {
+                nearSkuPromoMarkerObservations++;
+            }
             if (!first.usable() || !second.usable()) {
                 failedRequirements.add(item.requirement());
             }
@@ -154,6 +170,8 @@ final class MagnitCorpusProbe {
                 stableIdentity,
                 knownAvailability,
                 promoObservations,
+                nearSkuMultiplePriceObservations,
+                nearSkuPromoMarkerObservations,
                 List.copyOf(failedRequirements));
     }
 
@@ -166,7 +184,8 @@ final class MagnitCorpusProbe {
         var response = httpClient.send(
                 requestBuilder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         var observation = parseProductPage(response.body(), item.sku());
-        return new HttpObservation(response.statusCode(), observation);
+        var rawShape = inspectNearSkuRawShape(response.body(), item.sku());
+        return new HttpObservation(response.statusCode(), observation, rawShape);
     }
 
     static PageObservation parseProductPage(String html, String expectedSku) {
@@ -213,6 +232,40 @@ final class MagnitCorpusProbe {
                 regularPrice,
                 regularPrice.isPresent(),
                 availability);
+    }
+
+    static RawShapeEvidence inspectNearSkuRawShape(String html, String expectedSku) {
+        if (expectedSku == null || expectedSku.isBlank()) {
+            throw new IllegalArgumentException("expectedSku must not be blank");
+        }
+
+        var text = visibleText(html);
+        var multiplePriceCandidates = false;
+        var promoMarker = false;
+        var searchFrom = 0;
+        var skuIndex = text.indexOf(expectedSku, searchFrom);
+
+        while (skuIndex >= 0) {
+            var windowStart = Math.max(0, skuIndex - NEAR_SKU_WINDOW);
+            var currentArticleMarker = text.lastIndexOf(ARTICLE_MARKER, skuIndex);
+            var previousArticleMarker = currentArticleMarker >= 0
+                    ? text.lastIndexOf(ARTICLE_MARKER, currentArticleMarker - 1)
+                    : -1;
+            if (previousArticleMarker >= windowStart) {
+                windowStart = previousArticleMarker + ARTICLE_MARKER.length();
+            }
+
+            var scope = text.substring(windowStart, skuIndex);
+            var prices = distinctPrices(scope);
+            multiplePriceCandidates |= prices.size() >= 2;
+            var lowerScope = scope.toLowerCase(Locale.ROOT);
+            promoMarker |= lowerScope.contains("финальная цена") || DISCOUNT.matcher(scope).find();
+
+            searchFrom = skuIndex + expectedSku.length();
+            skuIndex = text.indexOf(expectedSku, searchFrom);
+        }
+
+        return new RawShapeEvidence(multiplePriceCandidates, promoMarker);
     }
 
     private static List<BigDecimal> distinctPrices(String text) {
@@ -271,7 +324,9 @@ final class MagnitCorpusProbe {
         }
     }
 
-    private record HttpObservation(int status, PageObservation observation) {
+    record RawShapeEvidence(boolean multiplePriceCandidates, boolean promoMarker) {}
+
+    private record HttpObservation(int status, PageObservation observation, RawShapeEvidence rawShape) {
         boolean http2xx() {
             return status >= 200 && status < 300;
         }
@@ -291,6 +346,8 @@ final class MagnitCorpusProbe {
             int stableIdentity,
             int knownAvailability,
             int promoObservations,
+            int nearSkuMultiplePriceObservations,
+            int nearSkuPromoMarkerObservations,
             List<String> failedRequirements) {
 
         String toEvidenceLine() {
@@ -304,6 +361,8 @@ final class MagnitCorpusProbe {
                     + " stable_identity=" + stableIdentity
                     + " known_availability=" + knownAvailability
                     + " promo_observations=" + promoObservations
+                    + " near_sku_multi_price=" + nearSkuMultiplePriceObservations
+                    + " near_sku_promo_marker=" + nearSkuPromoMarkerObservations
                     + " failed_count=" + failedRequirements.size()
                     + " failed_requirements=" + String.join(",", failedRequirements);
         }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -81,6 +81,14 @@ class MagnitCorpusProbeTest {
     }
 
     @Test
+    void detectsAggregateSafePromoShapeNearExpectedSku() throws Exception {
+        var shape = MagnitCorpusProbe.inspectNearSkuRawShape(fixture("embedded-promo-shape.html"), "9072651501");
+
+        assertThat(shape.multiplePriceCandidates()).isTrue();
+        assertThat(shape.promoMarker()).isTrue();
+    }
+
+    @Test
     void treatsExplicitProductUnavailabilityAsUnavailable() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("regular-unavailable.html"), "1000135280");
 

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -119,10 +119,12 @@ class MagnitCorpusProbeTest {
     @Test
     void evidenceLineIncludesOnlyApprovedFailedRequirementNames() {
         var result = new MagnitCorpusProbe.CorpusResult(
-                20, 40, 19, 19, 19, 19, 19, 6, 0, List.of("tea", "beef/mince"));
+                20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, List.of("tea", "beef/mince"));
 
         assertThat(result.toEvidenceLine())
                 .endsWith("failed_count=2 failed_requirements=tea,beef/mince");
+        assertThat(result.toEvidenceLine())
+                .contains("near_sku_multi_price=4 near_sku_promo_marker=3");
     }
 
     @Test
@@ -141,6 +143,8 @@ class MagnitCorpusProbeTest {
         assertThat(result.stableIdentity()).isBetween(0, 20);
         assertThat(result.knownAvailability()).isBetween(0, 40);
         assertThat(result.promoObservations()).isBetween(0, 40);
+        assertThat(result.nearSkuMultiplePriceObservations()).isBetween(0, 40);
+        assertThat(result.nearSkuPromoMarkerObservations()).isBetween(0, 40);
 
         var approvedRequirements = Set.copyOf(MagnitCorpusProbe.fixedCorpus().stream()
                 .map(MagnitCorpusProbe.CorpusItem::requirement)

--- a/apps/api/src/test/resources/provider/magnit/embedded-promo-shape.html
+++ b/apps/api/src/test/resources/provider/magnit/embedded-promo-shape.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <script type="application/json">
+      {"cards":["<div>77 ₽ Артикул 1111111111</div>","<div>Финальная цена 123,45 ₽ 150,00 ₽ -18% Артикул 9072651501</div>"]}
+    </script>
+  </head>
+  <body>
+    <h1>Санитизированный товар</h1>
+    <button>Добавить в корзину</button>
+    <section>Характеристики Артикул 9072651501</section>
+  </body>
+</html>


### PR DESCRIPTION
## Goal
Measure whether Magnit's raw public product-page shape contains enough SKU-near evidence to support a future regular/promo parser without guessing or exposing live prices.

Tracking: #45.

## Current merged-main evidence
Run `31541623826` on main SHA `964c24d311d7af0f9065f9e4af95f01fc3a1fb35` achieved full corpus coverage:

`MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=20 second_http_2xx=20 first_usable=20 second_usable=20 stable_identity=20 known_availability=6 promo_observations=0 failed_count=0`

The remaining technical question is why regular/promo semantics are not observed even though current-price identity is fully usable.

## RED → GREEN evidence
### RED
Head `8a4728a160998e21a2f1a94337303c04be2f025a` added only a synthetic `embedded-promo-shape.html` fixture and `detectsAggregateSafePromoShapeNearExpectedSku`.

`API CI` reached Java/Maven `testCompile` and failed exactly because `MagnitCorpusProbe.inspectNearSkuRawShape(String,String)` did not exist.

### GREEN
Head `c8fa961e36edf917590e302d0acbddb6640e8f68` adds a diagnostic-only `RawShapeEvidence` with two booleans:
- multiple RUB-price candidates in a bounded raw-text neighborhood before an expected-SKU occurrence;
- a nearby promo marker (`Финальная цена` or discount percent).

The live corpus aggregates those booleans into:
- `near_sku_multi_price`;
- `near_sku_promo_marker`.

The original RED test is unchanged and full API verification now passes.

## Trust / privacy boundary
- diagnostics do not alter `parseProductPage`, current price, promo, availability, `usable`, stable identity, or `observed-full` logic;
- the near-SKU window is diagnostic evidence only and is not treated as a product-binding parser contract;
- only aggregate counts are emitted across 40 responses;
- no numeric live prices, HTML, SKU/URL details, addresses, cookies, tokens, request headers, or response bodies are persisted;
- live request policy and workflow permissions are unchanged.

## Decision use
After full exact-head CI/security verification and merge, rerun `/provider-probe magnit-corpus` on issue #45. The aggregate result will determine whether an embedded regular/promo fallback has enough evidence to justify a separate TDD implementation.

## Non-goal
This PR does not promote Magnit support status and does not implement regular/promo fallback.