### PR TITLE
feat(retailer): add M1 canonical retailer registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - `AVAILABLE_PUBLIC_WEB` technical feasibility decision for Magnit explicit store contexts.
 - M0 → M1 GO decision recording completion of technical discovery and approval to begin M1 Shopping Core.
 - Explicit Magnit follow-up issues for safe location → `shopCode` resolution (#69) and production catalog usage-rights verification (#70).
+- M1 canonical retailer registry covering Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat with explicit technical coverage and independent production-access status.
 
 ### Changed
 
@@ -26,6 +27,8 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Magnit supplies the accepted independent non-X5 path and proves public web as a second acquisition mode alongside the browser bridge.
 - M1 entry rules are fixture-first, coverage-explicit, provenance-aware, fulfillment-context-aware and fail-closed for freshness, availability and unresolved production usage rights.
 - Retailer onboarding remains transport-neutral; direct API failure changes the acquisition mode under investigation rather than removing the retailer from scope.
+- Technical retailer connectivity and production-access readiness are modeled as separate decisions so an accepted feasibility path cannot silently enable production acquisition.
+- Kuper remains acquisition-provider/aggregator provenance rather than a retailer/banner identity in the canonical retailer registry.
 - `docs/README.md`, `docs/PROJECT_STATE.md`, `docs/ROADMAP.md`, the feasibility matrix and Magnit evidence documents were synchronized around the M0 completion decision.
 
 ### Fixed

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/ProductionAccessStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/ProductionAccessStatus.java
@@ -1,0 +1,12 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+public enum ProductionAccessStatus {
+    NOT_ASSESSED,
+    UNRESOLVED,
+    ACCEPTABLE,
+    BLOCKED;
+
+    public boolean isProductionReady() {
+        return this == ACCEPTABLE;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/Retailer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/Retailer.java
@@ -1,0 +1,35 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+import java.util.Objects;
+
+public final class Retailer {
+
+    private final RetailerId id;
+
+    public Retailer(RetailerId id) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+    }
+
+    public RetailerId id() {
+        return id;
+    }
+
+    public String canonicalId() {
+        return id.canonicalId();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof Retailer retailer && id == retailer.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return canonicalId();
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerCoverageState.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerCoverageState.java
@@ -1,0 +1,22 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+public enum RetailerCoverageState {
+    REQUIRED_UNIMPLEMENTED(false),
+    DISCOVERY(false),
+    AVAILABLE_DIRECT(true),
+    AVAILABLE_AGGREGATOR(true),
+    AVAILABLE_PUBLIC_WEB(true),
+    AVAILABLE_BROWSER_BRIDGE(true),
+    DEGRADED(false),
+    BLOCKED_EXTERNAL(false);
+
+    private final boolean technicallyAvailable;
+
+    RetailerCoverageState(boolean technicallyAvailable) {
+        this.technicallyAvailable = technicallyAvailable;
+    }
+
+    public boolean isTechnicallyAvailable() {
+        return technicallyAvailable;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerId.java
@@ -1,0 +1,22 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+public enum RetailerId {
+    PYATEROCHKA("pyaterochka"),
+    PEREKRESTOK("perekrestok"),
+    CHIZHIK("chizhik"),
+    MAGNIT("magnit"),
+    LENTA("lenta"),
+    VKUSVILL("vkusvill"),
+    OZON_FRESH("ozon-fresh"),
+    SAMOKAT("samokat");
+
+    private final String canonicalId;
+
+    RetailerId(String canonicalId) {
+        this.canonicalId = canonicalId;
+    }
+
+    public String canonicalId() {
+        return canonicalId;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistry.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistry.java
@@ -1,0 +1,88 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class RetailerRegistry {
+
+    private static final RetailerRegistry INITIAL = new RetailerRegistry(List.of(
+            entry(
+                    RetailerId.PYATEROCHKA,
+                    RetailerCoverageState.AVAILABLE_BROWSER_BRIDGE,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.PEREKRESTOK,
+                    RetailerCoverageState.AVAILABLE_BROWSER_BRIDGE,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.CHIZHIK,
+                    RetailerCoverageState.DISCOVERY,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.MAGNIT,
+                    RetailerCoverageState.AVAILABLE_PUBLIC_WEB,
+                    ProductionAccessStatus.UNRESOLVED),
+            entry(
+                    RetailerId.LENTA,
+                    RetailerCoverageState.DISCOVERY,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.VKUSVILL,
+                    RetailerCoverageState.DISCOVERY,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.OZON_FRESH,
+                    RetailerCoverageState.DISCOVERY,
+                    ProductionAccessStatus.NOT_ASSESSED),
+            entry(
+                    RetailerId.SAMOKAT,
+                    RetailerCoverageState.DISCOVERY,
+                    ProductionAccessStatus.NOT_ASSESSED)));
+
+    private final List<RetailerRegistryEntry> entries;
+    private final Map<RetailerId, RetailerRegistryEntry> entriesById;
+
+    private RetailerRegistry(List<RetailerRegistryEntry> entries) {
+        this.entries = List.copyOf(entries);
+
+        var byId = new EnumMap<RetailerId, RetailerRegistryEntry>(RetailerId.class);
+        for (var entry : this.entries) {
+            var previous = byId.put(entry.retailer().id(), entry);
+            if (previous != null) {
+                throw new IllegalArgumentException("duplicate retailer id: " + entry.retailer().canonicalId());
+            }
+        }
+
+        if (!byId.keySet().equals(EnumSet.allOf(RetailerId.class))) {
+            throw new IllegalStateException("initial retailer registry must cover every canonical retailer id");
+        }
+        this.entriesById = Map.copyOf(byId);
+    }
+
+    public static RetailerRegistry initial() {
+        return INITIAL;
+    }
+
+    public List<RetailerRegistryEntry> entries() {
+        return entries;
+    }
+
+    public RetailerRegistryEntry require(RetailerId retailerId) {
+        Objects.requireNonNull(retailerId, "retailerId must not be null");
+        var entry = entriesById.get(retailerId);
+        if (entry == null) {
+            throw new IllegalArgumentException("unknown retailer id: " + retailerId);
+        }
+        return entry;
+    }
+
+    private static RetailerRegistryEntry entry(
+            RetailerId retailerId,
+            RetailerCoverageState coverageState,
+            ProductionAccessStatus productionAccessStatus) {
+        return new RetailerRegistryEntry(new Retailer(retailerId), coverageState, productionAccessStatus);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistryEntry.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistryEntry.java
@@ -1,0 +1,19 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+import java.util.Objects;
+
+public record RetailerRegistryEntry(
+        Retailer retailer,
+        RetailerCoverageState coverageState,
+        ProductionAccessStatus productionAccessStatus) {
+
+    public RetailerRegistryEntry {
+        retailer = Objects.requireNonNull(retailer, "retailer must not be null");
+        coverageState = Objects.requireNonNull(coverageState, "coverageState must not be null");
+        productionAccessStatus = Objects.requireNonNull(productionAccessStatus, "productionAccessStatus must not be null");
+    }
+
+    public boolean isProductionReady() {
+        return coverageState.isTechnicallyAvailable() && productionAccessStatus.isProductionReady();
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistryTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/retailer/RetailerRegistryTest.java
@@ -1,0 +1,81 @@
+package io.github.trueruslan.zakupgotov.retailer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RetailerRegistryTest {
+
+    private final RetailerRegistry registry = RetailerRegistry.initial();
+
+    @Test
+    void exposesEveryInitialRetailerBannerInStableProductOrder() {
+        assertThat(registry.entries())
+                .extracting(entry -> entry.retailer().id())
+                .containsExactly(
+                        RetailerId.PYATEROCHKA,
+                        RetailerId.PEREKRESTOK,
+                        RetailerId.CHIZHIK,
+                        RetailerId.MAGNIT,
+                        RetailerId.LENTA,
+                        RetailerId.VKUSVILL,
+                        RetailerId.OZON_FRESH,
+                        RetailerId.SAMOKAT);
+    }
+
+    @Test
+    void preservesAcceptedM0ConnectivityWithoutClaimingProductionClearance() {
+        assertCoverage(
+                RetailerId.PYATEROCHKA,
+                RetailerCoverageState.AVAILABLE_BROWSER_BRIDGE,
+                ProductionAccessStatus.NOT_ASSESSED);
+        assertCoverage(
+                RetailerId.PEREKRESTOK,
+                RetailerCoverageState.AVAILABLE_BROWSER_BRIDGE,
+                ProductionAccessStatus.NOT_ASSESSED);
+        assertCoverage(
+                RetailerId.MAGNIT,
+                RetailerCoverageState.AVAILABLE_PUBLIC_WEB,
+                ProductionAccessStatus.UNRESOLVED);
+    }
+
+    @Test
+    void keepsMandatoryUnimplementedRetailersVisibleAsDiscoveryWork() {
+        assertThat(List.of(
+                        RetailerId.CHIZHIK,
+                        RetailerId.LENTA,
+                        RetailerId.VKUSVILL,
+                        RetailerId.OZON_FRESH,
+                        RetailerId.SAMOKAT))
+                .allSatisfy(retailerId -> assertCoverage(
+                        retailerId,
+                        RetailerCoverageState.DISCOVERY,
+                        ProductionAccessStatus.NOT_ASSESSED));
+    }
+
+    @Test
+    void doesNotConflateAggregatorProviderWithRetailerIdentity() {
+        assertThat(registry.entries())
+                .extracting(entry -> entry.retailer().canonicalId())
+                .doesNotContain("kuper");
+    }
+
+    @Test
+    void distinguishesTechnicalConnectivityFromProductionAccess() {
+        var magnit = registry.require(RetailerId.MAGNIT);
+
+        assertThat(magnit.coverageState().isTechnicallyAvailable()).isTrue();
+        assertThat(magnit.productionAccessStatus()).isEqualTo(ProductionAccessStatus.UNRESOLVED);
+        assertThat(magnit.isProductionReady()).isFalse();
+    }
+
+    private void assertCoverage(
+            RetailerId retailerId,
+            RetailerCoverageState expectedCoverage,
+            ProductionAccessStatus expectedProductionAccess) {
+        var entry = registry.require(retailerId);
+        assertThat(entry.coverageState()).isEqualTo(expectedCoverage);
+        assertThat(entry.productionAccessStatus()).isEqualTo(expectedProductionAccess);
+    }
+}


### PR DESCRIPTION
## Goal
Implement M1 slice 1: canonical retailer/banner registry plus explicit technical coverage and production-access state.

## Architectural boundaries
- retailer identity is distinct from provider/aggregator identity; Kuper is not a retailer banner;
- technical connectivity does not imply production clearance;
- unavailable mandatory retailers remain visible rather than silently omitted;
- accepted M0 connectivity states are preserved exactly;
- no live retailer traffic is introduced;
- `ObservedOffer` provenance evolution is intentionally deferred to the later provider-orchestration/snapshot slice to keep this PR atomic.

## TDD evidence
### RED
Head `fca8c6468277c60625d4ad513daa3464f5a9aa91` contained only `RetailerRegistryTest`. `API CI` reached Maven `testCompile` and failed because `RetailerRegistry`, `RetailerId`, `RetailerCoverageState` and `ProductionAccessStatus` did not exist. No production registry implementation existed.

### GREEN
Production implementation adds:
- canonical `RetailerId` values for Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat;
- `Retailer` identity wrapper with stable canonical IDs;
- approved `RetailerCoverageState` vocabulary and explicit technical-availability semantics;
- orthogonal `ProductionAccessStatus` so feasibility does not imply production clearance;
- immutable `RetailerRegistryEntry`;
- canonical immutable `RetailerRegistry.initial()` with fail-fast complete-enum coverage and duplicate protection.

The original RED contract is unchanged. Full Maven `verify` passes on the GREEN implementation and again on final documentation head `8d69d70d10253b62b675fe6a2de84df6ca991baa`.

## Initial registry state
- Pyaterochka: `AVAILABLE_BROWSER_BRIDGE`, production access `NOT_ASSESSED`;
- Perekrestok: `AVAILABLE_BROWSER_BRIDGE`, production access `NOT_ASSESSED`;
- Magnit: `AVAILABLE_PUBLIC_WEB`, production access `UNRESOLVED`;
- Chizhik, Lenta, VkusVill, Ozon Fresh, Samokat: `DISCOVERY`, production access `NOT_ASSESSED`.

Kuper intentionally remains provider/aggregator provenance rather than retailer identity.

## Documentation
`CHANGELOG.md` records the first M1 domain slice and the separation between technical connectivity and production-access readiness.

## Non-goals
- no retailer coverage API endpoint yet;
- no shopping-list aggregate yet;
- no provider-path orchestration yet;
- no `ObservedOffer` schema change;
- no production activation of Magnit or any unresolved acquisition path;
- no live retailer calls in ordinary CI.

## Next after merge
M1 slice 2: shopping-list aggregate + canonical quantity/unit primitives, followed by deterministic provider/path orchestration.