### PR TITLE
feat(shopping): add M1 shopping-list core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M0 → M1 GO decision recording completion of technical discovery and approval to begin M1 Shopping Core.
 - Explicit Magnit follow-up issues for safe location → `shopCode` resolution (#69) and production catalog usage-rights verification (#70).
 - M1 canonical retailer registry covering Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat with explicit technical coverage and independent production-access status.
+- M1 canonical quantity primitives: positive decimal quantities, `kg → g`, `l → ml`, piece quantities and stable normalized `BigDecimal` equality.
+- M1 shopping-list aggregate with UUID list/item identity, stable insertion order, immutable item views, whitespace-only requirement normalization and explicit add/replace/remove semantics.
 
 ### Changed
 
@@ -29,7 +31,10 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Retailer onboarding remains transport-neutral; direct API failure changes the acquisition mode under investigation rather than removing the retailer from scope.
 - Technical retailer connectivity and production-access readiness are modeled as separate decisions so an accepted feasibility path cannot silently enable production acquisition.
 - Kuper remains acquisition-provider/aggregator provenance rather than a retailer/banner identity in the canonical retailer registry.
-- `docs/README.md`, `docs/PROJECT_STATE.md`, `docs/ROADMAP.md`, the feasibility matrix and Magnit evidence documents were synchronized around the M0 completion decision.
+- Shopping requirements canonicalize measurement dimensions before matching while deliberately leaving package/container selection to later matching/basket optimization.
+- Requirement text normalization is intentionally limited to whitespace in the shopping domain; synonyms, aliases, categories and semantic canonicalization remain matching responsibilities.
+- Automatic duplicate-item merging is not performed by the M1 shopping-list aggregate; recipe/weekly-plan consolidation remains later scope.
+- `docs/PROJECT_STATE.md` and `docs/ROADMAP.md` now mark the retailer registry and shopping-list/quantity slices complete and move the active M1 focus to provider/path orchestration.
 
 ### Fixed
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/Quantity.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/Quantity.java
@@ -1,0 +1,23 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record Quantity(BigDecimal amount, QuantityUnit unit) {
+
+    public Quantity {
+        amount = Objects.requireNonNull(amount, "amount must not be null");
+        unit = Objects.requireNonNull(unit, "unit must not be null");
+        if (amount.signum() <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+
+        amount = normalize(unit.toCanonicalAmount(amount));
+        unit = unit.canonicalUnit();
+    }
+
+    private static BigDecimal normalize(BigDecimal value) {
+        var normalized = value.stripTrailingZeros();
+        return normalized.scale() < 0 ? normalized.setScale(0) : normalized;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/QuantityUnit.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/QuantityUnit.java
@@ -1,0 +1,26 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.math.BigDecimal;
+
+public enum QuantityUnit {
+    PIECE,
+    GRAM,
+    KILOGRAM,
+    MILLILITER,
+    LITER;
+
+    QuantityUnit canonicalUnit() {
+        return switch (this) {
+            case KILOGRAM -> GRAM;
+            case LITER -> MILLILITER;
+            default -> this;
+        };
+    }
+
+    BigDecimal toCanonicalAmount(BigDecimal amount) {
+        return switch (this) {
+            case KILOGRAM, LITER -> amount.movePointRight(3);
+            default -> amount;
+        };
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingItem.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingItem.java
@@ -1,0 +1,15 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.util.Objects;
+
+public record ShoppingItem(
+        ShoppingItemId id,
+        ShoppingRequirement requirement,
+        Quantity quantity) {
+
+    public ShoppingItem {
+        id = Objects.requireNonNull(id, "id must not be null");
+        requirement = Objects.requireNonNull(requirement, "requirement must not be null");
+        quantity = Objects.requireNonNull(quantity, "quantity must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingItemId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingItemId.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ShoppingItemId(UUID value) {
+
+    public ShoppingItemId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingList.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingList.java
@@ -1,0 +1,46 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ShoppingList {
+
+    private final ShoppingListId id;
+    private final Map<ShoppingItemId, ShoppingItem> items = new LinkedHashMap<>();
+
+    public ShoppingList(ShoppingListId id) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+    }
+
+    public ShoppingListId id() {
+        return id;
+    }
+
+    public List<ShoppingItem> items() {
+        return List.copyOf(items.values());
+    }
+
+    public void add(ShoppingItem item) {
+        Objects.requireNonNull(item, "item must not be null");
+        if (items.putIfAbsent(item.id(), item) != null) {
+            throw new IllegalArgumentException("duplicate shopping item id: " + item.id().value());
+        }
+    }
+
+    public void replace(ShoppingItem item) {
+        Objects.requireNonNull(item, "item must not be null");
+        if (!items.containsKey(item.id())) {
+            throw new IllegalArgumentException("unknown shopping item id: " + item.id().value());
+        }
+        items.put(item.id(), item);
+    }
+
+    public void remove(ShoppingItemId itemId) {
+        Objects.requireNonNull(itemId, "itemId must not be null");
+        if (items.remove(itemId) == null) {
+            throw new IllegalArgumentException("unknown shopping item id: " + itemId.value());
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingListId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingListId.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ShoppingListId(UUID value) {
+
+    public ShoppingListId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingRequirement.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/shopping/ShoppingRequirement.java
@@ -1,0 +1,15 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import java.util.Objects;
+
+public record ShoppingRequirement(String text) {
+
+    public ShoppingRequirement {
+        text = Objects.requireNonNull(text, "text must not be null")
+                .strip()
+                .replaceAll("\\s+", " ");
+        if (text.isBlank()) {
+            throw new IllegalArgumentException("text must not be blank");
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/shopping/QuantityTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/shopping/QuantityTest.java
@@ -1,0 +1,45 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class QuantityTest {
+
+    @Test
+    void normalizesMassToGrams() {
+        assertThat(new Quantity(new BigDecimal("1.25"), QuantityUnit.KILOGRAM))
+                .isEqualTo(new Quantity(new BigDecimal("1250"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void normalizesVolumeToMilliliters() {
+        assertThat(new Quantity(new BigDecimal("1.5"), QuantityUnit.LITER))
+                .isEqualTo(new Quantity(new BigDecimal("1500"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void preservesCanonicalPieceQuantity() {
+        assertThat(new Quantity(new BigDecimal("3"), QuantityUnit.PIECE))
+                .isEqualTo(new Quantity(new BigDecimal("3.0"), QuantityUnit.PIECE));
+    }
+
+    @Test
+    void rejectsNonPositiveAmount() {
+        assertThatThrownBy(() -> new Quantity(BigDecimal.ZERO, QuantityUnit.GRAM))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amount");
+        assertThatThrownBy(() -> new Quantity(new BigDecimal("-0.1"), QuantityUnit.MILLILITER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amount");
+    }
+
+    @Test
+    void rejectsMissingUnit() {
+        assertThatThrownBy(() -> new Quantity(BigDecimal.ONE, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("unit");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/shopping/ShoppingListTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/shopping/ShoppingListTest.java
@@ -1,0 +1,114 @@
+package io.github.trueruslan.zakupgotov.shopping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ShoppingListTest {
+
+    private static final ShoppingListId LIST_ID = new ShoppingListId(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"));
+    private static final ShoppingItemId MILK_ID = new ShoppingItemId(
+            UUID.fromString("22222222-2222-2222-2222-222222222222"));
+    private static final ShoppingItemId BREAD_ID = new ShoppingItemId(
+            UUID.fromString("33333333-3333-3333-3333-333333333333"));
+
+    @Test
+    void addsRequirementsInStableOrderAndNormalizesOnlyWhitespace() {
+        var list = new ShoppingList(LIST_ID);
+
+        list.add(new ShoppingItem(
+                MILK_ID,
+                new ShoppingRequirement("  Молоко   2.5%  "),
+                new Quantity(BigDecimal.ONE, QuantityUnit.LITER)));
+        list.add(new ShoppingItem(
+                BREAD_ID,
+                new ShoppingRequirement("Хлеб бородинский"),
+                new Quantity(BigDecimal.ONE, QuantityUnit.PIECE)));
+
+        assertThat(list.id()).isEqualTo(LIST_ID);
+        assertThat(list.items())
+                .extracting(item -> item.requirement().text())
+                .containsExactly("Молоко 2.5%", "Хлеб бородинский");
+        assertThat(list.items().getFirst().quantity())
+                .isEqualTo(new Quantity(new BigDecimal("1000"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void replacesExistingItemWithoutChangingItsPosition() {
+        var list = populatedList();
+
+        list.replace(new ShoppingItem(
+                MILK_ID,
+                new ShoppingRequirement("Кефир"),
+                new Quantity(new BigDecimal("0.9"), QuantityUnit.LITER)));
+
+        assertThat(list.items())
+                .extracting(ShoppingItem::id)
+                .containsExactly(MILK_ID, BREAD_ID);
+        assertThat(list.items().getFirst().requirement().text()).isEqualTo("Кефир");
+        assertThat(list.items().getFirst().quantity())
+                .isEqualTo(new Quantity(new BigDecimal("900"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void removesExistingItem() {
+        var list = populatedList();
+
+        list.remove(MILK_ID);
+
+        assertThat(list.items())
+                .extracting(ShoppingItem::id)
+                .containsExactly(BREAD_ID);
+    }
+
+    @Test
+    void rejectsDuplicateOrUnknownItemIdentifiers() {
+        var list = populatedList();
+
+        assertThatThrownBy(() -> list.add(new ShoppingItem(
+                        MILK_ID,
+                        new ShoppingRequirement("Молоко другое"),
+                        new Quantity(BigDecimal.ONE, QuantityUnit.PIECE))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate");
+
+        var unknown = new ShoppingItemId(UUID.fromString("44444444-4444-4444-4444-444444444444"));
+        assertThatThrownBy(() -> list.replace(new ShoppingItem(
+                        unknown,
+                        new ShoppingRequirement("Сахар"),
+                        new Quantity(BigDecimal.ONE, QuantityUnit.KILOGRAM))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown");
+        assertThatThrownBy(() -> list.remove(unknown))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown");
+    }
+
+    @Test
+    void rejectsBlankRequirementAndExposesImmutableItemView() {
+        assertThatThrownBy(() -> new ShoppingRequirement("   \t "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("text");
+
+        var list = populatedList();
+        assertThatThrownBy(() -> list.items().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private static ShoppingList populatedList() {
+        var list = new ShoppingList(LIST_ID);
+        list.add(new ShoppingItem(
+                MILK_ID,
+                new ShoppingRequirement("Молоко"),
+                new Quantity(BigDecimal.ONE, QuantityUnit.LITER)));
+        list.add(new ShoppingItem(
+                BREAD_ID,
+                new ShoppingRequirement("Хлеб"),
+                new Quantity(BigDecimal.ONE, QuantityUnit.PIECE)));
+        return list;
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **implement the retailer registry/coverage-state model and shopping-list core over deterministic provider observations without enabling unresolved production acquisition paths**
+Current focus: **provider/path orchestration over deterministic fixtures with explicit retailer/source-provider/acquisition-mode provenance**
 
 ## Product connectivity invariant
 
@@ -19,16 +19,11 @@ Universal Retailer Connectivity remains a permanent product rule beyond M0:
 
 > Every retailer/banner in the target registry remains mandatory coverage work until at least one reproducible accepted acquisition path exists. A failed transport changes the acquisition mode under investigation; it does not remove the retailer from product scope.
 
-Accepted acquisition-mode families are:
-
-1. supported/partner API;
-2. aggregator-backed observations with explicit provider/retailer provenance;
-3. stable public web/API surfaces;
-4. user-assisted first-party browser bridge.
+Accepted acquisition-mode families are supported/partner API, aggregator-backed observations, stable public web/API surfaces and user-assisted first-party browser bridge.
 
 ## M0 exit status
 
-All technical M0 exit gates are satisfied:
+All technical M0 exit gates remain satisfied:
 
 | Gate | Status | Evidence |
 |---|---|---|
@@ -37,170 +32,143 @@ All technical M0 exit gates are satisfied:
 | Independent non-X5 accepted technical path | **PASS** | Magnit `AVAILABLE_PUBLIC_WEB` for explicit public `shopCode` contexts |
 | Two distinct acquisition modes | **PASS** | Browser bridge + ordinary public web |
 | Deterministic sanitized verification | **PASS** | Bridge fixtures/E2E + Magnit Phase B fixtures/regressions |
-| Retailer-neutral provider boundary | **PASS** | `ObservedOffer`, provider feasibility harness, retailer registry/adapter boundaries |
+| Retailer-neutral connectivity boundary | **PASS** | provider harness, normalized observations and canonical retailer registry |
 
-M0 completion is a **technical feasibility decision**, not a blanket production-data-access approval.
+M0 completion is a **technical feasibility decision**, not blanket production-data-access approval.
+
+## M1 delivered foundations
+
+### Slice 1 — canonical retailer registry — COMPLETE
+
+PR #72 established the first M1 domain boundary:
+
+- canonical retailer/banner IDs for Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat;
+- explicit `RetailerCoverageState` vocabulary;
+- independent `ProductionAccessStatus` so technical feasibility cannot silently become production activation;
+- immutable registry entries and stable product order;
+- fail-fast invariant requiring every canonical retailer ID to have a registry entry;
+- Kuper intentionally remains acquisition-provider/aggregator provenance rather than retailer identity.
+
+Initial accepted technical states are preserved:
+
+- Pyaterochka — `AVAILABLE_BROWSER_BRIDGE`;
+- Perekrestok — `AVAILABLE_BROWSER_BRIDGE`;
+- Magnit — `AVAILABLE_PUBLIC_WEB`, production access `UNRESOLVED`;
+- Chizhik, Lenta, VkusVill, Ozon Fresh and Samokat — `DISCOVERY`.
+
+### Slice 2 — shopping-list core + canonical quantities — COMPLETE
+
+PR #73 establishes deterministic shopping requirements without provider dependencies:
+
+- `Quantity` accepts positive decimal amounts only;
+- kilograms normalize to grams;
+- liters normalize to milliliters;
+- piece quantities remain piece-based;
+- equivalent decimal representations normalize to stable value equality;
+- package/container units are intentionally not part of the requirement model because package selection belongs to matching/basket optimization;
+- `ShoppingRequirement` performs whitespace-only normalization and preserves user wording/case for later matching;
+- `ShoppingList` owns stable UUID list/item identity and insertion order;
+- add/replace/remove semantics reject duplicate or unknown item IDs instead of guessing;
+- exposed item views are immutable;
+- no automatic duplicate-name merging is performed in M1; recipe/weekly-plan merging remains later scope.
+
+Both M1 slices were implemented through explicit RED→GREEN cycles and verified by full Maven `verify` before final repository gating.
 
 ## Accepted retailer paths
 
 ### Pyaterochka
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**  
-Adapter: `pyaterochka-browser`, v1
-
-Real first-party browser gate from merged `main` on 2026-08-11:
-
-- bridge status `ok`;
-- 12 normalized observations;
-- exactly one fulfillment context;
-- exact `pyaterochka` / `pyaterochka-browser` provenance;
-- adapter version `1`;
-- zero normalized validation failures.
+Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. The real first-party browser gate on 2026-08-11 produced 12 normalized observations, one fulfillment context and zero normalized validation failures. The direct anonymous server path remains unsuitable (`store-403`).
 
 Evidence:
 
 - [`integrations/pyaterochka-browser-bridge-phase-a.md`](integrations/pyaterochka-browser-bridge-phase-a.md);
 - [`integrations/pyaterochka-browser-bridge-live-2026-08-11.md`](integrations/pyaterochka-browser-bridge-live-2026-08-11.md).
 
-The direct anonymous server path remains unsuitable (`store-403`).
-
 ### Perekrestok
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**  
-Adapter: v2
+Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter v2. Repeated real first-party browser evidence produced 90 normalized observations, one fulfillment context and zero acceptance-validation failures.
 
-Repeated real first-party browser gate on 2026-08-11:
-
-- 90 normalized observations;
-- exactly one fulfillment context;
-- adapter version `2`;
-- zero acceptance-validation failures;
-- canonical source references without query/hash.
+Issue #54 remains non-blocking lifecycle hardening for same-document store changes / SPA navigation; accepted page-snapshot operation assumes intended store selection followed by reload.
 
 Evidence:
 
 - [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md);
 - [`integrations/perekrestok-browser-bridge-live-2026-08-11.md`](integrations/perekrestok-browser-bridge-live-2026-08-11.md).
 
-Issue #54 remains non-blocking lifecycle hardening for post-success same-document store changes / SPA navigation. The accepted path assumes intended store selection followed by page reload.
-
 ### Magnit
 
-Status: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context M0 feasibility**
+Status: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context technical feasibility**.
 
-Phase A ordinary public HTTP passed on merged `main` for the same SKU under two explicit public `shopCode` contexts.
-
-Phase B final merged-main run `31544035409` on SHA `3bfadbf3ee569a561a6fc5222df9daebb21a5291` proved:
-
-- 20/20 HTTP 2xx in the first context;
-- 20/20 HTTP 2xx in the second context;
-- 20/20 expected-SKU/current-price usable observations in each context;
-- stable identity 20/20;
-- zero failed requirements;
-- price-bound promo status on all 40 final observations;
-- explicit availability on 6/40 observations and `UNKNOWN` where stock was not proven;
-- no invented regular/old price when a second supported price was absent.
-
-Final evidence:
-
-- [`integrations/magnit-phase-a.md`](integrations/magnit-phase-a.md);
-- [`integrations/magnit-public-page-live-2026-08-12.md`](integrations/magnit-public-page-live-2026-08-12.md);
-- [`integrations/magnit-phase-b.md`](integrations/magnit-phase-b.md);
-- [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
+Final Phase B merged-main evidence proved 20/20 HTTP and usable SKU/current-price observations in each of two explicit public `shopCode` contexts, stable identity 20/20, zero failed requirements, explicit availability where supported and `UNKNOWN` otherwise, plus fail-closed promo/regular-price semantics.
 
 Production constraints remain explicit:
 
 - **#69** — automatic location/address → public `shopCode` resolution is not proven;
 - **#70** — recurring production catalog acquisition usage rights are `UNRESOLVED`.
 
-Therefore M1 must not enable default recurring Magnit production polling until #70 reaches an authoritative `ACCEPTABLE` decision. Explicit/manual store context is the proven feasibility mode until #69 is resolved.
+M1 must not enable default recurring Magnit production polling until #70 reaches an authoritative `ACCEPTABLE` decision.
+
+Evidence:
+
+- [`integrations/magnit-phase-b.md`](integrations/magnit-phase-b.md);
+- [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
 
 ## Provider foundation
 
-Verified M0B infrastructure includes:
+Verified connectivity infrastructure includes:
 
-- normalized `ObservedOffer` trust boundary;
+- current `ObservedOffer` trust boundary;
 - provider-scoped `LocationContext`;
 - normalized `ProductQuery`;
 - `RetailerProvider` port;
 - structural fixture/live provider separation;
 - explicit live-probe entry points;
 - retailer-neutral browser adapter registry;
-- first-class `apps/retailer-bridge` pnpm workspace package;
-- frozen-install, unit, type, build and persistent-Chromium bridge gates;
+- first-class `apps/retailer-bridge` workspace and persistent-Chromium gate;
 - ordinary CI remains free of live retailer network dependencies.
+
+The next M1 domain evolution must update offer provenance to distinguish at least `retailerId`, `sourceProviderId` and acquisition/source mode before multiple accepted paths are orchestrated together.
 
 ## M1 entry rules
 
-M1 Shopping Core is approved to start under these constraints:
-
-1. shopping/basket logic must run deterministically over fixture providers;
-2. retailer coverage state is explicit and unavailable paths are never silently omitted;
+1. shopping/basket logic runs deterministically over fixtures;
+2. retailer coverage remains explicit and unavailable paths are never silently omitted;
 3. retailer, source-provider and fulfillment-context provenance remain distinct;
-4. `UNKNOWN` availability is preserved rather than guessed from product presence;
-5. observation time is not misrepresented as provider-side freshness when no provider timestamp exists;
+4. `UNKNOWN` availability is preserved;
+5. observation time is not misrepresented as provider-side freshness;
 6. production activation respects recorded usage-rights state;
-7. universal retailer connectivity continues for every registry entry after M0.
+7. universal retailer connectivity continues for every registry entry.
 
-Preferred first implementation sequence:
+## Immediate next work
 
-1. canonical retailer registry + coverage-state model;
-2. shopping-list aggregate + canonical quantity/unit primitives;
-3. provider/path orchestration over deterministic fixtures;
-4. location/fulfillment-context input boundary;
-5. price/availability snapshots with provenance/freshness;
-6. deterministic product-matching baseline;
-7. complete single-store basket comparison;
-8. partial-provider failure and unavailable-coverage UX;
-9. critical-journey browser E2E.
+1. **Provider/path orchestration over deterministic fixtures — NEXT**
+   - evolve normalized offer provenance to explicit retailer/source-provider/source-mode fields;
+   - define ordered/capability-aware path selection without blind retailer-specific branches;
+   - preserve partial/path failure explicitly;
+   - keep live adapters outside ordinary CI.
+2. Location / fulfillment-context product boundary.
+3. Price/availability snapshots with provenance and freshness semantics.
+4. Deterministic matching baseline.
+5. Complete single-store basket comparison.
+6. Coverage/failure/freshness UX and critical browser E2E.
 
-## Platform baseline
+## Parallel open work
 
-### Backend
-
-- Java 25;
-- Spring Boot 4.1;
-- Spring MVC + Virtual Threads;
-- Spring Modulith verification;
-- PostgreSQL 18 / Testcontainers PostgreSQL 18.4;
-- Flyway;
-- jOOQ;
-- pgJDBC `42.7.12`.
-
-### Contracts/web
-
-- OpenAPI 3.1;
-- generated `@zakup-gotov/api-client`;
-- generated-schema drift/type gates;
-- Next.js 16.3.0;
-- React 19.2.8;
-- TypeScript 5.9.3;
-- Node 24.18.1;
-- distroless Node 24 Debian 13 non-root runtime;
-- Vitest/Testing Library;
-- Playwright production-browser tests.
-
-### Operations/security
-
-- separate non-root API/web production images;
-- PostgreSQL 18.4 → API → web release topology;
-- CodeQL Java + JS/TS;
-- Dependency Review;
-- Release Bundle/Contract CI;
-- Container Security CI with HIGH/CRITICAL fail-closed scans;
-- Retailer Bridge CI with frozen install + unit/type/build/persistent-Chromium E2E;
-- public Actuator limited to health/liveness/readiness/info.
-
-## Open work
-
-M1 may proceed while these remain explicit parallel items:
-
+- #36 — Kuper supported aggregator access;
 - #54 — browser bridge persistent-session lifecycle hardening;
 - #69 — Magnit location → public `shopCode` resolution;
 - #70 — Magnit production usage-rights decision;
-- #36 — Kuper supported aggregator access;
-- Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and other mandatory retailer registry onboarding;
+- Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and other mandatory retailer onboarding;
 - successful real `v0.1.0-rc.3` release-pipeline proof.
+
+## Platform baseline
+
+Backend: Java 25, Spring Boot 4.1, Spring MVC + Virtual Threads, Spring Modulith, PostgreSQL 18/Testcontainers 18.4, Flyway, jOOQ, pgJDBC `42.7.12`.
+
+Contracts/web: OpenAPI 3.1, generated TypeScript client, Next.js 16.3.0, React 19.2.8, TypeScript 5.9.3, Node 24.18.1, Vitest/Testing Library and Playwright.
+
+Operations/security: non-root API/web images, PostgreSQL→API→web release topology, CodeQL Java + JS/TS, Dependency Review, Release Bundle/Contract CI, fail-closed HIGH/CRITICAL container scans and Retailer Bridge CI.
 
 ## Release-engineering state
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,36 +8,27 @@ The roadmap is evidence-driven. Milestones may change when retailer integration 
 
 Zakup Gotov targets **universal connectivity for the retailer registry**, not a permanently curated subset of easy integrations.
 
-Every retailer/banner added to the target registry is mandatory coverage work until at least one reproducible acquisition path is available. A failed direct API does not remove that retailer from scope; it moves integration work to another accepted path such as a supported aggregator, public web surface, or user-assisted first-party browser bridge.
+Every retailer/banner added to the target registry remains mandatory coverage work until at least one reproducible acquisition path is available. A failed direct path moves integration work to another accepted mode rather than removing the retailer from scope.
 
 Durable design: [`superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`](superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md).
 
 ## M0 — Product & Integration Discovery — COMPLETE
 
-Goal: prove that the core product promise and universal retailer-connectivity architecture are technically viable before substantial shopping-core development.
-
 Decision: **GO to M1** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md).
 
-Final exit status:
+Final technical exit status:
 
-- **Perekrestok retailer-path criterion: satisfied** through `AVAILABLE_BROWSER_BRIDGE`, adapter v2;
-- **Pyaterochka retailer-path criterion: satisfied** through `AVAILABLE_BROWSER_BRIDGE`, adapter v1;
-- **mandatory X5 per-banner criterion: satisfied**;
-- **retailer-bridge workspace maintenance gate: satisfied**;
-- **independent non-X5 retailer criterion: satisfied** through Magnit `AVAILABLE_PUBLIC_WEB` for explicit public `shopCode` contexts;
-- **second distinct acquisition-mode criterion: satisfied** through ordinary public web in addition to the browser bridge;
-- **fixed-corpus/deterministic fixture criterion: satisfied** through Magnit 20×2 Phase B plus bridge fixture/E2E suites;
-- **known limitations recorded rather than hidden: satisfied**.
+- Perekrestok: `AVAILABLE_BROWSER_BRIDGE`, adapter v2;
+- Pyaterochka: `AVAILABLE_BROWSER_BRIDGE`, adapter v1;
+- independent non-X5 path: Magnit `AVAILABLE_PUBLIC_WEB` for explicit `shopCode` contexts;
+- two acquisition modes proven: browser bridge + ordinary public web;
+- deterministic sanitized fixtures/tests proven;
+- retailer-neutral connectivity architecture proven;
+- known limitations recorded rather than hidden.
 
-Magnit final Phase B evidence: [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
+Magnit final evidence: [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
 
-M0 completion is a technical feasibility decision. It does not silently clear unresolved production constraints:
-
-- #69 — automatic Magnit location/address → public `shopCode` resolution remains open;
-- #70 — Magnit recurring production catalog usage rights remain `UNRESOLVED`;
-- #54 — browser bridge post-success SPA/store-change lifecycle hardening remains open.
-
-Universal retailer connectivity remains mandatory after M0; Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill, Kuper and other registry entries are still coverage work.
+M0 completion is technical feasibility, not production access clearance. Issues #69, #70 and #54 remain explicit constraints/hardening work.
 
 ## M1 — Shopping Core — CURRENT
 
@@ -45,56 +36,62 @@ Goal: compare a manually entered grocery list across connected retailers while p
 
 ### Entry rules
 
-- fixture-first provider orchestration; live retailer access is never required for ordinary M1 tests;
-- unavailable/blocked registry entries remain visible rather than silently disappearing;
+- fixture-first provider orchestration;
+- unavailable/blocked registry entries remain visible;
 - retailer identity, source-provider identity and fulfillment context remain distinct;
 - `UNKNOWN` availability remains first-class;
-- observation time is not misrepresented as a provider update timestamp;
-- production activation respects recorded usage-rights status;
-- Magnit recurring automated production polling remains disabled while #70 is unresolved;
-- Magnit automatic location discovery is not claimed while #69 is unresolved.
+- observation time is not misrepresented as provider update time;
+- production activation respects usage-rights state;
+- no ordinary M1 test depends on live retailer access.
 
 ### Implementation sequence
 
-1. **Retailer registry + coverage-state model**
-   - canonical retailer/banner identity;
-   - supported acquisition paths per retailer;
-   - coverage states such as available, unavailable, blocked, unresolved and degraded;
-   - provider/path provenance kept outside shopping-list domain semantics.
-2. **Shopping-list aggregate + canonical quantities/units**
-   - item CRUD;
-   - quantity/unit primitives;
-   - deterministic normalization rules;
-   - validation that rejects ambiguous/invalid quantities rather than guessing.
-3. **Provider/path orchestration over deterministic fixtures**
-   - select an eligible provider/path for a retailer/context;
-   - partial-provider failure remains explicit;
-   - live adapters stay outside ordinary test execution.
+1. **Retailer registry + coverage-state model — COMPLETE (PR #72)**
+   - canonical retailer/banner identities;
+   - explicit technical coverage state;
+   - separate production-access readiness;
+   - Kuper/provider identity kept distinct from retailer identity;
+   - registry completeness fails fast when a canonical retailer is omitted.
+2. **Shopping-list aggregate + canonical quantities/units — COMPLETE (PR #73)**
+   - UUID list/item identity;
+   - stable item order and explicit add/replace/remove semantics;
+   - whitespace-only requirement normalization;
+   - mass canonicalized to grams;
+   - volume canonicalized to milliliters;
+   - piece quantities preserved;
+   - non-positive quantities rejected;
+   - package/container selection deliberately deferred to matching/basket optimization.
+3. **Provider/path orchestration over deterministic fixtures — NEXT**
+   - evolve `ObservedOffer` provenance to explicit retailer/source-provider/source-mode fields;
+   - ordered/capability-aware path selection;
+   - no retailer-specific branches in shopping domain;
+   - partial/path failure stays explicit;
+   - live adapters remain outside ordinary CI.
 4. **Location / fulfillment-context boundary**
    - product-level location input;
    - provider-scoped context resolution/selection;
-   - no provider-specific identifiers leaking into shopping/basket domain logic.
+   - no provider-specific identifiers leaking into shopping/basket logic.
 5. **Price and availability snapshots**
    - observation time;
-   - currency/price minor units;
+   - currency/price representation;
    - explicit availability including `UNKNOWN`;
    - source and fulfillment-context provenance;
-   - freshness limitation surfaced to callers/UI.
+   - freshness limitations surfaced to callers/UI.
 6. **Deterministic product-matching baseline**
    - exact/normalized matching first;
    - explicit ambiguous/unmatched state;
-   - AI matching remains optional later, never required for baseline correctness.
+   - AI matching optional later, never required for baseline correctness.
 7. **Complete single-store basket comparison**
    - package/quantity selection baseline;
    - deterministic explainable ranking;
-   - incomplete basket is not presented as a complete cheapest basket.
+   - incomplete baskets never presented as complete cheapest baskets.
 8. **Failure/coverage/freshness UX**
    - unavailable retailer coverage;
    - partial provider failures;
    - stale/unknown freshness;
-   - ambiguous/unmatched shopping items.
+   - ambiguous/unmatched items.
 9. **Critical-journey browser E2E**
-   - manually enter list;
+   - enter list;
    - choose location/context where supported;
    - compare available retailers;
    - inspect missing coverage/freshness/provenance honestly.
@@ -105,7 +102,6 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - canonical units/quantities;
 - address/location input;
 - retailer registry and coverage-state visibility;
-- retailer discovery;
 - provider/path orchestration;
 - deterministic product matching baseline;
 - package/quantity selection baseline;
@@ -113,90 +109,48 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - complete-basket comparison;
 - partial-provider failure UX;
 - data freshness UX;
-- provider provenance UX for aggregator, public-web and browser-assisted observations.
+- provenance UX for aggregator, public-web and browser-assisted observations.
 
 ### Exit criteria
 
-- critical journey is covered by automated integration and browser E2E tests;
-- incomplete/ambiguous matches are transparent;
-- one-store ranking is deterministic and explainable;
-- unavailable target-retailer coverage is explicit rather than silently omitted;
-- no test or user-facing path requires hidden live retailer access;
-- provider provenance, fulfillment context and freshness limitations survive through basket comparison.
+- critical journey covered by automated integration and browser E2E tests;
+- incomplete/ambiguous matches transparent;
+- one-store ranking deterministic and explainable;
+- unavailable retailer coverage explicit;
+- no test or user path requires hidden live retailer access;
+- provider provenance, fulfillment context and freshness survive through basket comparison.
 
 ## M2 — Recipes
 
 Goal: make recipes a first-class source of shopping requirements.
 
-Scope:
-
-- built-in and user-created recipes;
-- servings;
-- normalized ingredient quantities;
-- instructions/content model;
-- recipe → shopping requirement conversion;
-- recipe editing and duplication;
-- import experiments only after core model is stable.
+Scope: built-in/user recipes, servings, normalized ingredient quantities, instructions, recipe → shopping-requirement conversion, editing/duplication and import experiments only after the core model is stable.
 
 ## M3 — Weekly Planning
 
-Goal: generate one coherent shopping requirement set from several meals.
+Goal: generate one coherent shopping-requirement set from several meals.
 
-Scope:
-
-- weekly meal planner;
-- merge duplicate ingredients;
-- unit conversion where safe;
-- pantry/exclusion controls;
-- shopping-list review before comparison.
+Scope: weekly planner, safe duplicate merging/unit conversion, pantry/exclusion controls and shopping-list review before comparison.
 
 ## M4 — Basket Optimization
 
-Goal: optimize for real checkout cost rather than naive SKU sums.
+Goal: optimize real checkout cost rather than naive SKU sums.
 
-Scope:
-
-- package-size optimization;
-- substitutes and user preferences;
-- delivery/service fees where available;
-- minimum order constraints;
-- single-store convenience mode;
-- multi-store lowest-total-cost mode;
-- confidence/freshness penalties.
+Scope: package-size optimization, substitutes/preferences, fees, minimum orders, single-store convenience, future multi-store lowest-total-cost mode and confidence/freshness penalties.
 
 ## M5 — Productization
 
-Goal: make the product reliable and useful for repeat users while enabling fast product experiments.
+Goal: make the product reliable and useful for repeat users while enabling fast experiments.
 
-Scope:
-
-- accounts/authentication;
-- saved addresses with privacy controls;
-- saved lists/recipes/preferences;
-- product analytics abstraction;
-- feature flags/experiments;
-- stronger provider and retailer-path health monitoring;
-- performance and accessibility budgets;
-- public SEO/content surfaces where justified;
-- production provider activation only after access/usage constraints are resolved.
+Scope: accounts/authentication, privacy-aware saved addresses/lists/preferences, analytics abstraction, feature flags, stronger provider health monitoring, performance/accessibility budgets and production provider activation only after access constraints are resolved.
 
 ## M6 — Native Mobile
 
 Goal: ship native Android and iOS clients without redesigning the core platform.
 
-Target stack:
-
-- Expo;
-- React Native;
-- TypeScript;
-- generated OpenAPI client;
-- shared analytics vocabulary and design tokens.
-
-Mobile-specific work may include barcode/camera flows, push notifications, deep links, native sharing and location UX only when validated by product needs.
+Target stack: Expo, React Native, TypeScript, generated OpenAPI client, shared analytics vocabulary and design tokens.
 
 ## Parallel connectivity and engineering work
-
-These items continue without blocking the first M1 domain slices:
 
 - Kuper supported aggregator investigation (#36);
 - browser bridge persistent-session lifecycle hardening (#54);
@@ -208,15 +162,7 @@ These items continue without blocking the first M1 domain slices:
 
 ## Later candidates — not commitments
 
-- broader retailer/affiliate partnerships beyond mandatory registry integration work;
-- direct cart creation/checkout handoff;
-- loyalty integration;
-- price history and alerts;
-- AI-assisted recipe import;
-- AI-assisted product matching as a ranked optional stage;
-- household collaboration;
-- nutrition/dietary planning;
-- retailer-facing or B2B APIs.
+Broader retailer/affiliate partnerships, direct cart handoff, loyalty, price history/alerts, AI-assisted recipe import/matching, household collaboration, nutrition planning and retailer-facing/B2B APIs remain later candidates.
 
 ## Guiding rule
 


### PR DESCRIPTION
## Goal
Implement M1 slice 2: canonical quantity/unit primitives and a minimal shopping-list aggregate, entirely deterministic and independent from provider/live-retailer concerns.

## Design boundary
- mass input may use grams/kilograms but is stored canonically in grams;
- volume input may use milliliters/liters but is stored canonically in milliliters;
- count uses pieces;
- package/container units are intentionally not modeled here: package selection belongs to matching/basket optimization;
- requirement text normalization will be lexical/whitespace-only; synonyms/category inference belong to matching;
- no persistence/API/provider integration in this slice.

## TDD status
RED head `546f99ae04620c6fabcd5e53eaf96adc28dd6fd7` contains only the first quantity contract. Production `Quantity` / `QuantityUnit` do not exist yet. API CI is expected to fail before GREEN implementation.

Further shopping-list behavior will be added through a second RED→GREEN cycle after the quantity primitive is green.