### PR TITLE
feat(location): add M1 product-to-fulfillment boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - `AcquisitionMode` with explicit `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB` and `BROWSER_BRIDGE` values independent from technical `ProviderAccessType`.
 - Deterministic fixture-only provider/path orchestrator with explicit selected-path and per-attempt outcome records.
 - Explicit expected provider-path failure type (`ProviderPathUnavailableException`) used as the only fallback trigger.
+- Provider-neutral `ProductLocationId` and `ProductLocation` M1 boundary for locality/address input without provider/store identifiers.
+- `SensitiveAddress` value object that requires explicit `reveal()` for raw use and renders `[REDACTED]` from default string/log representation.
+- ArchUnit privacy/modularity rule preventing production `location` classes from depending on provider or retailer packages.
+- Typed `FulfillmentContextBinding` / `FulfillmentContextSet` with `MANUAL` and `RESOLVED` selection provenance, stable order and duplicate/cross-location rejection.
+- Location-boundary implementation plan at `docs/superpowers/plans/2026-08-12-m1-location-boundary.md`.
 
 ### Changed
 
@@ -43,7 +48,10 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Provider path selection is capability/context-aware; missing capabilities and missing source-provider contexts are explicit outcomes and do not invoke the provider.
 - A successful empty provider search remains a success and does not silently combine/fallback to a lower-priority source.
 - Only explicit expected path unavailability triggers fallback; unexpected runtime defects propagate fail-fast.
-- `docs/PROJECT_STATE.md` and `docs/ROADMAP.md` now mark provenance-aware provider/path orchestration complete and move the active M1 focus to the location/fulfillment-context product boundary.
+- Provider routing now accepts a typed `FulfillmentContextSet` instead of a raw `Map<String, LocationContext>` and therefore never receives precise `ProductLocation`/`SensitiveAddress` values.
+- Provider-specific `shopCode`, X5 store IDs and similar identifiers stay inside source-provider-scoped `LocationContext` values bound to an opaque product location identity.
+- Manual provider context selection and already-resolved context selection are represented explicitly without claiming universal automatic address resolution.
+- `docs/PROJECT_STATE.md` and `docs/ROADMAP.md` now mark the location/fulfillment-context boundary complete and move the active M1 focus to price/availability snapshots.
 
 ### Fixed
 
@@ -53,6 +61,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Magnit promo status is now independent from regular-price presence: a proven price-bound promo marker may set `promo=true`, while regular/old price remains empty unless a second supported price is actually present.
 - Documentation index links were corrected to reference only documents that exist in the repository.
 - Provider offer validation now rejects retailer, source-provider, acquisition-mode and fulfillment-context mismatches before observations can reach comparison logic.
+- Precise user addresses are excluded from default `toString()` output for both `SensitiveAddress` and `ProductLocation`.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocation.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocation.java
@@ -1,0 +1,66 @@
+package io.github.trueruslan.zakupgotov.location;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class ProductLocation {
+
+    private final ProductLocationId id;
+    private final String locality;
+    private final SensitiveAddress address;
+
+    private ProductLocation(ProductLocationId id, String locality, SensitiveAddress address) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.locality = normalizeLocality(locality);
+        this.address = address;
+    }
+
+    public static ProductLocation localityOnly(ProductLocationId id, String locality) {
+        return new ProductLocation(id, locality, null);
+    }
+
+    public static ProductLocation withAddress(ProductLocationId id, String locality, String address) {
+        return new ProductLocation(id, locality, SensitiveAddress.of(address));
+    }
+
+    public ProductLocationId id() {
+        return id;
+    }
+
+    public String locality() {
+        return locality;
+    }
+
+    public Optional<SensitiveAddress> address() {
+        return Optional.ofNullable(address);
+    }
+
+    private static String normalizeLocality(String locality) {
+        Objects.requireNonNull(locality, "locality must not be null");
+        var normalized = locality.strip().replaceAll("\\s+", " ");
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException("locality must not be blank");
+        }
+        return normalized;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof ProductLocation location
+                        && id.equals(location.id)
+                        && locality.equals(location.locality)
+                        && Objects.equals(address, location.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, locality, address);
+    }
+
+    @Override
+    public String toString() {
+        return "ProductLocation[id=" + id + ", locality=" + locality + ", address="
+                + (address == null ? "empty" : address) + "]";
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocationId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocationId.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.location;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ProductLocationId(UUID value) {
+
+    public ProductLocationId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/SensitiveAddress.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/SensitiveAddress.java
@@ -1,0 +1,40 @@
+package io.github.trueruslan.zakupgotov.location;
+
+import java.util.Objects;
+
+public final class SensitiveAddress {
+
+    private final String value;
+
+    private SensitiveAddress(String value) {
+        this.value = value;
+    }
+
+    public static SensitiveAddress of(String raw) {
+        Objects.requireNonNull(raw, "address must not be null");
+        var normalized = raw.strip();
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException("address must not be blank");
+        }
+        return new SensitiveAddress(normalized);
+    }
+
+    public String reveal() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof SensitiveAddress address && value.equals(address.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "[REDACTED]";
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextBinding.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextBinding.java
@@ -1,0 +1,16 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
+import java.util.Objects;
+
+public record FulfillmentContextBinding(
+        ProductLocationId productLocationId,
+        LocationContext context,
+        FulfillmentContextSelectionMode mode) {
+
+    public FulfillmentContextBinding {
+        productLocationId = Objects.requireNonNull(productLocationId, "productLocationId must not be null");
+        context = Objects.requireNonNull(context, "context must not be null");
+        mode = Objects.requireNonNull(mode, "mode must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSelectionMode.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSelectionMode.java
@@ -1,0 +1,6 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+public enum FulfillmentContextSelectionMode {
+    MANUAL,
+    RESOLVED
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSet.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSet.java
@@ -1,0 +1,60 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class FulfillmentContextSet {
+
+    private final ProductLocationId productLocationId;
+    private final List<FulfillmentContextBinding> bindings;
+    private final Map<String, FulfillmentContextBinding> bindingsBySourceProvider;
+
+    private FulfillmentContextSet(
+            ProductLocationId productLocationId,
+            List<FulfillmentContextBinding> bindings) {
+        this.productLocationId = Objects.requireNonNull(productLocationId, "productLocationId must not be null");
+        this.bindings = List.copyOf(Objects.requireNonNull(bindings, "bindings must not be null"));
+
+        var byProvider = new LinkedHashMap<String, FulfillmentContextBinding>();
+        for (var binding : this.bindings) {
+            Objects.requireNonNull(binding, "binding must not be null");
+            if (!this.productLocationId.equals(binding.productLocationId())) {
+                throw new IllegalArgumentException("binding productLocationId must match context set productLocationId");
+            }
+            var sourceProviderId = binding.context().sourceProviderId();
+            if (byProvider.putIfAbsent(sourceProviderId, binding) != null) {
+                throw new IllegalArgumentException("duplicate sourceProviderId binding: " + sourceProviderId);
+            }
+        }
+        this.bindingsBySourceProvider = Map.copyOf(byProvider);
+    }
+
+    public static FulfillmentContextSet of(
+            ProductLocationId productLocationId,
+            List<FulfillmentContextBinding> bindings) {
+        return new FulfillmentContextSet(productLocationId, bindings);
+    }
+
+    public ProductLocationId productLocationId() {
+        return productLocationId;
+    }
+
+    public List<FulfillmentContextBinding> bindings() {
+        return bindings;
+    }
+
+    public Optional<FulfillmentContextBinding> bindingFor(String sourceProviderId) {
+        if (sourceProviderId == null || sourceProviderId.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(bindingsBySourceProvider.get(sourceProviderId));
+    }
+
+    public Optional<LocationContext> contextFor(String sourceProviderId) {
+        return bindingFor(sourceProviderId).map(FulfillmentContextBinding::context);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java
@@ -4,7 +4,6 @@ import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 public final class ProviderPathOrchestrator {
@@ -18,11 +17,11 @@ public final class ProviderPathOrchestrator {
     public ProviderSearchOutcome search(
             RetailerId retailerId,
             List<FixtureRetailerProvider> providers,
-            Map<String, LocationContext> contextsBySourceProvider,
+            FulfillmentContextSet fulfillmentContexts,
             ProductQuery query) {
         Objects.requireNonNull(retailerId, "retailerId must not be null");
         Objects.requireNonNull(providers, "providers must not be null");
-        Objects.requireNonNull(contextsBySourceProvider, "contextsBySourceProvider must not be null");
+        Objects.requireNonNull(fulfillmentContexts, "fulfillmentContexts must not be null");
         Objects.requireNonNull(query, "query must not be null");
 
         var candidates = providers.stream()
@@ -42,7 +41,7 @@ public final class ProviderPathOrchestrator {
                 continue;
             }
 
-            var location = contextsBySourceProvider.get(provider.sourceProviderId());
+            var location = fulfillmentContexts.contextFor(provider.sourceProviderId()).orElse(null);
             if (location == null) {
                 attempts.add(attempt(provider, ProviderPathAttemptStatus.MISSING_CONTEXT));
                 continue;

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/LocationBoundaryArchitectureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/LocationBoundaryArchitectureTest.java
@@ -1,0 +1,19 @@
+package io.github.trueruslan.zakupgotov.location;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.Test;
+
+class LocationBoundaryArchitectureTest {
+
+    @Test
+    void locationDomainDoesNotDependOnProviderOrRetailerPackages() {
+        var classes = new ClassFileImporter().importPackages("io.github.trueruslan.zakupgotov");
+
+        noClasses()
+                .that().resideInAPackage("..location..")
+                .should().dependOnClassesThat().resideInAnyPackage("..provider..", "..retailer..")
+                .check(classes);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/ProductLocationTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/ProductLocationTest.java
@@ -1,0 +1,55 @@
+package io.github.trueruslan.zakupgotov.location;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ProductLocationTest {
+
+    private static final ProductLocationId ID = new ProductLocationId(
+            UUID.fromString("55555555-5555-5555-5555-555555555555"));
+
+    @Test
+    void keepsPreciseAddressRedactedByDefault() {
+        var location = ProductLocation.withAddress(ID, " Москва ", " ул. Тестовая, 10 ");
+
+        assertThat(location.id()).isEqualTo(ID);
+        assertThat(location.locality()).isEqualTo("Москва");
+        assertThat(location.address()).get().extracting(SensitiveAddress::reveal).isEqualTo("ул. Тестовая, 10");
+        assertThat(location.address().orElseThrow().toString()).isEqualTo("[REDACTED]");
+        assertThat(location.toString()).doesNotContain("Тестовая", "10");
+    }
+
+    @Test
+    void supportsLocalityOnlyLocationWithoutInventingPreciseAddress() {
+        var location = ProductLocation.localityOnly(ID, "  Москва  ");
+
+        assertThat(location.locality()).isEqualTo("Москва");
+        assertThat(location.address()).isEmpty();
+        assertThat(location.toString()).contains("Москва").doesNotContain("provider", "store", "shopCode");
+    }
+
+    @Test
+    void sensitiveAddressHasValueEqualityWithoutExposingRawValueInStringForm() {
+        assertThat(SensitiveAddress.of(" ул. Тестовая, 10 "))
+                .isEqualTo(SensitiveAddress.of("ул. Тестовая, 10"));
+        assertThat(SensitiveAddress.of("ул. Тестовая, 10").hashCode())
+                .isEqualTo(SensitiveAddress.of("ул. Тестовая, 10").hashCode());
+        assertThat(SensitiveAddress.of("ул. Тестовая, 10").toString()).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    void rejectsMissingIdentityBlankLocalityAndBlankAddress() {
+        assertThatThrownBy(() -> new ProductLocationId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("value");
+        assertThatThrownBy(() -> ProductLocation.localityOnly(ID, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("locality");
+        assertThatThrownBy(() -> ProductLocation.withAddress(ID, "Москва", "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("address");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSetTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSetTest.java
@@ -1,0 +1,118 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class FulfillmentContextSetTest {
+
+    private static final ProductLocationId LOCATION_ID = new ProductLocationId(
+            UUID.fromString("55555555-5555-5555-5555-555555555555"));
+    private static final ProductLocationId OTHER_LOCATION_ID = new ProductLocationId(
+            UUID.fromString("66666666-6666-6666-6666-666666666666"));
+
+    @Test
+    void preservesManualAndResolvedProviderContextsInStableOrder() {
+        var manual = binding(
+                LOCATION_ID,
+                "magnit-public-web",
+                "shop-42",
+                FulfillmentContextSelectionMode.MANUAL);
+        var resolved = binding(
+                LOCATION_ID,
+                "kuper",
+                "fulfillment-99",
+                FulfillmentContextSelectionMode.RESOLVED);
+
+        var contexts = FulfillmentContextSet.of(LOCATION_ID, List.of(manual, resolved));
+
+        assertThat(contexts.productLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(contexts.bindings()).containsExactly(manual, resolved);
+        assertThat(contexts.bindingFor("magnit-public-web")).contains(manual);
+        assertThat(contexts.contextFor("kuper")).contains(resolved.context());
+        assertThat(contexts.bindingFor("unknown-provider")).isEmpty();
+    }
+
+    @Test
+    void rejectsBindingThatBelongsToAnotherProductLocation() {
+        var foreign = binding(
+                OTHER_LOCATION_ID,
+                "magnit-public-web",
+                "shop-42",
+                FulfillmentContextSelectionMode.MANUAL);
+
+        assertThatThrownBy(() -> FulfillmentContextSet.of(LOCATION_ID, List.of(foreign)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("productLocationId");
+    }
+
+    @Test
+    void rejectsDuplicateSourceProviderContext() {
+        var first = binding(
+                LOCATION_ID,
+                "kuper",
+                "fulfillment-1",
+                FulfillmentContextSelectionMode.RESOLVED);
+        var second = binding(
+                LOCATION_ID,
+                "kuper",
+                "fulfillment-2",
+                FulfillmentContextSelectionMode.MANUAL);
+
+        assertThatThrownBy(() -> FulfillmentContextSet.of(LOCATION_ID, List.of(first, second)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate")
+                .hasMessageContaining("kuper");
+    }
+
+    @Test
+    void exposesImmutableBindingSnapshot() {
+        var contexts = FulfillmentContextSet.of(
+                LOCATION_ID,
+                List.of(binding(
+                        LOCATION_ID,
+                        "kuper",
+                        "fulfillment-99",
+                        FulfillmentContextSelectionMode.RESOLVED)));
+
+        assertThatThrownBy(() -> contexts.bindings().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsMissingBindingParts() {
+        assertThatThrownBy(() -> new FulfillmentContextBinding(
+                        null,
+                        new LocationContext("kuper", "fulfillment-99", "Москва"),
+                        FulfillmentContextSelectionMode.RESOLVED))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("productLocationId");
+        assertThatThrownBy(() -> new FulfillmentContextBinding(
+                        LOCATION_ID,
+                        null,
+                        FulfillmentContextSelectionMode.RESOLVED))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("context");
+        assertThatThrownBy(() -> new FulfillmentContextBinding(
+                        LOCATION_ID,
+                        new LocationContext("kuper", "fulfillment-99", "Москва"),
+                        null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("mode");
+    }
+
+    private static FulfillmentContextBinding binding(
+            ProductLocationId productLocationId,
+            String sourceProviderId,
+            String fulfillmentContextId,
+            FulfillmentContextSelectionMode mode) {
+        return new FulfillmentContextBinding(
+                productLocationId,
+                new LocationContext(sourceProviderId, fulfillmentContextId, "Москва"),
+                mode);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathLocationBoundaryTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathLocationBoundaryTest.java
@@ -1,0 +1,34 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocation;
+import io.github.trueruslan.zakupgotov.location.SensitiveAddress;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProviderPathLocationBoundaryTest {
+
+    @Test
+    void orchestratorRequiresTypedFulfillmentContextSetInsteadOfRawProviderMap() throws Exception {
+        var search = ProviderPathOrchestrator.class.getMethod(
+                "search",
+                RetailerId.class,
+                List.class,
+                FulfillmentContextSet.class,
+                ProductQuery.class);
+
+        assertThat(search.getParameterTypes())
+                .contains(FulfillmentContextSet.class)
+                .doesNotContain(ProductLocation.class, SensitiveAddress.class);
+
+        assertThat(Arrays.stream(ProviderPathOrchestrator.class.getMethods())
+                        .filter(method -> method.getName().equals("search"))
+                        .flatMap(method -> Arrays.stream(method.getParameterTypes())))
+                .noneMatch(Map.class::isAssignableFrom);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java
@@ -3,12 +3,14 @@ package io.github.trueruslan.zakupgotov.provider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
 import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +18,8 @@ class ProviderPathOrchestratorTest {
 
     private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T06:30:00Z");
     private static final ProductQuery QUERY = new ProductQuery("молоко");
+    private static final ProductLocationId PRODUCT_LOCATION_ID = new ProductLocationId(
+            UUID.fromString("55555555-5555-5555-5555-555555555555"));
 
     @Test
     void selectsHighestPriorityEligiblePathForRequestedRetailer() {
@@ -89,7 +93,7 @@ class ProviderPathOrchestratorTest {
         var outcome = ProviderPathOrchestrator.offline().search(
                 RetailerId.PYATEROCHKA,
                 List.of(direct, aggregator),
-                Map.of("kuper", context(aggregator)),
+                contexts(aggregator),
                 QUERY);
 
         assertThat(outcome.attempts()).containsExactly(
@@ -200,12 +204,15 @@ class ProviderPathOrchestratorTest {
         return Set.of(ProviderCapability.PRODUCT_SEARCH, ProviderCapability.PRICE);
     }
 
-    private static Map<String, LocationContext> contexts(FakeFixtureProvider... providers) {
-        var builder = new java.util.LinkedHashMap<String, LocationContext>();
+    private static FulfillmentContextSet contexts(FakeFixtureProvider... providers) {
+        var bindings = new ArrayList<FulfillmentContextBinding>();
         for (var provider : providers) {
-            builder.put(provider.sourceProviderId(), context(provider));
+            bindings.add(new FulfillmentContextBinding(
+                    PRODUCT_LOCATION_ID,
+                    context(provider),
+                    FulfillmentContextSelectionMode.MANUAL));
         }
-        return Map.copyOf(builder);
+        return FulfillmentContextSet.of(PRODUCT_LOCATION_ID, bindings);
     }
 
     private static LocationContext context(FakeFixtureProvider provider) {

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **location / fulfillment-context product boundary over the completed provenance-aware provider/path orchestration layer**
+Current focus: **price / availability snapshot model with explicit provenance and freshness semantics**
 
 ## Product connectivity invariant
 
@@ -40,62 +40,63 @@ M0 completion is a **technical feasibility decision**, not blanket production-da
 
 ### Slice 1 — canonical retailer registry — COMPLETE
 
-PR #72 established the first M1 domain boundary:
+PR #72 established:
 
 - canonical retailer/banner IDs for Pyaterochka, Perekrestok, Chizhik, Magnit, Lenta, VkusVill, Ozon Fresh and Samokat;
-- explicit `RetailerCoverageState` vocabulary;
+- explicit `RetailerCoverageState`;
 - independent `ProductionAccessStatus` so technical feasibility cannot silently become production activation;
-- immutable registry entries and stable product order;
-- fail-fast invariant requiring every canonical retailer ID to have a registry entry;
-- Kuper intentionally remains acquisition-provider/aggregator provenance rather than retailer identity.
-
-Initial accepted technical states are preserved:
-
-- Pyaterochka — `AVAILABLE_BROWSER_BRIDGE`;
-- Perekrestok — `AVAILABLE_BROWSER_BRIDGE`;
-- Magnit — `AVAILABLE_PUBLIC_WEB`, production access `UNRESOLVED`;
-- Chizhik, Lenta, VkusVill, Ozon Fresh and Samokat — `DISCOVERY`.
+- immutable entries, stable product order and fail-fast registry completeness;
+- Kuper remains acquisition-provider/aggregator provenance rather than retailer identity.
 
 ### Slice 2 — shopping-list core + canonical quantities — COMPLETE
 
-PR #73 established deterministic shopping requirements without provider dependencies:
+PR #73 established:
 
-- positive decimal `Quantity` values only;
-- kilograms normalize to grams;
-- liters normalize to milliliters;
-- piece quantities remain piece-based;
-- equivalent decimal representations normalize to stable value equality;
-- package/container selection remains outside the requirement model and belongs to matching/basket optimization;
-- `ShoppingRequirement` performs whitespace-only normalization and preserves user wording/case;
-- `ShoppingList` owns stable UUID list/item identity and insertion order;
-- add/replace/remove reject duplicate or unknown item IDs instead of guessing;
-- exposed item views are immutable;
-- automatic duplicate-name merging is intentionally deferred.
+- positive decimal `Quantity` values;
+- `kg → g`, `l → ml`, pieces unchanged;
+- stable UUID list/item identity and insertion order;
+- whitespace-only requirement normalization;
+- explicit add/replace/remove semantics with duplicate/unknown IDs rejected;
+- immutable item views;
+- package/container selection and duplicate-name merging intentionally deferred to later matching/planning layers.
 
 ### Slice 3 — provenance-aware provider/path orchestration — COMPLETE
 
-PR #74 establishes the first deterministic M1 acquisition-routing boundary:
+PR #74 established:
 
-- normalized `ObservedOffer` now preserves `retailerId`, `sourceProviderId` and `sourceMode` independently from fulfillment context, SKU, price, availability, observation time and source reference;
-- `AcquisitionMode` distinguishes `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB` and `BROWSER_BRIDGE` without overloading `ProviderAccessType`;
-- `RetailerProvider` declares its retailer identity, source-provider identity and acquisition mode explicitly;
-- `LocationContext` is source-provider scoped rather than ambiguously provider-labelled;
-- fixture-only `ProviderPathOrchestrator` selects deterministic priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE`, then source-provider ID as a stable tie-breaker;
-- providers for other retailers are ignored rather than mixed into the requested retailer result;
-- missing required capabilities and missing provider-scoped context are explicit non-invoking attempt states;
-- only the explicit `ProviderPathUnavailableException` triggers fallback to another path;
-- a successful empty search remains a successful selected path and does not silently mix results from a lower-priority source;
-- unexpected runtime defects propagate instead of being hidden by fallback;
-- unsuccessful routing returns an explicit outcome with attempted-path evidence rather than pretending the retailer is absent;
-- the common trust boundary rejects observations whose retailer, source provider, acquisition mode or fulfillment context do not match the provider/request contract.
+- `ObservedOffer` preserves `retailerId`, `sourceProviderId` and `sourceMode` independently from fulfillment context, SKU, price, availability, observation time and source reference;
+- `AcquisitionMode`: `DIRECT_API`, `AGGREGATOR`, `PUBLIC_WEB`, `BROWSER_BRIDGE`;
+- `RetailerProvider` declares retailer, source-provider and acquisition mode explicitly;
+- deterministic fixture-only priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE` with stable source-provider tie-break;
+- explicit attempt states for missing capabilities, missing context, expected path failure and success;
+- fallback only on `ProviderPathUnavailableException`;
+- successful empty search does not silently mix a lower-priority source;
+- unexpected provider defects propagate;
+- trust validation rejects retailer/source-provider/source-mode/fulfillment-context mismatch.
 
-All three provider/orchestration behaviors were developed through separate RED→GREEN cycles and verified by full Maven `verify` before final repository gating. Ordinary CI still performs no live retailer traffic.
+### Slice 4 — product location / fulfillment-context boundary — COMPLETE
+
+PR #75 establishes the privacy and modularity boundary required before snapshots and comparison:
+
+- provider-neutral `ProductLocationId` is an opaque UUID identity;
+- `ProductLocation` contains only product location identity, normalized locality and optional `SensitiveAddress`;
+- `SensitiveAddress` exposes the raw value only through explicit `reveal()` and always renders as `[REDACTED]` by default;
+- `ProductLocation.toString()` never renders the precise address;
+- ArchUnit enforces that production `..location..` classes do not depend on `..provider..` or `..retailer..` packages;
+- `FulfillmentContextBinding` links an opaque `ProductLocationId` to a source-provider-scoped `LocationContext` without storing `ProductLocation` or precise address;
+- binding provenance distinguishes `MANUAL` and `RESOLVED` context selection without claiming that automatic resolution exists for every provider;
+- `FulfillmentContextSet` preserves stable binding order, rejects bindings for another product location and rejects duplicate source-provider contexts;
+- `ProviderPathOrchestrator` now consumes `FulfillmentContextSet`; the raw `Map<String, LocationContext>` boundary was removed;
+- orchestration has no `ProductLocation` or `SensitiveAddress` parameter, so provider routing cannot accidentally receive/log a precise user address;
+- all previous priority, fallback, capability and provenance-validation behavior remains unchanged.
+
+The slice was delivered through three explicit RED→GREEN cycles. Ordinary CI still makes no live retailer requests.
 
 ## Accepted retailer paths
 
 ### Pyaterochka
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. The real first-party browser gate on 2026-08-11 produced 12 normalized observations, one fulfillment context and zero normalized validation failures. The direct anonymous server path remains unsuitable (`store-403`).
+Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. The real first-party browser gate produced 12 normalized observations, one fulfillment context and zero normalized validation failures. The direct anonymous server path remains unsuitable (`store-403`).
 
 Evidence:
 
@@ -106,18 +107,13 @@ Evidence:
 
 Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter v2. Repeated real first-party browser evidence produced 90 normalized observations, one fulfillment context and zero acceptance-validation failures.
 
-Issue #54 remains non-blocking lifecycle hardening for same-document store changes / SPA navigation; accepted page-snapshot operation assumes intended store selection followed by reload.
-
-Evidence:
-
-- [`integrations/perekrestok-browser-bridge-phase-a.md`](integrations/perekrestok-browser-bridge-phase-a.md);
-- [`integrations/perekrestok-browser-bridge-live-2026-08-11.md`](integrations/perekrestok-browser-bridge-live-2026-08-11.md).
+Issue #54 remains lifecycle hardening for same-document store changes / SPA navigation; accepted page-snapshot operation assumes intended store selection followed by reload.
 
 ### Magnit
 
 Status: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context technical feasibility**.
 
-Final Phase B merged-main evidence proved 20/20 HTTP and usable SKU/current-price observations in each of two explicit public `shopCode` contexts, stable identity 20/20, zero failed requirements, explicit availability where supported and `UNKNOWN` otherwise, plus fail-closed promo/regular-price semantics.
+Final Phase B evidence proved 20/20 HTTP and usable SKU/current-price observations in each of two explicit public `shopCode` contexts, stable identity 20/20 and zero failed requirements while availability remains `UNKNOWN` when stock semantics are not proven.
 
 Production constraints remain explicit:
 
@@ -131,41 +127,31 @@ Evidence:
 - [`integrations/magnit-phase-b.md`](integrations/magnit-phase-b.md);
 - [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
 
-## Provider foundation
-
-Verified connectivity infrastructure now includes:
-
-- provenance-complete `ObservedOffer` trust boundary;
-- source-provider-scoped `LocationContext`;
-- normalized `ProductQuery`;
-- metadata-explicit `RetailerProvider` port;
-- structural fixture/live provider separation;
-- deterministic fixture-only path orchestration and explicit attempt outcomes;
-- explicit live-probe entry points kept outside ordinary CI;
-- retailer-neutral browser adapter registry;
-- first-class `apps/retailer-bridge` workspace and persistent-Chromium gate.
-
-## M1 entry rules
+## M1 invariants
 
 1. shopping/basket logic runs deterministically over fixtures;
 2. retailer coverage remains explicit and unavailable paths are never silently omitted;
-3. retailer, source-provider, acquisition mode and fulfillment-context provenance remain distinct;
-4. `UNKNOWN` availability is preserved;
-5. observation time is not misrepresented as provider-side freshness;
-6. production activation respects recorded usage-rights state;
-7. universal retailer connectivity continues for every registry entry.
+3. product location remains provider-neutral;
+4. precise addresses are sensitive and redacted by default;
+5. provider-specific store/fulfillment IDs remain inside provider-scoped contexts;
+6. retailer, source-provider, acquisition mode and fulfillment-context provenance remain distinct;
+7. `UNKNOWN` availability is preserved;
+8. observation time is not misrepresented as provider-side freshness;
+9. production activation respects recorded usage-rights state;
+10. universal retailer connectivity continues for every registry entry.
 
 ## Immediate next work
 
-1. **Location / fulfillment-context product boundary — NEXT**
-   - define provider-neutral user/product location input separately from provider-specific fulfillment contexts;
-   - prevent `shopCode`, X5 store IDs and other provider identifiers from leaking into shopping/basket domain objects;
-   - support explicit/manual contexts where automatic resolution is not proven;
-   - keep precise user addresses out of fixtures/logs by default.
-2. Price/availability snapshots with provenance and freshness semantics.
-3. Deterministic product-matching baseline.
-4. Complete single-store basket comparison.
-5. Coverage/failure/freshness UX and critical browser E2E.
+1. **Price / availability snapshots — NEXT**
+   - define immutable snapshot identity/value boundary;
+   - preserve retailer, source-provider, acquisition mode and fulfillment context;
+   - preserve explicit `AVAILABLE` / `UNAVAILABLE` / `UNKNOWN`;
+   - distinguish observation time from provider-side freshness/update time;
+   - reject invalid currency/price/timestamps/provenance fail-closed;
+   - remain fixture-first and independent from live retailer access.
+2. Deterministic product-matching baseline.
+3. Complete single-store basket comparison.
+4. Coverage/failure/freshness UX and critical browser E2E.
 
 ## Parallel open work
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,18 +26,17 @@ Final technical exit status:
 - retailer-neutral connectivity architecture proven;
 - known limitations recorded rather than hidden.
 
-Magnit final evidence: [`integrations/magnit-public-page-phase-b-live-2026-08-12.md`](integrations/magnit-public-page-phase-b-live-2026-08-12.md).
-
 M0 completion is technical feasibility, not production access clearance. Issues #69, #70 and #54 remain explicit constraints/hardening work.
 
 ## M1 — Shopping Core — CURRENT
 
-Goal: compare a manually entered grocery list across connected retailers while preserving explicit coverage state, fulfillment context, provenance, freshness and uncertainty.
+Goal: compare a manually entered grocery list across connected retailers while preserving explicit coverage state, privacy-safe location input, fulfillment context, provenance, freshness and uncertainty.
 
 ### Entry rules
 
 - fixture-first provider orchestration;
 - unavailable/blocked registry entries remain visible;
+- product location stays provider-neutral and precise addresses are redacted by default;
 - retailer identity, source-provider identity, acquisition mode and fulfillment context remain distinct;
 - `UNKNOWN` availability remains first-class;
 - observation time is not misrepresented as provider update time;
@@ -62,29 +61,31 @@ Goal: compare a manually entered grocery list across connected retailers while p
    - non-positive quantities rejected;
    - package/container selection deliberately deferred to matching/basket optimization.
 3. **Provider/path orchestration over deterministic fixtures — COMPLETE (PR #74)**
-   - `ObservedOffer` preserves explicit `retailerId`, `sourceProviderId` and acquisition/source mode;
-   - `RetailerProvider` declares retailer, source provider and acquisition mode separately;
+   - explicit `retailerId`, `sourceProviderId` and acquisition/source mode on `ObservedOffer`;
    - deterministic priority `DIRECT_API → AGGREGATOR → PUBLIC_WEB → BROWSER_BRIDGE`;
-   - stable source-provider tie-break for same-mode candidates;
    - capability-aware and provider-context-aware eligibility;
-   - explicit attempt states for missing capabilities, missing context, expected failure and success;
-   - fallback only on explicit expected path-unavailable failure;
-   - successful empty search does not mix/fallback to another provider;
-   - unexpected provider defects propagate;
-   - trust boundary rejects retailer/source-provider/source-mode/fulfillment-context provenance mismatch;
+   - explicit attempt outcomes;
+   - fallback only on expected path-unavailable failure;
+   - successful empty search does not mix providers;
+   - unexpected defects propagate;
+   - trust boundary rejects provenance mismatch;
    - live adapters remain outside ordinary CI.
-4. **Location / fulfillment-context boundary — NEXT**
-   - provider-neutral product location input;
-   - provider-scoped context resolution/selection;
-   - explicit/manual contexts where automatic resolution is unavailable;
-   - no `shopCode`, X5 store IDs or other provider identifiers leaking into shopping/basket logic;
-   - precise user addresses stay out of fixtures/logs by default.
-5. **Price and availability snapshots**
-   - observation time;
-   - currency/price representation;
+4. **Location / fulfillment-context boundary — COMPLETE (PR #75)**
+   - opaque provider-neutral `ProductLocationId`;
+   - `ProductLocation` with locality and optional redacted `SensitiveAddress`;
+   - explicit `reveal()` for sensitive address use, default string/log representation `[REDACTED]`;
+   - ArchUnit prevents `location` production code from depending on provider/retailer packages;
+   - typed `FulfillmentContextBinding` and `FulfillmentContextSet` link only opaque location identity to provider-scoped contexts;
+   - manual and resolved context-selection modes are explicit without claiming universal automatic resolution;
+   - duplicate provider contexts and cross-location bindings fail closed;
+   - provider orchestrator consumes typed context sets, not raw provider maps or exact addresses.
+5. **Price and availability snapshots — NEXT**
+   - immutable snapshot identity/value boundary;
+   - observation time distinct from provider-side freshness/update time;
    - explicit availability including `UNKNOWN`;
-   - source and fulfillment-context provenance;
-   - freshness limitations surfaced to callers/UI.
+   - retailer/source-provider/acquisition-mode/fulfillment-context provenance;
+   - currency/price validation and fail-closed temporal/provenance validation;
+   - fixture-first snapshot tests with no live retailer dependency.
 6. **Deterministic product-matching baseline**
    - exact/normalized matching first;
    - explicit ambiguous/unmatched state;
@@ -104,21 +105,6 @@ Goal: compare a manually entered grocery list across connected retailers while p
    - compare available retailers;
    - inspect missing coverage/freshness/provenance honestly.
 
-### Scope
-
-- shopping list CRUD;
-- canonical units/quantities;
-- address/location input;
-- retailer registry and coverage-state visibility;
-- provider/path orchestration;
-- deterministic product matching baseline;
-- package/quantity selection baseline;
-- price and availability snapshots;
-- complete-basket comparison;
-- partial-provider failure UX;
-- data freshness UX;
-- provenance UX for aggregator, public-web and browser-assisted observations.
-
 ### Exit criteria
 
 - critical journey covered by automated integration and browser E2E tests;
@@ -126,6 +112,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - one-store ranking deterministic and explainable;
 - unavailable retailer coverage explicit;
 - no test or user path requires hidden live retailer access;
+- product location remains provider-neutral and precise user addresses are not leaked into provider routing/logs;
 - provider provenance, fulfillment context and freshness survive through basket comparison.
 
 ## M2 — Recipes

--- a/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
+++ b/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
@@ -1,6 +1,6 @@
 # M1 Location / Fulfillment Context Boundary Implementation Plan
 
-Status: **COMPLETE** — implemented in PR #75 on 2026-08-12.
+Status: **COMPLETE** — implemented and fully verified in PR #75 on 2026-08-12.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -92,8 +92,8 @@ Delivered behavior:
 - [x] **Step 3: Implement minimal orchestrator migration**
 - [x] **Step 4: Run Maven verify**
 - [x] **Step 5: Synchronize durable docs**
-- [ ] **Step 6: Run final repository CI/security gate and review**
+- [x] **Step 6: Run final repository CI/security gate and review**
 
 RED head `c2735cb11630f7b9da2d7f04bf983bd618c657d8` failed with seven expected compile errors because `ProviderPathOrchestrator` still required `Map<String, LocationContext>`. GREEN head `a58b0e3cf8baf29c8caa9da7ef5926e66a8d0fd9` replaced that raw map with `FulfillmentContextSet` and passed full Maven verification without changing priority, capability, fallback or provenance behavior.
 
-Final repository-wide CI/security verification and exact-head review are the remaining shipping gate before squash merge.
+Shipping evidence: exact head `2e8721e33c23431e8273a13d5960cc0aff4d8cb9` passed API, Contract, Web/E2E, CodeQL Java + JavaScript/TypeScript, Dependency Review, Retailer Bridge, Container Security API + Web, Release Bundle and Release Contract before this documentation-only completion marker was written. The completion-marker head must pass the same required repository gate before squash merge.

--- a/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
+++ b/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
@@ -1,0 +1,139 @@
+# M1 Location / Fulfillment Context Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Separate privacy-sensitive provider-neutral product location from provider-specific fulfillment contexts, then route fixture providers through typed bindings instead of raw provider-ID maps.
+
+**Architecture:** Introduce a `location` domain package that owns product location identity and a redacted sensitive-address value object without any dependency on retailer/provider packages. The provider package owns bindings from an opaque `ProductLocationId` to source-provider-scoped `LocationContext` values and records whether a context was manually selected or resolved. `ProviderPathOrchestrator` consumes a typed `FulfillmentContextSet`, never a precise address or raw `Map<String, LocationContext>`.
+
+**Tech Stack:** Java 25, JUnit 5, AssertJ, ArchUnit/Spring Modulith verification, Maven 3.9.16.
+
+## Global Constraints
+
+- Precise user addresses are sensitive user data and must be redacted from default string/log representations.
+- `location` domain types must not depend on `provider` or `retailer` packages.
+- Provider-specific identifiers such as Magnit `shopCode` and X5 store IDs must remain inside provider-scoped fulfillment contexts.
+- Ordinary CI must remain fully deterministic and make no live retailer requests.
+- Automatic location resolution is not claimed by this slice; manual and already-resolved provider contexts are both representable.
+- TDD is mandatory: each behavior starts RED, then minimal GREEN, then full Maven verification.
+
+---
+
+### Task 1: Provider-neutral product location and sensitive address
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocationId.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/SensitiveAddress.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocation.java`
+- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/ProductLocationTest.java`
+- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/LocationBoundaryArchitectureTest.java`
+
+**Interfaces:**
+- Produces: `ProductLocationId(UUID value)`.
+- Produces: `SensitiveAddress.of(String raw)`, `String reveal()`, redacted `toString()`.
+- Produces: `ProductLocation.localityOnly(ProductLocationId id, String locality)`.
+- Produces: `ProductLocation.withAddress(ProductLocationId id, String locality, String address)`.
+- Produces: `id()`, `locality()`, `Optional<SensitiveAddress> address()`.
+
+- [ ] **Step 1: Write failing value/privacy tests**
+
+```java
+@Test
+void keepsPreciseAddressRedactedByDefault() {
+    var location = ProductLocation.withAddress(ID, " Москва ", " ул. Тестовая, 10 ");
+    assertThat(location.locality()).isEqualTo("Москва");
+    assertThat(location.address()).get().extracting(SensitiveAddress::reveal).isEqualTo("ул. Тестовая, 10");
+    assertThat(location.address().orElseThrow().toString()).isEqualTo("[REDACTED]");
+    assertThat(location.toString()).doesNotContain("Тестовая", "10");
+}
+```
+
+Also require locality-only locations, blank locality/address rejection, non-null ID, immutable equality semantics for IDs, and no raw provider identifiers on the product location API.
+
+- [ ] **Step 2: Add architecture RED**
+
+Use ArchUnit to require that `..location..` classes do not depend on `..provider..` or `..retailer..` classes.
+
+- [ ] **Step 3: Run `./mvnw --batch-mode --no-transfer-progress verify` in `apps/api`**
+
+Expected: RED because the `location` package/types do not exist.
+
+- [ ] **Step 4: Implement minimal product location types**
+
+`SensitiveAddress` stores trimmed raw text, exposes it only through explicit `reveal()`, implements value equality/hashCode, and always returns `[REDACTED]` from `toString()`. `ProductLocation` validates/normalizes locality, stores optional sensitive address, and uses a custom redacted `toString()`.
+
+- [ ] **Step 5: Run full Maven verify and commit GREEN**
+
+Expected: all API tests and architecture checks pass.
+
+---
+
+### Task 2: Typed fulfillment-context bindings
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSelectionMode.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextBinding.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSet.java`
+- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSetTest.java`
+
+**Interfaces:**
+- Produces enum: `MANUAL`, `RESOLVED`.
+- Produces record: `FulfillmentContextBinding(ProductLocationId productLocationId, LocationContext context, FulfillmentContextSelectionMode mode)`.
+- Produces: `FulfillmentContextSet.of(ProductLocationId productLocationId, List<FulfillmentContextBinding> bindings)`.
+- Produces: `productLocationId()`, `bindings()`, `Optional<FulfillmentContextBinding> bindingFor(String sourceProviderId)`, `Optional<LocationContext> contextFor(String sourceProviderId)`.
+
+- [ ] **Step 1: Write failing binding tests**
+
+Require manual and resolved contexts to coexist, preserve stable input order, reject bindings for a different `ProductLocationId`, reject duplicate `sourceProviderId`, return immutable bindings, and return empty for unknown source providers.
+
+- [ ] **Step 2: Run Maven verify**
+
+Expected: RED because binding types do not exist.
+
+- [ ] **Step 3: Implement minimal immutable binding set**
+
+Use an insertion-preserving map keyed by `LocationContext.sourceProviderId()`. The set stores only opaque `ProductLocationId` plus provider contexts; it never stores `ProductLocation` or `SensitiveAddress`.
+
+- [ ] **Step 4: Run Maven verify and commit GREEN**
+
+Expected: all tests pass.
+
+---
+
+### Task 3: Route providers through typed fulfillment contexts
+
+**Files:**
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java`
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java`
+- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathLocationBoundaryTest.java`
+- Modify: `docs/PROJECT_STATE.md`
+- Modify: `docs/ROADMAP.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Replaces the orchestration parameter `Map<String, LocationContext> contextsBySourceProvider` with `FulfillmentContextSet fulfillmentContexts`.
+- Retains all existing path ordering, capability checks, fallback behavior and trust validation unchanged.
+
+- [ ] **Step 1: Write failing typed-boundary test and migrate orchestration test calls**
+
+Require the orchestrator to accept `FulfillmentContextSet`, preserve `MISSING_CONTEXT` behavior for absent bindings, and expose no method that accepts a raw provider-context map.
+
+- [ ] **Step 2: Run Maven verify**
+
+Expected: RED because the orchestrator still requires the raw `Map<String, LocationContext>` signature.
+
+- [ ] **Step 3: Implement minimal orchestrator migration**
+
+Replace direct map lookup with `fulfillmentContexts.contextFor(provider.sourceProviderId())`; do not change priority, fallback or offer validation.
+
+- [ ] **Step 4: Run Maven verify**
+
+Expected: all provider/orchestration tests remain green.
+
+- [ ] **Step 5: Synchronize durable docs**
+
+Mark M1 slice 4 complete, make price/availability snapshots the next active slice, record privacy/address redaction and typed fulfillment binding behavior in `CHANGELOG.md`.
+
+- [ ] **Step 6: Run final repository CI/security gate and review**
+
+Require API, Contract, Web/E2E, CodeQL Java+JS/TS, Dependency Review, Retailer Bridge, Container Security API+Web, Release Bundle and Release Contract to pass on the exact final head before squash merge.

--- a/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
+++ b/docs/superpowers/plans/2026-08-12-m1-location-boundary.md
@@ -1,5 +1,7 @@
 # M1 Location / Fulfillment Context Boundary Implementation Plan
 
+Status: **COMPLETE** — implemented in PR #75 on 2026-08-12.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Separate privacy-sensitive provider-neutral product location from provider-specific fulfillment contexts, then route fixture providers through typed bindings instead of raw provider-ID maps.
@@ -19,121 +21,79 @@
 
 ---
 
-### Task 1: Provider-neutral product location and sensitive address
+### Task 1: Provider-neutral product location and sensitive address — COMPLETE
 
 **Files:**
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocationId.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/SensitiveAddress.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocation.java`
-- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/ProductLocationTest.java`
-- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/LocationBoundaryArchitectureTest.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocationId.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/SensitiveAddress.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/location/ProductLocation.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/ProductLocationTest.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/location/LocationBoundaryArchitectureTest.java`
 
-**Interfaces:**
-- Produces: `ProductLocationId(UUID value)`.
-- Produces: `SensitiveAddress.of(String raw)`, `String reveal()`, redacted `toString()`.
-- Produces: `ProductLocation.localityOnly(ProductLocationId id, String locality)`.
-- Produces: `ProductLocation.withAddress(ProductLocationId id, String locality, String address)`.
-- Produces: `id()`, `locality()`, `Optional<SensitiveAddress> address()`.
+- [x] **Step 1: Write failing value/privacy tests**
+- [x] **Step 2: Add architecture RED**
+- [x] **Step 3: Run Maven verify and observe RED**
+- [x] **Step 4: Implement minimal product location types**
+- [x] **Step 5: Run full Maven verify and commit GREEN**
 
-- [ ] **Step 1: Write failing value/privacy tests**
+RED head `48df6d36994f42ff684e95d1d7bc9d2a46d20d87` failed at `testCompile` only because location production types did not exist. GREEN head `f840ebe8ddea0d93b60be0421388f5cb332da4a5` passed full Maven verification including the ArchUnit dependency rule.
 
-```java
-@Test
-void keepsPreciseAddressRedactedByDefault() {
-    var location = ProductLocation.withAddress(ID, " Москва ", " ул. Тестовая, 10 ");
-    assertThat(location.locality()).isEqualTo("Москва");
-    assertThat(location.address()).get().extracting(SensitiveAddress::reveal).isEqualTo("ул. Тестовая, 10");
-    assertThat(location.address().orElseThrow().toString()).isEqualTo("[REDACTED]");
-    assertThat(location.toString()).doesNotContain("Тестовая", "10");
-}
-```
+Delivered behavior:
 
-Also require locality-only locations, blank locality/address rejection, non-null ID, immutable equality semantics for IDs, and no raw provider identifiers on the product location API.
-
-- [ ] **Step 2: Add architecture RED**
-
-Use ArchUnit to require that `..location..` classes do not depend on `..provider..` or `..retailer..` classes.
-
-- [ ] **Step 3: Run `./mvnw --batch-mode --no-transfer-progress verify` in `apps/api`**
-
-Expected: RED because the `location` package/types do not exist.
-
-- [ ] **Step 4: Implement minimal product location types**
-
-`SensitiveAddress` stores trimmed raw text, exposes it only through explicit `reveal()`, implements value equality/hashCode, and always returns `[REDACTED]` from `toString()`. `ProductLocation` validates/normalizes locality, stores optional sensitive address, and uses a custom redacted `toString()`.
-
-- [ ] **Step 5: Run full Maven verify and commit GREEN**
-
-Expected: all API tests and architecture checks pass.
+- `ProductLocationId(UUID value)` with non-null identity;
+- locality-only or locality+address product locations;
+- locality normalization and blank rejection;
+- explicit `SensitiveAddress.reveal()`;
+- default sensitive-address string representation `[REDACTED]`;
+- `ProductLocation.toString()` never renders the precise address;
+- production `location` package has no dependency on provider/retailer packages.
 
 ---
 
-### Task 2: Typed fulfillment-context bindings
+### Task 2: Typed fulfillment-context bindings — COMPLETE
 
 **Files:**
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSelectionMode.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextBinding.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSet.java`
-- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSetTest.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSelectionMode.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextBinding.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSet.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/FulfillmentContextSetTest.java`
 
-**Interfaces:**
-- Produces enum: `MANUAL`, `RESOLVED`.
-- Produces record: `FulfillmentContextBinding(ProductLocationId productLocationId, LocationContext context, FulfillmentContextSelectionMode mode)`.
-- Produces: `FulfillmentContextSet.of(ProductLocationId productLocationId, List<FulfillmentContextBinding> bindings)`.
-- Produces: `productLocationId()`, `bindings()`, `Optional<FulfillmentContextBinding> bindingFor(String sourceProviderId)`, `Optional<LocationContext> contextFor(String sourceProviderId)`.
+- [x] **Step 1: Write failing binding tests**
+- [x] **Step 2: Run Maven verify and observe RED**
+- [x] **Step 3: Implement minimal immutable binding set**
+- [x] **Step 4: Run Maven verify and commit GREEN**
 
-- [ ] **Step 1: Write failing binding tests**
+RED head `bf4bcdf63c0d76cd0029f2fddc26874c79ffb367` failed at `testCompile` only because typed binding classes did not exist. GREEN head `4f9d08d1f7d902ef8fce3cf5829087b68f7de9a9` passed full Maven verification.
 
-Require manual and resolved contexts to coexist, preserve stable input order, reject bindings for a different `ProductLocationId`, reject duplicate `sourceProviderId`, return immutable bindings, and return empty for unknown source providers.
+Delivered behavior:
 
-- [ ] **Step 2: Run Maven verify**
-
-Expected: RED because binding types do not exist.
-
-- [ ] **Step 3: Implement minimal immutable binding set**
-
-Use an insertion-preserving map keyed by `LocationContext.sourceProviderId()`. The set stores only opaque `ProductLocationId` plus provider contexts; it never stores `ProductLocation` or `SensitiveAddress`.
-
-- [ ] **Step 4: Run Maven verify and commit GREEN**
-
-Expected: all tests pass.
+- selection provenance `MANUAL` / `RESOLVED`;
+- a binding stores only opaque `ProductLocationId` plus source-provider-scoped `LocationContext`;
+- stable binding order;
+- immutable binding snapshot;
+- duplicate source-provider contexts rejected;
+- binding to another product location rejected;
+- unknown source provider returns no binding/context.
 
 ---
 
-### Task 3: Route providers through typed fulfillment contexts
+### Task 3: Route providers through typed fulfillment contexts — COMPLETE
 
 **Files:**
-- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java`
-- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java`
-- Test: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathLocationBoundaryTest.java`
-- Modify: `docs/PROJECT_STATE.md`
-- Modify: `docs/ROADMAP.md`
-- Modify: `CHANGELOG.md`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestrator.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathOrchestratorTest.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ProviderPathLocationBoundaryTest.java`
+- `docs/PROJECT_STATE.md`
+- `docs/ROADMAP.md`
+- `CHANGELOG.md`
 
-**Interfaces:**
-- Replaces the orchestration parameter `Map<String, LocationContext> contextsBySourceProvider` with `FulfillmentContextSet fulfillmentContexts`.
-- Retains all existing path ordering, capability checks, fallback behavior and trust validation unchanged.
-
-- [ ] **Step 1: Write failing typed-boundary test and migrate orchestration test calls**
-
-Require the orchestrator to accept `FulfillmentContextSet`, preserve `MISSING_CONTEXT` behavior for absent bindings, and expose no method that accepts a raw provider-context map.
-
-- [ ] **Step 2: Run Maven verify**
-
-Expected: RED because the orchestrator still requires the raw `Map<String, LocationContext>` signature.
-
-- [ ] **Step 3: Implement minimal orchestrator migration**
-
-Replace direct map lookup with `fulfillmentContexts.contextFor(provider.sourceProviderId())`; do not change priority, fallback or offer validation.
-
-- [ ] **Step 4: Run Maven verify**
-
-Expected: all provider/orchestration tests remain green.
-
-- [ ] **Step 5: Synchronize durable docs**
-
-Mark M1 slice 4 complete, make price/availability snapshots the next active slice, record privacy/address redaction and typed fulfillment binding behavior in `CHANGELOG.md`.
-
+- [x] **Step 1: Write failing typed-boundary test and migrate orchestration test calls**
+- [x] **Step 2: Run Maven verify and observe RED**
+- [x] **Step 3: Implement minimal orchestrator migration**
+- [x] **Step 4: Run Maven verify**
+- [x] **Step 5: Synchronize durable docs**
 - [ ] **Step 6: Run final repository CI/security gate and review**
 
-Require API, Contract, Web/E2E, CodeQL Java+JS/TS, Dependency Review, Retailer Bridge, Container Security API+Web, Release Bundle and Release Contract to pass on the exact final head before squash merge.
+RED head `c2735cb11630f7b9da2d7f04bf983bd618c657d8` failed with seven expected compile errors because `ProviderPathOrchestrator` still required `Map<String, LocationContext>`. GREEN head `a58b0e3cf8baf29c8caa9da7ef5926e66a8d0fd9` replaced that raw map with `FulfillmentContextSet` and passed full Maven verification without changing priority, capability, fallback or provenance behavior.
+
+Final repository-wide CI/security verification and exact-head review are the remaining shipping gate before squash merge.


### PR DESCRIPTION
## Goal
Implement M1 slice 4: separate privacy-sensitive provider-neutral product location from provider-specific fulfillment contexts, then route fixture providers through typed bindings instead of raw provider-ID maps.

## Approved design sources
- `docs/superpowers/specs/2026-08-09-zakup-gotov-foundation-design.md`;
- `docs/superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`;
- `docs/superpowers/plans/2026-08-12-m1-location-boundary.md`.

## Architectural boundaries
- precise user address is sensitive and never appears in default string/log output;
- production `location` code has no provider/retailer dependency;
- no `shopCode`, X5 store ID, source-provider ID or retailer ID exists in product-location types;
- provider-specific identifiers remain inside source-provider-scoped `LocationContext`;
- provider routing receives only opaque `ProductLocationId` bindings and never a precise address;
- `MANUAL` and `RESOLVED` bindings are distinguishable without claiming universal automatic resolution;
- no live retailer traffic, persistence, REST API or UI is introduced.

## TDD evidence
### Task 1 — provider-neutral location + privacy
RED `48df6d36994f42ff684e95d1d7bc9d2a46d20d87`: `testCompile` failed only because `ProductLocationId`, `ProductLocation`, `SensitiveAddress` did not exist. ArchUnit itself compiled.

GREEN `f840ebe8ddea0d93b60be0421388f5cb332da4a5`: opaque product-location identity, normalized locality, explicit sensitive address reveal, redacted string representation and production `location → provider/retailer` dependency prohibition. Full Maven `verify` passed with RED tests unchanged.

### Task 2 — typed fulfillment bindings
RED `bf4bcdf63c0d76cd0029f2fddc26874c79ffb367`: failed only on absent binding types.

GREEN `4f9d08d1f7d902ef8fce3cf5829087b68f7de9a9`: `MANUAL` / `RESOLVED` bindings, stable immutable context set, duplicate source-provider and cross-product-location rejection. Full Maven `verify` passed.

### Task 3 — typed orchestration boundary
RED `c2735cb11630f7b9da2d7f04bf983bd618c657d8`: seven expected compile errors because production orchestration still required `Map<String, LocationContext>`.

GREEN `a58b0e3cf8baf29c8caa9da7ef5926e66a8d0fd9`: orchestration now requires `FulfillmentContextSet.contextFor(sourceProviderId)` with priority/capability/fallback/provenance behavior unchanged. Boundary tests prove there is no raw `Map`, `ProductLocation`, or `SensitiveAddress` orchestration parameter. Full Maven `verify` passed.

## Documentation / shipping
`PROJECT_STATE.md`, `ROADMAP.md`, `CHANGELOG.md` and the implementation plan are synchronized. The plan records all implementation and shipping steps complete.

Exact final head: `63a18543a04b5dbe9d5dc0347125c594c4375f6d`.

Two repository-wide gates were observed: the functional/docs head `2e8721e33c23431e8273a13d5960cc0aff4d8cb9` passed completely, then the documentation-only completion marker produced the final head above and **API, Contract, Web/E2E, CodeQL Java+JS/TS, Dependency Review, Retailer Bridge, Container Security API+Web, Release Bundle and Release Contract all passed again**.

Final Change Review verdict: **Looks good**, no blocking findings.

## Non-goals
- no automatic address → provider-store resolver;
- no change to Magnit #69/#70 constraints;
- no persistence/schema migration;
- no REST API/UI;
- no price/availability snapshot aggregate yet;
- no live retailer access.

## Next after merge
M1 slice 5: price/availability snapshots with immutable provenance and freshness semantics.