### PR TITLE
feat(provider): add provenance-aware M1 path orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M1 canonical retailer registry covering Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat with explicit technical coverage and independent production-access status.
 - M1 canonical quantity primitives: positive decimal quantities, `kg → g`, `l → ml`, piece quantities and stable normalized `BigDecimal` equality.
 - M1 shopping-list aggregate with UUID list/item identity, stable insertion order, immutable item views, whitespace-only requirement normalization and explicit add/replace/remove semantics.
+- Provenance-complete M1 `ObservedOffer` contract with separate `retailerId`, `sourceProviderId`, `sourceMode`, fulfillment context and existing SKU/price/availability/time/source-reference evidence.
+- `AcquisitionMode` with explicit `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB` and `BROWSER_BRIDGE` values independent from technical `ProviderAccessType`.
+- Deterministic fixture-only provider/path orchestrator with explicit selected-path and per-attempt outcome records.
+- Explicit expected provider-path failure type (`ProviderPathUnavailableException`) used as the only fallback trigger.
 
 ### Changed
 
@@ -34,7 +38,12 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Shopping requirements canonicalize measurement dimensions before matching while deliberately leaving package/container selection to later matching/basket optimization.
 - Requirement text normalization is intentionally limited to whitespace in the shopping domain; synonyms, aliases, categories and semantic canonicalization remain matching responsibilities.
 - Automatic duplicate-item merging is not performed by the M1 shopping-list aggregate; recipe/weekly-plan consolidation remains later scope.
-- `docs/PROJECT_STATE.md` and `docs/ROADMAP.md` now mark the retailer registry and shopping-list/quantity slices complete and move the active M1 focus to provider/path orchestration.
+- `RetailerProvider` now declares retailer identity, source-provider identity and acquisition mode separately; provider-specific location context is keyed by source-provider identity rather than an ambiguous generic provider ID.
+- M1 provider-path priority is deterministic: `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE`, with stable source-provider ID tie-breaking within a mode.
+- Provider path selection is capability/context-aware; missing capabilities and missing source-provider contexts are explicit outcomes and do not invoke the provider.
+- A successful empty provider search remains a success and does not silently combine/fallback to a lower-priority source.
+- Only explicit expected path unavailability triggers fallback; unexpected runtime defects propagate fail-fast.
+- `docs/PROJECT_STATE.md` and `docs/ROADMAP.md` now mark provenance-aware provider/path orchestration complete and move the active M1 focus to the location/fulfillment-context product boundary.
 
 ### Fixed
 
@@ -43,6 +52,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - The stale Magnit `eggs` corpus candidate was replaced with the current public product candidate after diagnostics isolated it as the sole failed requirement.
 - Magnit promo status is now independent from regular-price presence: a proven price-bound promo marker may set `promo=true`, while regular/old price remains empty unless a second supported price is actually present.
 - Documentation index links were corrected to reference only documents that exist in the repository.
+- Provider offer validation now rejects retailer, source-provider, acquisition-mode and fulfillment-context mismatches before observations can reach comparison logic.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/AcquisitionMode.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/AcquisitionMode.java
@@ -1,0 +1,8 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+public enum AcquisitionMode {
+    DIRECT_API,
+    AGGREGATOR,
+    PUBLIC_WEB,
+    BROWSER_BRIDGE
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/LocationContext.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/LocationContext.java
@@ -1,9 +1,9 @@
 package io.github.trueruslan.zakupgotov.provider;
 
-public record LocationContext(String providerId, String fulfillmentContextId, String locality) {
+public record LocationContext(String sourceProviderId, String fulfillmentContextId, String locality) {
 
     public LocationContext {
-        providerId = requireText(providerId, "providerId");
+        sourceProviderId = requireText(sourceProviderId, "sourceProviderId");
         fulfillmentContextId = requireText(fulfillmentContextId, "fulfillmentContextId");
         locality = requireText(locality, "locality");
     }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ObservedOffer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ObservedOffer.java
@@ -1,11 +1,14 @@
 package io.github.trueruslan.zakupgotov.provider;
 
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Currency;
 
 public record ObservedOffer(
-        String providerId,
+        RetailerId retailerId,
+        String sourceProviderId,
+        AcquisitionMode sourceMode,
         String fulfillmentContextId,
         String sku,
         BigDecimal price,
@@ -15,7 +18,9 @@ public record ObservedOffer(
         String sourceReference) {
 
     public ObservedOffer {
-        providerId = requireText(providerId, "providerId");
+        retailerId = requireValue(retailerId, "retailerId");
+        sourceProviderId = requireText(sourceProviderId, "sourceProviderId");
+        sourceMode = requireValue(sourceMode, "sourceMode");
         fulfillmentContextId = requireText(fulfillmentContextId, "fulfillmentContextId");
         sku = requireText(sku, "sku");
         price = requireValue(price, "price");

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathAttempt.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathAttempt.java
@@ -1,0 +1,17 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import java.util.Objects;
+
+public record ProviderPathAttempt(
+        String sourceProviderId,
+        AcquisitionMode sourceMode,
+        ProviderPathAttemptStatus status) {
+
+    public ProviderPathAttempt {
+        if (sourceProviderId == null || sourceProviderId.isBlank()) {
+            throw new IllegalArgumentException("sourceProviderId must not be blank");
+        }
+        sourceMode = Objects.requireNonNull(sourceMode, "sourceMode must not be null");
+        status = Objects.requireNonNull(status, "status must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathAttemptStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathAttemptStatus.java
@@ -1,0 +1,8 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+public enum ProviderPathAttemptStatus {
+    INELIGIBLE_CAPABILITIES,
+    MISSING_CONTEXT,
+    FAILED,
+    SUCCESS
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java
@@ -1,0 +1,81 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ProviderPathOrchestrator {
+
+    private ProviderPathOrchestrator() {}
+
+    public static ProviderPathOrchestrator offline() {
+        return new ProviderPathOrchestrator();
+    }
+
+    public ProviderSearchOutcome search(
+            RetailerId retailerId,
+            List<FixtureRetailerProvider> providers,
+            Map<String, LocationContext> contextsBySourceProvider,
+            ProductQuery query) {
+        Objects.requireNonNull(retailerId, "retailerId must not be null");
+        Objects.requireNonNull(providers, "providers must not be null");
+        Objects.requireNonNull(contextsBySourceProvider, "contextsBySourceProvider must not be null");
+        Objects.requireNonNull(query, "query must not be null");
+
+        var candidates = providers.stream()
+                .filter(Objects::nonNull)
+                .filter(provider -> retailerId.equals(provider.retailerId()))
+                .sorted(Comparator
+                        .comparingInt((FixtureRetailerProvider provider) -> priority(provider.acquisitionMode()))
+                        .thenComparing(FixtureRetailerProvider::sourceProviderId))
+                .toList();
+        var attempts = new ArrayList<ProviderPathAttempt>();
+
+        for (var provider : candidates) {
+            var capabilities = Objects.requireNonNull(provider.capabilities(), "provider capabilities must not be null");
+            if (!capabilities.contains(ProviderCapability.PRODUCT_SEARCH)
+                    || !capabilities.contains(ProviderCapability.PRICE)) {
+                attempts.add(attempt(provider, ProviderPathAttemptStatus.INELIGIBLE_CAPABILITIES));
+                continue;
+            }
+
+            var location = contextsBySourceProvider.get(provider.sourceProviderId());
+            if (location == null) {
+                attempts.add(attempt(provider, ProviderPathAttemptStatus.MISSING_CONTEXT));
+                continue;
+            }
+
+            try {
+                var offers = ProviderFeasibilityHarness.offline().search(provider, location, query);
+                attempts.add(attempt(provider, ProviderPathAttemptStatus.SUCCESS));
+                return ProviderSearchOutcome.success(
+                        retailerId,
+                        new ProviderPathSelection(provider.sourceProviderId(), provider.acquisitionMode()),
+                        offers,
+                        attempts);
+            } catch (ProviderPathUnavailableException exception) {
+                attempts.add(attempt(provider, ProviderPathAttemptStatus.FAILED));
+            }
+        }
+
+        return ProviderSearchOutcome.unavailable(retailerId, attempts);
+    }
+
+    private static ProviderPathAttempt attempt(
+            FixtureRetailerProvider provider,
+            ProviderPathAttemptStatus status) {
+        return new ProviderPathAttempt(provider.sourceProviderId(), provider.acquisitionMode(), status);
+    }
+
+    private static int priority(AcquisitionMode mode) {
+        return switch (Objects.requireNonNull(mode, "acquisitionMode must not be null")) {
+            case DIRECT_API -> 0;
+            case AGGREGATOR -> 1;
+            case PUBLIC_WEB -> 2;
+            case BROWSER_BRIDGE -> 3;
+        };
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathSelection.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathSelection.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import java.util.Objects;
+
+public record ProviderPathSelection(String sourceProviderId, AcquisitionMode sourceMode) {
+
+    public ProviderPathSelection {
+        if (sourceProviderId == null || sourceProviderId.isBlank()) {
+            throw new IllegalArgumentException("sourceProviderId must not be blank");
+        }
+        sourceMode = Objects.requireNonNull(sourceMode, "sourceMode must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathUnavailableException.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathUnavailableException.java
@@ -1,0 +1,12 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+public final class ProviderPathUnavailableException extends RuntimeException {
+
+    public ProviderPathUnavailableException(String message) {
+        super(message);
+    }
+
+    public ProviderPathUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
@@ -24,8 +24,8 @@ final class ProviderProbeSupport {
 
         var offers = List.copyOf(provider.search(location, query));
         for (var offer : offers) {
-            if (!provider.providerId().equals(offer.providerId())) {
-                throw new IllegalStateException("offer providerId does not match provider");
+            if (!provider.providerId().equals(offer.sourceProviderId())) {
+                throw new IllegalStateException("offer sourceProviderId does not match provider");
             }
             if (!location.fulfillmentContextId().equals(offer.fulfillmentContextId())) {
                 throw new IllegalStateException("offer fulfillmentContextId does not match requested location context");

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
@@ -15,8 +15,8 @@ final class ProviderProbeSupport {
         Objects.requireNonNull(location, "location");
         Objects.requireNonNull(query, "query");
 
-        if (!provider.providerId().equals(location.providerId())) {
-            throw new IllegalArgumentException("providerId must match location context providerId");
+        if (!provider.sourceProviderId().equals(location.sourceProviderId())) {
+            throw new IllegalArgumentException("sourceProviderId must match location context sourceProviderId");
         }
         var capabilities = Objects.requireNonNull(provider.capabilities(), "capabilities");
         requireCapability(capabilities, ProviderCapability.PRODUCT_SEARCH);
@@ -24,7 +24,7 @@ final class ProviderProbeSupport {
 
         var offers = List.copyOf(provider.search(location, query));
         for (var offer : offers) {
-            if (!provider.providerId().equals(offer.sourceProviderId())) {
+            if (!provider.sourceProviderId().equals(offer.sourceProviderId())) {
                 throw new IllegalStateException("offer sourceProviderId does not match provider");
             }
             if (!location.fulfillmentContextId().equals(offer.fulfillmentContextId())) {

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderProbeSupport.java
@@ -24,8 +24,14 @@ final class ProviderProbeSupport {
 
         var offers = List.copyOf(provider.search(location, query));
         for (var offer : offers) {
+            if (!provider.retailerId().equals(offer.retailerId())) {
+                throw new IllegalStateException("offer retailerId does not match provider");
+            }
             if (!provider.sourceProviderId().equals(offer.sourceProviderId())) {
                 throw new IllegalStateException("offer sourceProviderId does not match provider");
+            }
+            if (!provider.acquisitionMode().equals(offer.sourceMode())) {
+                throw new IllegalStateException("offer sourceMode does not match provider");
             }
             if (!location.fulfillmentContextId().equals(offer.fulfillmentContextId())) {
                 throw new IllegalStateException("offer fulfillmentContextId does not match requested location context");

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderSearchOutcome.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderSearchOutcome.java
@@ -1,0 +1,36 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public record ProviderSearchOutcome(
+        RetailerId retailerId,
+        Optional<ProviderPathSelection> selectedPath,
+        List<ObservedOffer> offers,
+        List<ProviderPathAttempt> attempts) {
+
+    public ProviderSearchOutcome {
+        retailerId = Objects.requireNonNull(retailerId, "retailerId must not be null");
+        selectedPath = Objects.requireNonNull(selectedPath, "selectedPath must not be null");
+        offers = List.copyOf(Objects.requireNonNull(offers, "offers must not be null"));
+        attempts = List.copyOf(Objects.requireNonNull(attempts, "attempts must not be null"));
+    }
+
+    public boolean succeeded() {
+        return selectedPath.isPresent();
+    }
+
+    static ProviderSearchOutcome success(
+            RetailerId retailerId,
+            ProviderPathSelection selectedPath,
+            List<ObservedOffer> offers,
+            List<ProviderPathAttempt> attempts) {
+        return new ProviderSearchOutcome(retailerId, Optional.of(selectedPath), offers, attempts);
+    }
+
+    static ProviderSearchOutcome unavailable(RetailerId retailerId, List<ProviderPathAttempt> attempts) {
+        return new ProviderSearchOutcome(retailerId, Optional.empty(), List.of(), attempts);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/RetailerProvider.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/RetailerProvider.java
@@ -1,11 +1,16 @@
 package io.github.trueruslan.zakupgotov.provider;
 
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.util.List;
 import java.util.Set;
 
 public interface RetailerProvider {
 
-    String providerId();
+    RetailerId retailerId();
+
+    String sourceProviderId();
+
+    AcquisitionMode acquisitionMode();
 
     ProviderAccessType accessType();
 

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ObservedOfferProvenanceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ObservedOfferProvenanceTest.java
@@ -1,0 +1,63 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ObservedOfferProvenanceTest {
+
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T06:15:00Z");
+
+    @Test
+    void preservesRetailerProviderAndAcquisitionModeAsIndependentProvenance() {
+        var offer = offer(RetailerId.PYATEROCHKA, "kuper", AcquisitionMode.AGGREGATOR);
+
+        assertThat(offer.retailerId()).isEqualTo(RetailerId.PYATEROCHKA);
+        assertThat(offer.sourceProviderId()).isEqualTo("kuper");
+        assertThat(offer.sourceMode()).isEqualTo(AcquisitionMode.AGGREGATOR);
+    }
+
+    @Test
+    void keepsDirectPublicWebAndBrowserBridgeModesDistinct() {
+        assertThat(offer(RetailerId.MAGNIT, "magnit-public-web", AcquisitionMode.PUBLIC_WEB).sourceMode())
+                .isEqualTo(AcquisitionMode.PUBLIC_WEB);
+        assertThat(offer(RetailerId.PEREKRESTOK, "perekrestok-browser", AcquisitionMode.BROWSER_BRIDGE).sourceMode())
+                .isEqualTo(AcquisitionMode.BROWSER_BRIDGE);
+        assertThat(offer(RetailerId.PYATEROCHKA, "x5-supported", AcquisitionMode.DIRECT_API).sourceMode())
+                .isEqualTo(AcquisitionMode.DIRECT_API);
+    }
+
+    @Test
+    void rejectsIncompleteProvenance() {
+        assertThatThrownBy(() -> offer(null, "kuper", AcquisitionMode.AGGREGATOR))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("retailerId");
+        assertThatThrownBy(() -> offer(RetailerId.PYATEROCHKA, " ", AcquisitionMode.AGGREGATOR))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sourceProviderId");
+        assertThatThrownBy(() -> offer(RetailerId.PYATEROCHKA, "kuper", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sourceMode");
+    }
+
+    private static ObservedOffer offer(
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode sourceMode) {
+        return new ObservedOffer(
+                retailerId,
+                sourceProviderId,
+                sourceMode,
+                "store-42",
+                "sku-milk-1",
+                new BigDecimal("99.90"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                OBSERVED_AT,
+                "fixture://provider/search/milk.json");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ObservedOfferTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ObservedOfferTest.java
@@ -2,6 +2,7 @@ package io.github.trueruslan.zakupgotov.provider;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.math.BigDecimal;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,8 @@ class ObservedOfferTest {
     }
 
     @Test
-    void rejectsOfferWithoutProvider() {
-        assertInvalid("providerId", () -> offer(" ", "fulfillment-context-1", "sku-1", new BigDecimal("149.90"),
+    void rejectsOfferWithoutSourceProvider() {
+        assertInvalid("sourceProviderId", () -> offer(" ", "fulfillment-context-1", "sku-1", new BigDecimal("149.90"),
                 "RUB", AvailabilityStatus.AVAILABLE, OBSERVED_AT, SOURCE_REFERENCE));
     }
 
@@ -73,7 +74,7 @@ class ObservedOfferTest {
     }
 
     private static ObservedOffer offer(
-            String providerId,
+            String sourceProviderId,
             String fulfillmentContextId,
             String sku,
             BigDecimal price,
@@ -82,7 +83,9 @@ class ObservedOfferTest {
             Instant observedAt,
             String sourceReference) {
         return new ObservedOffer(
-                providerId,
+                RetailerId.PYATEROCHKA,
+                sourceProviderId,
+                AcquisitionMode.DIRECT_API,
                 fulfillmentContextId,
                 sku,
                 price,

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderFeasibilityHarnessTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderFeasibilityHarnessTest.java
@@ -24,7 +24,9 @@ class ProviderFeasibilityHarnessTest {
         var offers = ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY);
 
         assertThat(offers).hasSize(1);
+        assertThat(offers.getFirst().retailerId()).isEqualTo(RetailerId.PYATEROCHKA);
         assertThat(offers.getFirst().sourceProviderId()).isEqualTo("provider-a");
+        assertThat(offers.getFirst().sourceMode()).isEqualTo(AcquisitionMode.DIRECT_API);
         assertThat(offers.getFirst().fulfillmentContextId()).isEqualTo("store-42");
     }
 
@@ -32,7 +34,6 @@ class ProviderFeasibilityHarnessTest {
     void offlineHarnessExposesFixtureOnlyProviderBoundary() throws NoSuchMethodException {
         var search = ProviderFeasibilityHarness.class.getMethod(
                 "search", FixtureRetailerProvider.class, LocationContext.class, ProductQuery.class);
-
         assertThat(search.getParameterTypes()[0]).isEqualTo(FixtureRetailerProvider.class);
     }
 
@@ -40,7 +41,9 @@ class ProviderFeasibilityHarnessTest {
     void liveProviderRunsOnlyThroughExplicitLiveProbe() {
         var invoked = new AtomicBoolean(false);
         LiveRetailerProvider provider = new FakeLiveProvider(
+                RetailerId.PYATEROCHKA,
                 "provider-a",
+                AcquisitionMode.DIRECT_API,
                 ProviderAccessType.PUBLIC_UNOFFICIAL_API,
                 Set.of(ProviderCapability.PRODUCT_SEARCH, ProviderCapability.PRICE),
                 invoked);
@@ -52,19 +55,18 @@ class ProviderFeasibilityHarnessTest {
     }
 
     @Test
-    void rejectsLocationContextOwnedByAnotherProvider() {
+    void rejectsLocationContextOwnedByAnotherSourceProvider() {
         var provider = fixtureProvider("provider-a", Set.of(ProviderCapability.PRODUCT_SEARCH, ProviderCapability.PRICE));
         var foreignLocation = new LocationContext("provider-b", "store-42", "Москва");
 
         assertThatThrownBy(() -> ProviderFeasibilityHarness.offline().search(provider, foreignLocation, QUERY))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("providerId");
+                .hasMessageContaining("sourceProviderId");
     }
 
     @Test
     void rejectsProviderWithoutProductSearchCapability() {
         var provider = fixtureProvider("provider-a", Set.of(ProviderCapability.PRICE));
-
         assertThatThrownBy(() -> ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("PRODUCT_SEARCH");
@@ -73,7 +75,6 @@ class ProviderFeasibilityHarnessTest {
     @Test
     void rejectsProviderWithoutPriceCapability() {
         var provider = fixtureProvider("provider-a", Set.of(ProviderCapability.PRODUCT_SEARCH));
-
         assertThatThrownBy(() -> ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("PRICE");
@@ -83,8 +84,18 @@ class ProviderFeasibilityHarnessTest {
     void rejectsOfferThatDoesNotBelongToRequestedFulfillmentContext() {
         FixtureRetailerProvider provider = new FixtureRetailerProvider() {
             @Override
-            public String providerId() {
+            public RetailerId retailerId() {
+                return RetailerId.PYATEROCHKA;
+            }
+
+            @Override
+            public String sourceProviderId() {
                 return "provider-a";
+            }
+
+            @Override
+            public AcquisitionMode acquisitionMode() {
+                return AcquisitionMode.DIRECT_API;
             }
 
             @Override
@@ -99,7 +110,7 @@ class ProviderFeasibilityHarnessTest {
 
             @Override
             public List<ObservedOffer> search(LocationContext location, ProductQuery query) {
-                return List.of(offer("provider-a", "store-99"));
+                return List.of(offer(RetailerId.PYATEROCHKA, "provider-a", AcquisitionMode.DIRECT_API, "store-99"));
             }
         };
 
@@ -108,15 +119,24 @@ class ProviderFeasibilityHarnessTest {
                 .hasMessageContaining("fulfillmentContextId");
     }
 
-    private static FixtureRetailerProvider fixtureProvider(String providerId, Set<ProviderCapability> capabilities) {
-        return new FakeFixtureProvider(providerId, ProviderAccessType.PUBLIC_UNOFFICIAL_API, capabilities);
-    }
-
-    private static ObservedOffer offer(String sourceProviderId, String fulfillmentContextId) {
-        return new ObservedOffer(
+    private static FixtureRetailerProvider fixtureProvider(String sourceProviderId, Set<ProviderCapability> capabilities) {
+        return new FakeFixtureProvider(
                 RetailerId.PYATEROCHKA,
                 sourceProviderId,
                 AcquisitionMode.DIRECT_API,
+                ProviderAccessType.PUBLIC_UNOFFICIAL_API,
+                capabilities);
+    }
+
+    private static ObservedOffer offer(
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode mode,
+            String fulfillmentContextId) {
+        return new ObservedOffer(
+                retailerId,
+                sourceProviderId,
+                mode,
                 fulfillmentContextId,
                 "sku-milk-1",
                 new BigDecimal("99.90"),
@@ -127,18 +147,22 @@ class ProviderFeasibilityHarnessTest {
     }
 
     private record FakeFixtureProvider(
-            String providerId,
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode acquisitionMode,
             ProviderAccessType accessType,
             Set<ProviderCapability> capabilities) implements FixtureRetailerProvider {
 
         @Override
         public List<ObservedOffer> search(LocationContext location, ProductQuery query) {
-            return List.of(offer(providerId, location.fulfillmentContextId()));
+            return List.of(offer(retailerId, sourceProviderId, acquisitionMode, location.fulfillmentContextId()));
         }
     }
 
     private record FakeLiveProvider(
-            String providerId,
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode acquisitionMode,
             ProviderAccessType accessType,
             Set<ProviderCapability> capabilities,
             AtomicBoolean invoked) implements LiveRetailerProvider {
@@ -146,7 +170,7 @@ class ProviderFeasibilityHarnessTest {
         @Override
         public List<ObservedOffer> search(LocationContext location, ProductQuery query) {
             invoked.set(true);
-            return List.of(offer(providerId, location.fulfillmentContextId()));
+            return List.of(offer(retailerId, sourceProviderId, acquisitionMode, location.fulfillmentContextId()));
         }
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderFeasibilityHarnessTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderFeasibilityHarnessTest.java
@@ -3,6 +3,7 @@ package io.github.trueruslan.zakupgotov.provider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -23,7 +24,7 @@ class ProviderFeasibilityHarnessTest {
         var offers = ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY);
 
         assertThat(offers).hasSize(1);
-        assertThat(offers.getFirst().providerId()).isEqualTo("provider-a");
+        assertThat(offers.getFirst().sourceProviderId()).isEqualTo("provider-a");
         assertThat(offers.getFirst().fulfillmentContextId()).isEqualTo("store-42");
     }
 
@@ -111,9 +112,11 @@ class ProviderFeasibilityHarnessTest {
         return new FakeFixtureProvider(providerId, ProviderAccessType.PUBLIC_UNOFFICIAL_API, capabilities);
     }
 
-    private static ObservedOffer offer(String providerId, String fulfillmentContextId) {
+    private static ObservedOffer offer(String sourceProviderId, String fulfillmentContextId) {
         return new ObservedOffer(
-                providerId,
+                RetailerId.PYATEROCHKA,
+                sourceProviderId,
+                AcquisitionMode.DIRECT_API,
                 fulfillmentContextId,
                 "sku-milk-1",
                 new BigDecimal("99.90"),

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java
@@ -1,0 +1,252 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class ProviderPathOrchestratorTest {
+
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T06:30:00Z");
+    private static final ProductQuery QUERY = new ProductQuery("молоко");
+
+    @Test
+    void selectsHighestPriorityEligiblePathForRequestedRetailer() {
+        var direct = provider("x5-supported", AcquisitionMode.DIRECT_API, Behavior.SUCCESS);
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS);
+        var publicWeb = provider("public-web", AcquisitionMode.PUBLIC_WEB, Behavior.SUCCESS);
+        var browser = provider("pyaterochka-browser", AcquisitionMode.BROWSER_BRIDGE, Behavior.SUCCESS);
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(browser, publicWeb, aggregator, direct),
+                contexts(direct, aggregator, publicWeb, browser),
+                QUERY);
+
+        assertThat(outcome.succeeded()).isTrue();
+        assertThat(outcome.selectedPath()).contains(new ProviderPathSelection("x5-supported", AcquisitionMode.DIRECT_API));
+        assertThat(outcome.offers()).hasSize(1);
+        assertThat(outcome.offers().getFirst().retailerId()).isEqualTo(RetailerId.PYATEROCHKA);
+        assertThat(outcome.attempts())
+                .containsExactly(new ProviderPathAttempt(
+                        "x5-supported", AcquisitionMode.DIRECT_API, ProviderPathAttemptStatus.SUCCESS));
+    }
+
+    @Test
+    void recordsExpectedFailureAndFallsBackToNextEligiblePath() {
+        var direct = provider("x5-supported", AcquisitionMode.DIRECT_API, Behavior.UNAVAILABLE);
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS);
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(aggregator, direct),
+                contexts(direct, aggregator),
+                QUERY);
+
+        assertThat(outcome.selectedPath()).contains(new ProviderPathSelection("kuper", AcquisitionMode.AGGREGATOR));
+        assertThat(outcome.attempts()).containsExactly(
+                new ProviderPathAttempt("x5-supported", AcquisitionMode.DIRECT_API, ProviderPathAttemptStatus.FAILED),
+                new ProviderPathAttempt("kuper", AcquisitionMode.AGGREGATOR, ProviderPathAttemptStatus.SUCCESS));
+        assertThat(outcome.offers().getFirst().sourceProviderId()).isEqualTo("kuper");
+        assertThat(outcome.offers().getFirst().sourceMode()).isEqualTo(AcquisitionMode.AGGREGATOR);
+    }
+
+    @Test
+    void skipsPathWithoutRequiredCapabilitiesAndKeepsReasonExplicit() {
+        var direct = provider(
+                "x5-supported",
+                AcquisitionMode.DIRECT_API,
+                Behavior.SUCCESS,
+                Set.of(ProviderCapability.PRODUCT_SEARCH));
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS);
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(direct, aggregator),
+                contexts(direct, aggregator),
+                QUERY);
+
+        assertThat(outcome.attempts()).containsExactly(
+                new ProviderPathAttempt(
+                        "x5-supported",
+                        AcquisitionMode.DIRECT_API,
+                        ProviderPathAttemptStatus.INELIGIBLE_CAPABILITIES),
+                new ProviderPathAttempt("kuper", AcquisitionMode.AGGREGATOR, ProviderPathAttemptStatus.SUCCESS));
+    }
+
+    @Test
+    void skipsPathWithoutProviderScopedContextAndKeepsReasonExplicit() {
+        var direct = provider("x5-supported", AcquisitionMode.DIRECT_API, Behavior.SUCCESS);
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS);
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(direct, aggregator),
+                Map.of("kuper", context(aggregator)),
+                QUERY);
+
+        assertThat(outcome.attempts()).containsExactly(
+                new ProviderPathAttempt(
+                        "x5-supported", AcquisitionMode.DIRECT_API, ProviderPathAttemptStatus.MISSING_CONTEXT),
+                new ProviderPathAttempt("kuper", AcquisitionMode.AGGREGATOR, ProviderPathAttemptStatus.SUCCESS));
+    }
+
+    @Test
+    void successfulEmptyResultDoesNotFallBackToAnotherProvider() {
+        var aggregatorInvoked = new AtomicBoolean(false);
+        var direct = provider("x5-supported", AcquisitionMode.DIRECT_API, Behavior.EMPTY);
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS, defaultCapabilities(), aggregatorInvoked);
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(aggregator, direct),
+                contexts(direct, aggregator),
+                QUERY);
+
+        assertThat(outcome.succeeded()).isTrue();
+        assertThat(outcome.selectedPath()).contains(new ProviderPathSelection("x5-supported", AcquisitionMode.DIRECT_API));
+        assertThat(outcome.offers()).isEmpty();
+        assertThat(aggregatorInvoked).isFalse();
+    }
+
+    @Test
+    void unexpectedProviderDefectPropagatesInsteadOfBeingHiddenByFallback() {
+        var direct = provider("x5-supported", AcquisitionMode.DIRECT_API, Behavior.DEFECT);
+        var aggregator = provider("kuper", AcquisitionMode.AGGREGATOR, Behavior.SUCCESS);
+
+        assertThatThrownBy(() -> ProviderPathOrchestrator.offline().search(
+                        RetailerId.PYATEROCHKA,
+                        List.of(direct, aggregator),
+                        contexts(direct, aggregator),
+                        QUERY))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("fixture defect");
+    }
+
+    @Test
+    void ignoresProvidersForOtherRetailers() {
+        var perekrestok = provider(
+                RetailerId.PEREKRESTOK,
+                "perekrestok-browser",
+                AcquisitionMode.BROWSER_BRIDGE,
+                Behavior.SUCCESS,
+                defaultCapabilities(),
+                new AtomicBoolean());
+
+        var outcome = ProviderPathOrchestrator.offline().search(
+                RetailerId.PYATEROCHKA,
+                List.of(perekrestok),
+                contexts(perekrestok),
+                QUERY);
+
+        assertThat(outcome.succeeded()).isFalse();
+        assertThat(outcome.selectedPath()).isEmpty();
+        assertThat(outcome.offers()).isEmpty();
+        assertThat(outcome.attempts()).isEmpty();
+    }
+
+    private static FakeFixtureProvider provider(String sourceProviderId, AcquisitionMode mode, Behavior behavior) {
+        return provider(sourceProviderId, mode, behavior, defaultCapabilities());
+    }
+
+    private static FakeFixtureProvider provider(
+            String sourceProviderId,
+            AcquisitionMode mode,
+            Behavior behavior,
+            Set<ProviderCapability> capabilities) {
+        return provider(
+                RetailerId.PYATEROCHKA,
+                sourceProviderId,
+                mode,
+                behavior,
+                capabilities,
+                new AtomicBoolean());
+    }
+
+    private static FakeFixtureProvider provider(
+            String sourceProviderId,
+            AcquisitionMode mode,
+            Behavior behavior,
+            Set<ProviderCapability> capabilities,
+            AtomicBoolean invoked) {
+        return provider(RetailerId.PYATEROCHKA, sourceProviderId, mode, behavior, capabilities, invoked);
+    }
+
+    private static FakeFixtureProvider provider(
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode mode,
+            Behavior behavior,
+            Set<ProviderCapability> capabilities,
+            AtomicBoolean invoked) {
+        return new FakeFixtureProvider(
+                retailerId,
+                sourceProviderId,
+                mode,
+                ProviderAccessType.PUBLIC_UNOFFICIAL_API,
+                capabilities,
+                behavior,
+                invoked);
+    }
+
+    private static Set<ProviderCapability> defaultCapabilities() {
+        return Set.of(ProviderCapability.PRODUCT_SEARCH, ProviderCapability.PRICE);
+    }
+
+    private static Map<String, LocationContext> contexts(FakeFixtureProvider... providers) {
+        var builder = new java.util.LinkedHashMap<String, LocationContext>();
+        for (var provider : providers) {
+            builder.put(provider.sourceProviderId(), context(provider));
+        }
+        return Map.copyOf(builder);
+    }
+
+    private static LocationContext context(FakeFixtureProvider provider) {
+        return new LocationContext(provider.sourceProviderId(), "store-42", "Москва");
+    }
+
+    private enum Behavior {
+        SUCCESS,
+        EMPTY,
+        UNAVAILABLE,
+        DEFECT
+    }
+
+    private record FakeFixtureProvider(
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode acquisitionMode,
+            ProviderAccessType accessType,
+            Set<ProviderCapability> capabilities,
+            Behavior behavior,
+            AtomicBoolean invoked) implements FixtureRetailerProvider {
+
+        @Override
+        public List<ObservedOffer> search(LocationContext location, ProductQuery query) {
+            invoked.set(true);
+            return switch (behavior) {
+                case SUCCESS -> List.of(new ObservedOffer(
+                        retailerId,
+                        sourceProviderId,
+                        acquisitionMode,
+                        location.fulfillmentContextId(),
+                        "sku-milk-1",
+                        new BigDecimal("99.90"),
+                        "RUB",
+                        AvailabilityStatus.AVAILABLE,
+                        OBSERVED_AT,
+                        "fixture://" + sourceProviderId + "/search/milk.json"));
+                case EMPTY -> List.of();
+                case UNAVAILABLE -> throw new ProviderPathUnavailableException("fixture unavailable");
+                case DEFECT -> throw new IllegalStateException("fixture defect");
+            };
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderProvenanceValidationTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderProvenanceValidationTest.java
@@ -1,0 +1,88 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ProviderProvenanceValidationTest {
+
+    private static final LocationContext LOCATION = new LocationContext("provider-a", "store-42", "Москва");
+    private static final ProductQuery QUERY = new ProductQuery("молоко");
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T06:45:00Z");
+
+    @Test
+    void rejectsOfferForDifferentRetailerThanProviderDeclares() {
+        var provider = provider(RetailerId.PYATEROCHKA, AcquisitionMode.DIRECT_API,
+                offer(RetailerId.PEREKRESTOK, AcquisitionMode.DIRECT_API));
+
+        assertThatThrownBy(() -> ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("retailerId");
+    }
+
+    @Test
+    void rejectsOfferWithDifferentAcquisitionModeThanProviderDeclares() {
+        var provider = provider(RetailerId.PYATEROCHKA, AcquisitionMode.DIRECT_API,
+                offer(RetailerId.PYATEROCHKA, AcquisitionMode.AGGREGATOR));
+
+        assertThatThrownBy(() -> ProviderFeasibilityHarness.offline().search(provider, LOCATION, QUERY))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("sourceMode");
+    }
+
+    private static FixtureRetailerProvider provider(
+            RetailerId retailerId,
+            AcquisitionMode mode,
+            ObservedOffer returnedOffer) {
+        return new FixtureRetailerProvider() {
+            @Override
+            public RetailerId retailerId() {
+                return retailerId;
+            }
+
+            @Override
+            public String sourceProviderId() {
+                return "provider-a";
+            }
+
+            @Override
+            public AcquisitionMode acquisitionMode() {
+                return mode;
+            }
+
+            @Override
+            public ProviderAccessType accessType() {
+                return ProviderAccessType.PUBLIC_UNOFFICIAL_API;
+            }
+
+            @Override
+            public Set<ProviderCapability> capabilities() {
+                return Set.of(ProviderCapability.PRODUCT_SEARCH, ProviderCapability.PRICE);
+            }
+
+            @Override
+            public List<ObservedOffer> search(LocationContext location, ProductQuery query) {
+                return List.of(returnedOffer);
+            }
+        };
+    }
+
+    private static ObservedOffer offer(RetailerId retailerId, AcquisitionMode mode) {
+        return new ObservedOffer(
+                retailerId,
+                "provider-a",
+                mode,
+                "store-42",
+                "sku-milk-1",
+                new BigDecimal("99.90"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                OBSERVED_AT,
+                "fixture://provider-a/search/milk.json");
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **provider/path orchestration over deterministic fixtures with explicit retailer/source-provider/acquisition-mode provenance**
+Current focus: **location / fulfillment-context product boundary over the completed provenance-aware provider/path orchestration layer**
 
 ## Product connectivity invariant
 
@@ -19,7 +19,7 @@ Universal Retailer Connectivity remains a permanent product rule beyond M0:
 
 > Every retailer/banner in the target registry remains mandatory coverage work until at least one reproducible accepted acquisition path exists. A failed transport changes the acquisition mode under investigation; it does not remove the retailer from product scope.
 
-Accepted acquisition-mode families are supported/partner API, aggregator-backed observations, stable public web/API surfaces and user-assisted first-party browser bridge.
+Accepted acquisition-mode families are supported/direct API, aggregator-backed observations, stable public web/API surfaces and user-assisted first-party browser bridge.
 
 ## M0 exit status
 
@@ -58,21 +58,38 @@ Initial accepted technical states are preserved:
 
 ### Slice 2 — shopping-list core + canonical quantities — COMPLETE
 
-PR #73 establishes deterministic shopping requirements without provider dependencies:
+PR #73 established deterministic shopping requirements without provider dependencies:
 
-- `Quantity` accepts positive decimal amounts only;
+- positive decimal `Quantity` values only;
 - kilograms normalize to grams;
 - liters normalize to milliliters;
 - piece quantities remain piece-based;
 - equivalent decimal representations normalize to stable value equality;
-- package/container units are intentionally not part of the requirement model because package selection belongs to matching/basket optimization;
-- `ShoppingRequirement` performs whitespace-only normalization and preserves user wording/case for later matching;
+- package/container selection remains outside the requirement model and belongs to matching/basket optimization;
+- `ShoppingRequirement` performs whitespace-only normalization and preserves user wording/case;
 - `ShoppingList` owns stable UUID list/item identity and insertion order;
-- add/replace/remove semantics reject duplicate or unknown item IDs instead of guessing;
+- add/replace/remove reject duplicate or unknown item IDs instead of guessing;
 - exposed item views are immutable;
-- no automatic duplicate-name merging is performed in M1; recipe/weekly-plan merging remains later scope.
+- automatic duplicate-name merging is intentionally deferred.
 
-Both M1 slices were implemented through explicit RED→GREEN cycles and verified by full Maven `verify` before final repository gating.
+### Slice 3 — provenance-aware provider/path orchestration — COMPLETE
+
+PR #74 establishes the first deterministic M1 acquisition-routing boundary:
+
+- normalized `ObservedOffer` now preserves `retailerId`, `sourceProviderId` and `sourceMode` independently from fulfillment context, SKU, price, availability, observation time and source reference;
+- `AcquisitionMode` distinguishes `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB` and `BROWSER_BRIDGE` without overloading `ProviderAccessType`;
+- `RetailerProvider` declares its retailer identity, source-provider identity and acquisition mode explicitly;
+- `LocationContext` is source-provider scoped rather than ambiguously provider-labelled;
+- fixture-only `ProviderPathOrchestrator` selects deterministic priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE`, then source-provider ID as a stable tie-breaker;
+- providers for other retailers are ignored rather than mixed into the requested retailer result;
+- missing required capabilities and missing provider-scoped context are explicit non-invoking attempt states;
+- only the explicit `ProviderPathUnavailableException` triggers fallback to another path;
+- a successful empty search remains a successful selected path and does not silently mix results from a lower-priority source;
+- unexpected runtime defects propagate instead of being hidden by fallback;
+- unsuccessful routing returns an explicit outcome with attempted-path evidence rather than pretending the retailer is absent;
+- the common trust boundary rejects observations whose retailer, source provider, acquisition mode or fulfillment context do not match the provider/request contract.
+
+All three provider/orchestration behaviors were developed through separate RED→GREEN cycles and verified by full Maven `verify` before final repository gating. Ordinary CI still performs no live retailer traffic.
 
 ## Accepted retailer paths
 
@@ -116,25 +133,23 @@ Evidence:
 
 ## Provider foundation
 
-Verified connectivity infrastructure includes:
+Verified connectivity infrastructure now includes:
 
-- current `ObservedOffer` trust boundary;
-- provider-scoped `LocationContext`;
+- provenance-complete `ObservedOffer` trust boundary;
+- source-provider-scoped `LocationContext`;
 - normalized `ProductQuery`;
-- `RetailerProvider` port;
+- metadata-explicit `RetailerProvider` port;
 - structural fixture/live provider separation;
-- explicit live-probe entry points;
+- deterministic fixture-only path orchestration and explicit attempt outcomes;
+- explicit live-probe entry points kept outside ordinary CI;
 - retailer-neutral browser adapter registry;
-- first-class `apps/retailer-bridge` workspace and persistent-Chromium gate;
-- ordinary CI remains free of live retailer network dependencies.
-
-The next M1 domain evolution must update offer provenance to distinguish at least `retailerId`, `sourceProviderId` and acquisition/source mode before multiple accepted paths are orchestrated together.
+- first-class `apps/retailer-bridge` workspace and persistent-Chromium gate.
 
 ## M1 entry rules
 
 1. shopping/basket logic runs deterministically over fixtures;
 2. retailer coverage remains explicit and unavailable paths are never silently omitted;
-3. retailer, source-provider and fulfillment-context provenance remain distinct;
+3. retailer, source-provider, acquisition mode and fulfillment-context provenance remain distinct;
 4. `UNKNOWN` availability is preserved;
 5. observation time is not misrepresented as provider-side freshness;
 6. production activation respects recorded usage-rights state;
@@ -142,16 +157,15 @@ The next M1 domain evolution must update offer provenance to distinguish at leas
 
 ## Immediate next work
 
-1. **Provider/path orchestration over deterministic fixtures — NEXT**
-   - evolve normalized offer provenance to explicit retailer/source-provider/source-mode fields;
-   - define ordered/capability-aware path selection without blind retailer-specific branches;
-   - preserve partial/path failure explicitly;
-   - keep live adapters outside ordinary CI.
-2. Location / fulfillment-context product boundary.
-3. Price/availability snapshots with provenance and freshness semantics.
-4. Deterministic matching baseline.
-5. Complete single-store basket comparison.
-6. Coverage/failure/freshness UX and critical browser E2E.
+1. **Location / fulfillment-context product boundary — NEXT**
+   - define provider-neutral user/product location input separately from provider-specific fulfillment contexts;
+   - prevent `shopCode`, X5 store IDs and other provider identifiers from leaking into shopping/basket domain objects;
+   - support explicit/manual contexts where automatic resolution is not proven;
+   - keep precise user addresses out of fixtures/logs by default.
+2. Price/availability snapshots with provenance and freshness semantics.
+3. Deterministic product-matching baseline.
+4. Complete single-store basket comparison.
+5. Coverage/failure/freshness UX and critical browser E2E.
 
 ## Parallel open work
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 
 - fixture-first provider orchestration;
 - unavailable/blocked registry entries remain visible;
-- retailer identity, source-provider identity and fulfillment context remain distinct;
+- retailer identity, source-provider identity, acquisition mode and fulfillment context remain distinct;
 - `UNKNOWN` availability remains first-class;
 - observation time is not misrepresented as provider update time;
 - production activation respects usage-rights state;
@@ -61,16 +61,24 @@ Goal: compare a manually entered grocery list across connected retailers while p
    - piece quantities preserved;
    - non-positive quantities rejected;
    - package/container selection deliberately deferred to matching/basket optimization.
-3. **Provider/path orchestration over deterministic fixtures — NEXT**
-   - evolve `ObservedOffer` provenance to explicit retailer/source-provider/source-mode fields;
-   - ordered/capability-aware path selection;
-   - no retailer-specific branches in shopping domain;
-   - partial/path failure stays explicit;
+3. **Provider/path orchestration over deterministic fixtures — COMPLETE (PR #74)**
+   - `ObservedOffer` preserves explicit `retailerId`, `sourceProviderId` and acquisition/source mode;
+   - `RetailerProvider` declares retailer, source provider and acquisition mode separately;
+   - deterministic priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE`;
+   - stable source-provider tie-break for same-mode candidates;
+   - capability-aware and provider-context-aware eligibility;
+   - explicit attempt states for missing capabilities, missing context, expected failure and success;
+   - fallback only on explicit expected path-unavailable failure;
+   - successful empty search does not mix/fallback to another provider;
+   - unexpected provider defects propagate;
+   - trust boundary rejects retailer/source-provider/source-mode/fulfillment-context provenance mismatch;
    - live adapters remain outside ordinary CI.
-4. **Location / fulfillment-context boundary**
-   - product-level location input;
+4. **Location / fulfillment-context boundary — NEXT**
+   - provider-neutral product location input;
    - provider-scoped context resolution/selection;
-   - no provider-specific identifiers leaking into shopping/basket logic.
+   - explicit/manual contexts where automatic resolution is unavailable;
+   - no `shopCode`, X5 store IDs or other provider identifiers leaking into shopping/basket logic;
+   - precise user addresses stay out of fixtures/logs by default.
 5. **Price and availability snapshots**
    - observation time;
    - currency/price representation;


### PR DESCRIPTION
## Goal
Implement M1 slice 3: provenance-complete normalized offers plus deterministic fixture-only provider/path orchestration.

## Architectural boundaries
- retailer identity, source-provider identity and acquisition mode are distinct;
- `ProviderAccessType` remains a separate technical/API-access classification and is not overloaded as observation provenance;
- Kuper/aggregators can be source providers without becoming retailer identities;
- orchestration is fixture-only in ordinary CI;
- no live retailer traffic, location resolution, persistence or shopping-list behavior is introduced;
- unexpected provider defects are never hidden by fallback.

## TDD evidence

### Cycle 1 — explicit observation provenance
**RED** head `d1d1ad2ba1df43c35e40aaffb1708a22243badc2` added only `ObservedOfferProvenanceTest`. Maven reached `testCompile` and failed because `AcquisitionMode` and the new provenance contract did not exist.

**GREEN** head `00421bb2694f4298cc6233cd163c5fd4357a309e` introduced:
- `AcquisitionMode`: `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB`, `BROWSER_BRIDGE`;
- `ObservedOffer.retailerId`;
- `ObservedOffer.sourceProviderId`;
- `ObservedOffer.sourceMode`;
- preservation of existing fulfillment/SKU/price/currency/availability/time/source-reference validation.

The original RED test remained unchanged and full Maven `verify` passed.

### Cycle 2 — deterministic provider/path orchestration
**RED** head `d59e277dd77b2c768dc888ee9b6d0a057ac8f9f6` added only `ProviderPathOrchestratorTest`. Maven reached `testCompile` and failed on the absent orchestration types and on the old ambiguous `providerId()` provider contract.

**GREEN** head `26f084761f8575a238ad675d3db0ee1feeae1eec` introduced:
- `RetailerProvider.retailerId/sourceProviderId/acquisitionMode` metadata;
- source-provider-scoped `LocationContext`;
- fixture-only `ProviderPathOrchestrator`;
- deterministic priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE` and stable source-provider tie-break;
- explicit `ProviderPathAttempt` states: missing capabilities, missing context, expected failure, success;
- explicit selected-path/outcome records;
- `ProviderPathUnavailableException` as the only fallback trigger.

Behavior proven by unchanged RED tests:
- other-retailer providers are ignored;
- missing SEARCH/PRICE capability does not invoke a provider;
- missing provider-scoped context does not invoke a provider;
- expected path unavailability falls back;
- a successful empty result remains success and does not fall back/mix observations;
- unexpected runtime defects propagate fail-fast.

Full Maven `verify` passed.

### Cycle 3 — anti-spoofing trust validation
**RED** head `eb56c19d4202f45a08f4e8cdedc2d41f74f5bffb` added only `ProviderProvenanceValidationTest`. All code compiled and Maven ran 71 tests; exactly two failed because the shared harness accepted:
1. an offer whose `retailerId` differed from the provider declaration;
2. an offer whose `sourceMode` differed from the provider declaration.

**GREEN** head `056bee2f61b2a251679973fe2973a38b089679f3` changed only `ProviderProbeSupport`, adding fail-closed retailer and acquisition-mode validation alongside existing source-provider and fulfillment-context validation. The RED test remained unchanged and full Maven `verify` passed.

## Final documentation head
Head `5b9de88b2bf4935ba8c660b06eabe1e65725d321` synchronizes `PROJECT_STATE.md`, `ROADMAP.md` and `CHANGELOG.md`. The next active M1 slice is the provider-neutral location/fulfillment-context product boundary.

## Non-goals
- no live retailer calls in ordinary CI;
- no location/address → provider-context resolution;
- no persistence/schema migration;
- no REST API/UI;
- no price/availability snapshot aggregate yet;
- no matching or basket ranking.

## Next after merge
M1 slice 4: provider-neutral location input + provider-scoped fulfillment-context selection/resolution, with explicit/manual contexts where automatic resolution is not proven and no provider-specific IDs leaking into shopping/basket domain objects.