### PR TITLE
spike(provider): bind Magnit promo diagnostics to selected price

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -22,6 +22,7 @@ final class MagnitCorpusProbe {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(8);
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(12);
     private static final int NEAR_SKU_WINDOW = 900;
+    private static final int PRICE_BOUND_PROMO_WINDOW = 160;
     private static final String ARTICLE_MARKER = "Артикул ";
     private static final Map<String, String> REQUEST_HEADERS = Map.of(
             "Accept", "text/html,application/xhtml+xml",
@@ -108,6 +109,7 @@ final class MagnitCorpusProbe {
         var promoObservations = 0;
         var nearSkuMultiplePriceObservations = 0;
         var nearSkuPromoMarkerObservations = 0;
+        var priceBoundPromoMarkerObservations = 0;
         var failedRequirements = new ArrayList<String>();
 
         for (var item : FIXED_CORPUS) {
@@ -155,6 +157,12 @@ final class MagnitCorpusProbe {
             if (second.rawShape().promoMarker()) {
                 nearSkuPromoMarkerObservations++;
             }
+            if (first.priceBoundPromo().promoMarker()) {
+                priceBoundPromoMarkerObservations++;
+            }
+            if (second.priceBoundPromo().promoMarker()) {
+                priceBoundPromoMarkerObservations++;
+            }
             if (!first.usable() || !second.usable()) {
                 failedRequirements.add(item.requirement());
             }
@@ -172,6 +180,7 @@ final class MagnitCorpusProbe {
                 promoObservations,
                 nearSkuMultiplePriceObservations,
                 nearSkuPromoMarkerObservations,
+                priceBoundPromoMarkerObservations,
                 List.copyOf(failedRequirements));
     }
 
@@ -185,7 +194,8 @@ final class MagnitCorpusProbe {
                 requestBuilder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         var observation = parseProductPage(response.body(), item.sku());
         var rawShape = inspectNearSkuRawShape(response.body(), item.sku());
-        return new HttpObservation(response.statusCode(), observation, rawShape);
+        var priceBoundPromo = inspectPriceBoundPromoShape(response.body(), item.sku());
+        return new HttpObservation(response.statusCode(), observation, rawShape, priceBoundPromo);
     }
 
     static PageObservation parseProductPage(String html, String expectedSku) {
@@ -268,6 +278,56 @@ final class MagnitCorpusProbe {
         return new RawShapeEvidence(multiplePriceCandidates, promoMarker);
     }
 
+    static PriceBoundPromoEvidence inspectPriceBoundPromoShape(String html, String expectedSku) {
+        if (expectedSku == null || expectedSku.isBlank()) {
+            throw new IllegalArgumentException("expectedSku must not be blank");
+        }
+
+        var text = visibleText(html);
+        var bestDistance = Integer.MAX_VALUE;
+        String bestScope = null;
+        var searchFrom = 0;
+        var skuIndex = text.indexOf(expectedSku, searchFrom);
+
+        while (skuIndex >= 0) {
+            var matcher = PRICE.matcher(text);
+            var priceStart = -1;
+            var priceEnd = -1;
+            while (matcher.find() && matcher.end() <= skuIndex) {
+                priceStart = matcher.start();
+                priceEnd = matcher.end();
+            }
+
+            if (priceEnd >= 0) {
+                var distance = skuIndex - priceEnd;
+                if (distance < bestDistance) {
+                    var scopeStart = Math.max(0, priceStart - PRICE_BOUND_PROMO_WINDOW);
+                    var currentArticleMarker = text.lastIndexOf(ARTICLE_MARKER, skuIndex);
+                    var previousArticleMarker = currentArticleMarker >= 0
+                            ? text.lastIndexOf(ARTICLE_MARKER, currentArticleMarker - 1)
+                            : -1;
+                    if (previousArticleMarker >= scopeStart) {
+                        scopeStart = previousArticleMarker + ARTICLE_MARKER.length();
+                    }
+
+                    bestDistance = distance;
+                    bestScope = text.substring(scopeStart, skuIndex);
+                }
+            }
+
+            searchFrom = skuIndex + expectedSku.length();
+            skuIndex = text.indexOf(expectedSku, searchFrom);
+        }
+
+        if (bestScope == null) {
+            return new PriceBoundPromoEvidence(false);
+        }
+
+        var lowerScope = bestScope.toLowerCase(Locale.ROOT);
+        var promoMarker = lowerScope.contains("финальная цена") || DISCOUNT.matcher(bestScope).find();
+        return new PriceBoundPromoEvidence(promoMarker);
+    }
+
     private static List<BigDecimal> distinctPrices(String text) {
         var prices = new ArrayList<BigDecimal>();
         var seen = new LinkedHashSet<BigDecimal>();
@@ -326,7 +386,13 @@ final class MagnitCorpusProbe {
 
     record RawShapeEvidence(boolean multiplePriceCandidates, boolean promoMarker) {}
 
-    private record HttpObservation(int status, PageObservation observation, RawShapeEvidence rawShape) {
+    record PriceBoundPromoEvidence(boolean promoMarker) {}
+
+    private record HttpObservation(
+            int status,
+            PageObservation observation,
+            RawShapeEvidence rawShape,
+            PriceBoundPromoEvidence priceBoundPromo) {
         boolean http2xx() {
             return status >= 200 && status < 300;
         }
@@ -348,6 +414,7 @@ final class MagnitCorpusProbe {
             int promoObservations,
             int nearSkuMultiplePriceObservations,
             int nearSkuPromoMarkerObservations,
+            int priceBoundPromoMarkerObservations,
             List<String> failedRequirements) {
 
         String toEvidenceLine() {
@@ -363,6 +430,7 @@ final class MagnitCorpusProbe {
                     + " promo_observations=" + promoObservations
                     + " near_sku_multi_price=" + nearSkuMultiplePriceObservations
                     + " near_sku_promo_marker=" + nearSkuPromoMarkerObservations
+                    + " price_bound_promo_marker=" + priceBoundPromoMarkerObservations
                     + " failed_count=" + failedRequirements.size()
                     + " failed_requirements=" + String.join(",", failedRequirements);
         }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -18,33 +18,14 @@ class MagnitCorpusProbeTest {
         assertThat(corpus).hasSize(20);
         assertThat(corpus.stream().map(MagnitCorpusProbe.CorpusItem::requirement).toList())
                 .containsExactly(
-                        "milk",
-                        "eggs",
-                        "bread",
-                        "bananas",
-                        "potatoes",
-                        "onions",
-                        "tomatoes",
-                        "cucumbers",
-                        "chicken",
-                        "beef/mince",
-                        "rice",
-                        "buckwheat",
-                        "pasta",
-                        "sunflower oil",
-                        "butter",
-                        "cheese",
-                        "kefir",
-                        "sugar",
-                        "salt",
-                        "tea");
-        assertThat(corpus)
-                .allSatisfy(item -> {
-                    assertThat(item.sku()).isNotBlank();
-                    assertThat(item.productSlug()).startsWith(item.sku() + "-");
-                });
-        assertThat(corpus.stream().map(MagnitCorpusProbe.CorpusItem::sku).toList())
-                .doesNotHaveDuplicates();
+                        "milk", "eggs", "bread", "bananas", "potatoes", "onions", "tomatoes", "cucumbers",
+                        "chicken", "beef/mince", "rice", "buckwheat", "pasta", "sunflower oil", "butter",
+                        "cheese", "kefir", "sugar", "salt", "tea");
+        assertThat(corpus).allSatisfy(item -> {
+            assertThat(item.sku()).isNotBlank();
+            assertThat(item.productSlug()).startsWith(item.sku() + "-");
+        });
+        assertThat(corpus.stream().map(MagnitCorpusProbe.CorpusItem::sku).toList()).doesNotHaveDuplicates();
     }
 
     @Test
@@ -53,7 +34,6 @@ class MagnitCorpusProbeTest {
                 .filter(item -> item.requirement().equals("eggs"))
                 .findFirst()
                 .orElseThrow();
-
         assertThat(eggs.sku()).isEqualTo("2047000014");
         assertThat(eggs.productSlug()).isEqualTo("2047000014-yaytso_kurinoe_stolovoe_so_10sht");
     }
@@ -61,7 +41,6 @@ class MagnitCorpusProbeTest {
     @Test
     void parsesCurrentAndRegularPromoPriceBoundToExpectedSku() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("promo-available.html"), "9072651501");
-
         assertThat(observation.skuEvidence()).isTrue();
         assertThat(observation.currentPrice()).contains(new BigDecimal("123.45"));
         assertThat(observation.regularPrice()).contains(new BigDecimal("150.00"));
@@ -72,7 +51,6 @@ class MagnitCorpusProbeTest {
     @Test
     void fallsBackToSkuBoundEmbeddedCurrentPriceWhenRenderedScopeHasNoPrice() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("embedded-current-price.html"), "9072651501");
-
         assertThat(observation.skuEvidence()).isTrue();
         assertThat(observation.currentPrice()).contains(new BigDecimal("123.45"));
         assertThat(observation.regularPrice()).isEmpty();
@@ -83,15 +61,23 @@ class MagnitCorpusProbeTest {
     @Test
     void detectsAggregateSafePromoShapeNearExpectedSku() throws Exception {
         var shape = MagnitCorpusProbe.inspectNearSkuRawShape(fixture("embedded-promo-shape.html"), "9072651501");
-
         assertThat(shape.multiplePriceCandidates()).isTrue();
         assertThat(shape.promoMarker()).isTrue();
     }
 
     @Test
+    void bindsPromoMarkerToTheSelectedSkuPriceEvidence() throws Exception {
+        var promo = MagnitCorpusProbe.inspectPriceBoundPromoShape(fixture("embedded-promo-shape.html"), "9072651501");
+        var nonPromo = MagnitCorpusProbe.inspectPriceBoundPromoShape(
+                fixture("embedded-nonpromo-with-nearby-promo.html"), "9072651501");
+
+        assertThat(promo.promoMarker()).isTrue();
+        assertThat(nonPromo.promoMarker()).isFalse();
+    }
+
+    @Test
     void treatsExplicitProductUnavailabilityAsUnavailable() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("regular-unavailable.html"), "1000135280");
-
         assertThat(observation.currentPrice()).contains(new BigDecimal("111.11"));
         assertThat(observation.regularPrice()).isEmpty();
         assertThat(observation.promo()).isFalse();
@@ -101,7 +87,6 @@ class MagnitCorpusProbeTest {
     @Test
     void keepsAvailabilityUnknownWhenNoExplicitStockSemanticExists() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("regular-unknown.html"), "3152910003");
-
         assertThat(observation.currentPrice()).contains(new BigDecimal("88.88"));
         assertThat(observation.availability()).isEqualTo(MagnitCorpusProbe.Availability.UNKNOWN);
     }
@@ -109,7 +94,6 @@ class MagnitCorpusProbeTest {
     @Test
     void refusesPriceAndAvailabilityWhenExpectedSkuIsMissing() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("promo-available.html"), "1111111111");
-
         assertThat(observation.skuEvidence()).isFalse();
         assertThat(observation.currentPrice()).isEmpty();
         assertThat(observation.regularPrice()).isEmpty();
@@ -120,17 +104,13 @@ class MagnitCorpusProbeTest {
     void evidenceLineIncludesOnlyApprovedFailedRequirementNames() {
         var result = new MagnitCorpusProbe.CorpusResult(
                 20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, List.of("tea", "beef/mince"));
-
-        assertThat(result.toEvidenceLine())
-                .endsWith("failed_count=2 failed_requirements=tea,beef/mince");
-        assertThat(result.toEvidenceLine())
-                .contains("near_sku_multi_price=4 near_sku_promo_marker=3");
+        assertThat(result.toEvidenceLine()).endsWith("failed_count=2 failed_requirements=tea,beef/mince");
+        assertThat(result.toEvidenceLine()).contains("near_sku_multi_price=4 near_sku_promo_marker=3");
     }
 
     @Test
     void livePhaseBCorpusRunsOnlyWhenExplicitlyEnabled() throws Exception {
         assumeTrue(Boolean.getBoolean("zakup.live.magnit.corpus"));
-
         var result = MagnitCorpusProbe.create().runFixedCorpus("139147", "773577");
         System.out.println(result.toEvidenceLine());
 
@@ -147,8 +127,7 @@ class MagnitCorpusProbeTest {
         assertThat(result.nearSkuPromoMarkerObservations()).isBetween(0, 40);
 
         var approvedRequirements = Set.copyOf(MagnitCorpusProbe.fixedCorpus().stream()
-                .map(MagnitCorpusProbe.CorpusItem::requirement)
-                .toList());
+                .map(MagnitCorpusProbe.CorpusItem::requirement).toList());
         assertThat(result.failedRequirements()).allSatisfy(requirement -> assertThat(approvedRequirements).contains(requirement));
     }
 

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -103,9 +103,10 @@ class MagnitCorpusProbeTest {
     @Test
     void evidenceLineIncludesOnlyApprovedFailedRequirementNames() {
         var result = new MagnitCorpusProbe.CorpusResult(
-                20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, List.of("tea", "beef/mince"));
+                20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, 2, List.of("tea", "beef/mince"));
         assertThat(result.toEvidenceLine()).endsWith("failed_count=2 failed_requirements=tea,beef/mince");
         assertThat(result.toEvidenceLine()).contains("near_sku_multi_price=4 near_sku_promo_marker=3");
+        assertThat(result.toEvidenceLine()).contains("price_bound_promo_marker=2");
     }
 
     @Test
@@ -125,6 +126,7 @@ class MagnitCorpusProbeTest {
         assertThat(result.promoObservations()).isBetween(0, 40);
         assertThat(result.nearSkuMultiplePriceObservations()).isBetween(0, 40);
         assertThat(result.nearSkuPromoMarkerObservations()).isBetween(0, 40);
+        assertThat(result.priceBoundPromoMarkerObservations()).isBetween(0, 40);
 
         var approvedRequirements = Set.copyOf(MagnitCorpusProbe.fixedCorpus().stream()
                 .map(MagnitCorpusProbe.CorpusItem::requirement).toList());

--- a/apps/api/src/test/resources/provider/magnit/embedded-nonpromo-with-nearby-promo.html
+++ b/apps/api/src/test/resources/provider/magnit/embedded-nonpromo-with-nearby-promo.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <script type="application/json">
+      {"cards":["<div>Финальная цена 77 ₽ -10% Артикул 1111111111</div>","<div>123,45 ₽ Артикул 9072651501</div>"]}
+    </script>
+  </head>
+  <body>
+    <h1>Санитизированный товар без промо</h1>
+    <button>Добавить в корзину</button>
+    <section>Характеристики Артикул 9072651501</section>
+  </body>
+</html>


### PR DESCRIPTION
## Goal
Determine whether Magnit promo markers can be bound to the same SKU-local price evidence used by the public-page current-price path, instead of relying on the intentionally broad near-SKU diagnostic.

Tracking: #45.

## Triggering evidence
Merged-main run `31542338546` on SHA `650a4a090e49cdfa1dec5dd63d8b00be81ebe4c3` kept full 20/20 corpus coverage and emitted:

`promo_observations=0 near_sku_multi_price=0 near_sku_promo_marker=40`

A 40/40 broad marker count is not trustworthy enough to set `promo=true`; neighboring/template content may contaminate the 900-character research window.

## RED → GREEN evidence
### RED
Head `5272172c14afb161855f2c341ee106e9180785ca` added a sanitized negative-binding fixture and `bindsPromoMarkerToTheSelectedSkuPriceEvidence` only.

`API CI` reached Java/Maven `testCompile` and failed exactly because `MagnitCorpusProbe.inspectPriceBoundPromoShape(String,String)` did not exist.

The negative fixture deliberately places a promo marker on an unrelated preceding SKU and a non-promo current price on the expected SKU.

### GREEN
Head `6863e53bc8e30b714e489283ad1a23d7e6976964` implements diagnostic-only price binding:
- for each expected-SKU occurrence, find the closest preceding RUB-price token;
- select the price/SKU pair with minimum distance;
- inspect only a short 160-character region before the selected price through the SKU;
- if a previous `Артикул` boundary enters that region, start after it so a neighboring product cannot donate its promo marker;
- return one boolean `PriceBoundPromoEvidence.promoMarker`;
- aggregate only the count as `price_bound_promo_marker` across the 40 live observations.

The RED test is unchanged and full API verification now passes. The positive fixture binds a promo marker to the selected expected-SKU price; the contaminated negative fixture correctly remains non-promo.

## Trust / privacy boundary
- diagnostics do not alter `parseProductPage`, current price, regular price, promo output, availability, `usable`, stable identity, live request policy, or `observed-full` logic;
- the price-bound signal remains research evidence only and cannot itself promote support status;
- only an aggregate count is emitted;
- no numeric live prices, HTML, URL/SKU details, addresses, cookies, tokens, request headers, or response bodies are persisted;
- no workflow permission changes are introduced.

## Post-merge diagnostic
After full exact-head CI/security verification and merge, rerun `/provider-probe magnit-corpus` on issue #45. Compare `price_bound_promo_marker` with the already-proven 20/20 corpus evidence before deciding whether a separate promo parser fallback is justified.

## Non-goal
This PR does not promote Magnit support status and does not implement regular/promo fallback.