### PR TITLE
fix(provider): preserve Magnit promo status without inventing regular price

### DIFF
--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -224,10 +224,12 @@ final class MagnitCorpusProbe {
                 : Optional.of(prices.getFirst());
 
         Optional<BigDecimal> regularPrice = Optional.empty();
-        var promoMarker = lowerText.contains("финальная цена") || DISCOUNT.matcher(text).find();
-        if (promoMarker && prices.size() >= 2 && prices.get(1).compareTo(prices.getFirst()) > 0) {
+        var renderedPromoMarker = lowerText.contains("финальная цена") || DISCOUNT.matcher(text).find();
+        if (renderedPromoMarker && prices.size() >= 2 && prices.get(1).compareTo(prices.getFirst()) > 0) {
             regularPrice = Optional.of(prices.get(1));
         }
+        var promo = renderedPromoMarker
+                || (currentPrice.isPresent() && inspectPriceBoundPromoShape(html, expectedSku).promoMarker());
 
         var availability = Availability.UNKNOWN;
         if (lowerText.contains("нет в наличии")) {
@@ -240,7 +242,7 @@ final class MagnitCorpusProbe {
                 true,
                 currentPrice,
                 regularPrice,
-                regularPrice.isPresent(),
+                promo,
                 availability);
     }
 

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -76,6 +76,18 @@ class MagnitCorpusProbeTest {
     }
 
     @Test
+    void marksPriceBoundPromoWithoutInventingRegularPrice() throws Exception {
+        var observation = MagnitCorpusProbe.parseProductPage(fixture("embedded-single-price-promo.html"), "9072651501");
+        var contaminated = MagnitCorpusProbe.parseProductPage(
+                fixture("embedded-nonpromo-with-nearby-promo.html"), "9072651501");
+
+        assertThat(observation.currentPrice()).contains(new BigDecimal("123.45"));
+        assertThat(observation.regularPrice()).isEmpty();
+        assertThat(observation.promo()).isTrue();
+        assertThat(contaminated.promo()).isFalse();
+    }
+
+    @Test
     void treatsExplicitProductUnavailabilityAsUnavailable() throws Exception {
         var observation = MagnitCorpusProbe.parseProductPage(fixture("regular-unavailable.html"), "1000135280");
         assertThat(observation.currentPrice()).contains(new BigDecimal("111.11"));

--- a/apps/api/src/test/resources/provider/magnit/embedded-single-price-promo.html
+++ b/apps/api/src/test/resources/provider/magnit/embedded-single-price-promo.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <script type="application/json">
+      {"cards":["<div>77 ₽ Артикул 1111111111</div>","<div>Финальная цена 123,45 ₽ +5% с Премиум Артикул 9072651501</div>"]}
+    </script>
+  </head>
+  <body>
+    <h1>Санитизированный товар с promo-status без regular price</h1>
+    <button>Добавить в корзину</button>
+    <section>Характеристики Артикул 9072651501</section>
+  </body>
+</html>


### PR DESCRIPTION
## Goal
Preserve Magnit promo/special-price status when the public page exposes a price-bound promo marker for an already confirmed SKU, without inventing a regular/old price when only one supported price is present.

Tracking: #45.

## Triggering merged-main evidence
Phase B is technically full-coverage for the fixed corpus in both explicit store contexts. Run `31543089595` on merged `main` SHA `9f26ddfc72e1cc5ff42d7b1a2da99cd0de77dd28` emitted:

`MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=20 second_http_2xx=20 first_usable=20 second_usable=20 stable_identity=20 known_availability=6 promo_observations=0 near_sku_multi_price=0 near_sku_promo_marker=40 price_bound_promo_marker=40 failed_count=0 failed_requirements=`

The diagnostic proves the promo marker is bound to the selected SKU-price pair on all 40 observations, while no second nearby RUB-price candidate is proven.

Current official Magnit public pages also show the marker is store/product-context dependent rather than a universal page template: the same product can appear with `Финальная цена` in one store context and without it in another, while some products separately expose current + regular price + discount.

## RED → GREEN evidence
### RED
Head `475fd7920e87c11b4d3245d757748c6e2b07af77` added only the sanitized `embedded-single-price-promo.html` fixture plus `marksPriceBoundPromoWithoutInventingRegularPrice`.

`API CI` ran 44 tests and failed exactly one assertion: current price was already correctly `123.45`, `regularPrice` was correctly empty, but `promo` was `false` instead of the required `true`. The contaminated neighboring-SKU negative case did not introduce a second failure.

### GREEN
Head `e088a002be5fac0c69233efda6c52415ccf1552d` keeps all existing price/identity semantics and changes promo status only:
- rendered product-scope promo marker still counts;
- for a confirmed SKU with current price, the already-tested price-bound marker may also set `promo=true`;
- `regularPrice` remains populated only when a second higher supported rendered price is actually present;
- a promo marker alone never synthesizes a regular price;
- availability semantics remain unchanged.

The RED regression is unchanged and full API verification now passes.

## Safety / non-goals
- no new network path;
- no live request-policy or workflow-permission change;
- no cookies/auth/partner keys/browser/anti-bot/proxy/retry behavior;
- no raw HTML or numeric live price persistence;
- no automatic Magnit support-status promotion in this PR;
- production usage-rights and location→shopCode resolution remain separate scorecard items.

## Post-merge gate
After full exact-head CI/security verification and merge, rerun `/provider-probe magnit-corpus` on issue #45. Only that merged-main result may confirm live `promo_observations` semantics and feed the explicit Phase B acceptance decision.