### PR TITLE
feat(m1): add structured package evidence plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Responsive M1 comparison form/results UI with repeatable shopping rows, typed quantities, accessible error states and a bounded server-side comparison timeout.
 - Desktop/mobile Playwright critical-journey coverage that submits a real product request shape, keeps all eight retailer results visible and verifies that internal provider identifiers do not leak.
 - Preview architecture guard preventing upstream shopping/location/provider/matching/basket/comparison/retailer production packages from depending back on `preview`, and preventing production preview code from depending on fixture/test-support namespaces.
+- Optional source-validated canonical package quantity on `ObservedOffer`, preserved unchanged through immutable `OfferSnapshot` creation.
+- Snapshot-driven `PackageQuantitySet.fromSnapshots(...)` projection that creates basket bindings only for explicit structured package evidence.
+- Runtime package-evidence derivation from snapshots so comparison fixtures and future provider paths carry one provenance-preserving source of package truth.
+- Regression coverage proving presentation names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.
 
 ### Changed
 
@@ -46,14 +50,17 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - `ObservedOffer` remains the provider trust boundary; `OfferSnapshot` remains the immutable comparison record.
 - Observation time and provider-side update time remain distinct.
 - Matching never breaks semantic ambiguity using price, availability, freshness, acquisition mode or SKU ordering.
-- Package size/quantity is modeled as explicit basket evidence and is **not** inferred from `productName` or assumed to be one unit per SKU.
+- Package size/quantity is modeled as explicit structured evidence and is **not** inferred from `productName`, title, URL or other presentation text, nor assumed to be one unit per SKU.
+- Existing provider integrations remain source-compatible and package-unknown unless they explicitly supply a proven structured package quantity.
+- Runtime comparison package bindings now derive from immutable snapshot evidence instead of being independently injected downstream.
+- Deterministic comparison fixtures attach package quantity at the provider observation boundary before snapshotting, mirroring the production evidence flow without live retailer access.
 - `UNKNOWN` availability propagates into `AVAILABILITY_UNKNOWN` line state and an `UNCERTAIN` basket rather than a confirmed complete basket.
 - Incomplete single-store baskets expose no aggregate total, preventing partial-price comparisons from masquerading as complete basket prices.
 - Technical retailer connectivity no longer leaks directly into the product/API contract: public readiness uses stable coverage/access/comparison states and finite product-safe reason codes instead of provider IDs, acquisition modes or source references.
 - The home page now makes the stateless comparison preview the primary M1 action instead of the previous readiness-only surface.
 - The critical browser journey is driven through the generated OpenAPI client and the same product-safe comparison vocabulary as the core/read model.
 - Production comparison evidence remains deliberately no-op/fail-closed in this slice; passing deterministic acceptance does not claim live production retailer acquisition.
-- Active M1 focus moves from building the shopping-list comparison journey to trusted structured package evidence, retailer connectivity/lifecycle hardening and production-access constraints after #80 ships.
+- Active M1 focus is the first evidence-backed source-specific package extractor plus retailer connectivity/lifecycle and production-access constraints.
 
 ### Fixed
 
@@ -74,6 +81,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Incomplete/unavailable product comparison states cannot expose a misleading aggregate total or freshness summary.
 - Responsive Playwright coverage distinguishes product service-unavailable alerts from framework route announcements while preserving accessible alert semantics.
 - Critical-journey Playwright item-gap assertions are scoped to the relevant retailer card with exact text matching, avoiding collisions between item labels and explanatory retailer reason copy.
+- Runtime evidence rejects an explicit package-quantity set when it differs from the structured quantities preserved by its snapshots, preventing two package-evidence sources from silently diverging.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basket/PackageQuantitySet.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basket/PackageQuantitySet.java
@@ -1,7 +1,9 @@
 package io.github.trueruslan.zakupgotov.basket;
 
+import io.github.trueruslan.zakupgotov.provider.OfferSnapshot;
 import io.github.trueruslan.zakupgotov.provider.OfferSnapshotId;
 import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,17 @@ public final class PackageQuantitySet {
 
     public static PackageQuantitySet of(List<PackageQuantityBinding> bindings) {
         return new PackageQuantitySet(bindings);
+    }
+
+    public static PackageQuantitySet fromSnapshots(List<OfferSnapshot> snapshots) {
+        var input = Objects.requireNonNull(snapshots, "snapshots must not be null");
+        var bindings = new ArrayList<PackageQuantityBinding>();
+        for (var snapshot : input) {
+            Objects.requireNonNull(snapshot, "snapshot must not be null");
+            snapshot.packageQuantity().ifPresent(quantity ->
+                    bindings.add(new PackageQuantityBinding(snapshot.id(), quantity)));
+        }
+        return of(bindings);
     }
 
     public List<PackageQuantityBinding> bindings() {

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimeEvidence.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimeEvidence.java
@@ -21,6 +21,18 @@ public record RetailerRuntimeEvidence(
     public RetailerRuntimeEvidence(
             RetailerId retailerId,
             ProviderSearchOutcome providerOutcome,
+            List<OfferSnapshot> snapshots) {
+        this(
+                retailerId,
+                inferFulfillmentContext(providerOutcome, snapshots),
+                providerOutcome,
+                snapshots,
+                PackageQuantitySet.fromSnapshots(snapshots));
+    }
+
+    public RetailerRuntimeEvidence(
+            RetailerId retailerId,
+            ProviderSearchOutcome providerOutcome,
             List<OfferSnapshot> snapshots,
             PackageQuantitySet packageQuantities) {
         this(retailerId, inferFulfillmentContext(providerOutcome, snapshots), providerOutcome, snapshots, packageQuantities);
@@ -76,6 +88,25 @@ public record RetailerRuntimeEvidence(
                                 + binding.snapshotId().value());
             }
         }
+
+        var snapshotPackageQuantities = PackageQuantitySet.fromSnapshots(snapshots);
+        if (!packageQuantities.bindings().equals(snapshotPackageQuantities.bindings())) {
+            throw new IllegalArgumentException("package quantity evidence must match structured snapshot evidence");
+        }
+        packageQuantities = snapshotPackageQuantities;
+    }
+
+    public static RetailerRuntimeEvidence withFulfillmentContext(
+            RetailerId retailerId,
+            String fulfillmentContextId,
+            ProviderSearchOutcome providerOutcome,
+            List<OfferSnapshot> snapshots) {
+        return new RetailerRuntimeEvidence(
+                retailerId,
+                Optional.of(requireContext(fulfillmentContextId)),
+                providerOutcome,
+                snapshots,
+                PackageQuantitySet.fromSnapshots(snapshots));
     }
 
     public static RetailerRuntimeEvidence withFulfillmentContext(

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ObservedOffer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ObservedOffer.java
@@ -1,9 +1,11 @@
 package io.github.trueruslan.zakupgotov.provider;
 
 import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Currency;
+import java.util.Optional;
 
 public record ObservedOffer(
         RetailerId retailerId,
@@ -16,7 +18,8 @@ public record ObservedOffer(
         String currencyCode,
         AvailabilityStatus availability,
         Instant observedAt,
-        String sourceReference) {
+        String sourceReference,
+        Optional<Quantity> packageQuantity) {
 
     public ObservedOffer {
         retailerId = requireValue(retailerId, "retailerId");
@@ -33,6 +36,34 @@ public record ObservedOffer(
         availability = requireValue(availability, "availability");
         observedAt = requireValue(observedAt, "observedAt");
         sourceReference = requireText(sourceReference, "sourceReference");
+        packageQuantity = requireValue(packageQuantity, "packageQuantity");
+    }
+
+    public ObservedOffer(
+            RetailerId retailerId,
+            String sourceProviderId,
+            AcquisitionMode sourceMode,
+            String fulfillmentContextId,
+            String sku,
+            String productName,
+            BigDecimal price,
+            String currencyCode,
+            AvailabilityStatus availability,
+            Instant observedAt,
+            String sourceReference) {
+        this(
+                retailerId,
+                sourceProviderId,
+                sourceMode,
+                fulfillmentContextId,
+                sku,
+                productName,
+                price,
+                currencyCode,
+                availability,
+                observedAt,
+                sourceReference,
+                Optional.empty());
     }
 
     private static String requireText(String value, String field) {

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/OfferSnapshot.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/OfferSnapshot.java
@@ -1,9 +1,11 @@
 package io.github.trueruslan.zakupgotov.provider;
 
 import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class OfferSnapshot {
 
@@ -19,6 +21,7 @@ public final class OfferSnapshot {
     private final AvailabilityStatus availability;
     private final FreshnessEvidence freshness;
     private final String sourceReference;
+    private final Optional<Quantity> packageQuantity;
 
     private OfferSnapshot(
             OfferSnapshotId id,
@@ -41,6 +44,7 @@ public final class OfferSnapshot {
         this.currencyCode = observation.currencyCode();
         this.availability = observation.availability();
         this.sourceReference = observation.sourceReference();
+        this.packageQuantity = observation.packageQuantity();
     }
 
     public static OfferSnapshot observationOnly(
@@ -110,5 +114,9 @@ public final class OfferSnapshot {
 
     public String sourceReference() {
         return sourceReference;
+    }
+
+    public Optional<Quantity> packageQuantity() {
+        return packageQuantity;
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basket/PackageQuantityProjectionTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basket/PackageQuantityProjectionTest.java
@@ -1,0 +1,96 @@
+package io.github.trueruslan.zakupgotov.basket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.provider.AcquisitionMode;
+import io.github.trueruslan.zakupgotov.provider.AvailabilityStatus;
+import io.github.trueruslan.zakupgotov.provider.ObservedOffer;
+import io.github.trueruslan.zakupgotov.provider.OfferSnapshot;
+import io.github.trueruslan.zakupgotov.provider.OfferSnapshotId;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PackageQuantityProjectionTest {
+
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T16:30:00Z");
+    private static final OfferSnapshotId FIRST_ID = new OfferSnapshotId(
+            UUID.fromString("10101010-1010-1010-1010-101010101010"));
+    private static final OfferSnapshotId SECOND_ID = new OfferSnapshotId(
+            UUID.fromString("20202020-2020-2020-2020-202020202020"));
+    private static final OfferSnapshotId THIRD_ID = new OfferSnapshotId(
+            UUID.fromString("30303030-3030-3030-3030-303030303030"));
+
+    @Test
+    void projectsOnlyExplicitStructuredPackageEvidenceInSnapshotOrder() {
+        var first = OfferSnapshot.observationOnly(
+                FIRST_ID,
+                offer("sku-flour", "Мука", Optional.of(new Quantity(new BigDecimal("0.5"), QuantityUnit.KILOGRAM))));
+        var second = OfferSnapshot.observationOnly(
+                SECOND_ID,
+                offerWithoutPackage("sku-water", "Вода питьевая 1,5л"));
+        var third = OfferSnapshot.observationOnly(
+                THIRD_ID,
+                offer("sku-eggs", "Яйца", Optional.of(new Quantity(new BigDecimal("2"), QuantityUnit.PIECE))));
+
+        var set = PackageQuantitySet.fromSnapshots(List.of(first, second, third));
+
+        assertThat(set.bindings())
+                .extracting(PackageQuantityBinding::snapshotId)
+                .containsExactly(FIRST_ID, THIRD_ID);
+        assertThat(set.quantityFor(FIRST_ID))
+                .contains(new Quantity(new BigDecimal("500"), QuantityUnit.GRAM));
+        assertThat(set.quantityFor(SECOND_ID)).isEmpty();
+        assertThat(set.quantityFor(THIRD_ID))
+                .contains(new Quantity(new BigDecimal("2"), QuantityUnit.PIECE));
+    }
+
+    @Test
+    void projectionFailsClosedForMissingInputOrSnapshot() {
+        assertThatThrownBy(() -> PackageQuantitySet.fromSnapshots(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("snapshots");
+        assertThatThrownBy(() -> PackageQuantitySet.fromSnapshots(Arrays.asList((OfferSnapshot) null)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("snapshot");
+    }
+
+    private static ObservedOffer offer(String sku, String name, Optional<Quantity> packageQuantity) {
+        return new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "structured-fixture",
+                AcquisitionMode.AGGREGATOR,
+                "store-42",
+                sku,
+                name,
+                new BigDecimal("100.00"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                OBSERVED_AT,
+                "fixture://structured-package/" + sku,
+                packageQuantity);
+    }
+
+    private static ObservedOffer offerWithoutPackage(String sku, String name) {
+        return new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "structured-fixture",
+                AcquisitionMode.AGGREGATOR,
+                "store-42",
+                sku,
+                name,
+                new BigDecimal("100.00"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                OBSERVED_AT,
+                "fixture://structured-package/" + sku);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/ComparisonPreviewServiceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/ComparisonPreviewServiceTest.java
@@ -13,8 +13,6 @@ import static io.github.trueruslan.zakupgotov.comparison.RetailerComparisonStatu
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.trueruslan.zakupgotov.basket.BasketItemResolutionStatus;
-import io.github.trueruslan.zakupgotov.basket.PackageQuantityBinding;
-import io.github.trueruslan.zakupgotov.basket.PackageQuantitySet;
 import io.github.trueruslan.zakupgotov.provider.AcquisitionMode;
 import io.github.trueruslan.zakupgotov.provider.AvailabilityStatus;
 import io.github.trueruslan.zakupgotov.provider.ObservedOffer;
@@ -130,8 +128,7 @@ class ComparisonPreviewServiceTest {
                 RetailerId.PYATEROCHKA,
                 "ctx-empty",
                 outcome,
-                List.of(),
-                PackageQuantitySet.of(List.of()));
+                List.of());
         var source = (ComparisonRuntimeEvidenceSource) (shoppingList, productLocation) ->
                 ComparisonRuntimeEvidence.of(List.of(evidence));
 
@@ -241,8 +238,7 @@ class ComparisonPreviewServiceTest {
         return new RetailerRuntimeEvidence(
                 retailerId,
                 new ProviderSearchOutcome(retailerId, Optional.empty(), List.of(), List.of()),
-                List.of(),
-                PackageQuantitySet.of(List.of()));
+                List.of());
     }
 
     private static RetailerRuntimeEvidence successfulEvidence(
@@ -250,29 +246,44 @@ class ComparisonPreviewServiceTest {
             String context,
             List<ObservedOffer> offers,
             List<Quantity> packageQuantities) {
+        var normalizedOffers = new ArrayList<ObservedOffer>();
         var snapshots = new ArrayList<OfferSnapshot>();
-        var bindings = new ArrayList<PackageQuantityBinding>();
         for (var index = 0; index < offers.size(); index++) {
-            var snapshot = OfferSnapshot.observationOnly(
+            var offer = withPackageQuantity(offers.get(index), packageQuantities.get(index));
+            normalizedOffers.add(offer);
+            snapshots.add(OfferSnapshot.observationOnly(
                     new OfferSnapshotId(UUID.nameUUIDFromBytes((retailerId + "-snapshot-" + index).getBytes())),
-                    offers.get(index));
-            snapshots.add(snapshot);
-            var packageQuantity = packageQuantities.get(index);
-            if (packageQuantity != null) {
-                bindings.add(new PackageQuantityBinding(snapshot.id(), packageQuantity));
-            }
+                    offer));
         }
         var outcome = new ProviderSearchOutcome(
                 retailerId,
                 Optional.of(new ProviderPathSelection("fixture-" + retailerId.canonicalId(), AcquisitionMode.DIRECT_API)),
-                offers,
+                normalizedOffers,
                 List.of());
         return RetailerRuntimeEvidence.withFulfillmentContext(
                 retailerId,
                 context,
                 outcome,
-                snapshots,
-                PackageQuantitySet.of(bindings));
+                snapshots);
+    }
+
+    private static ObservedOffer withPackageQuantity(ObservedOffer offer, Quantity packageQuantity) {
+        if (packageQuantity == null) {
+            return offer;
+        }
+        return new ObservedOffer(
+                offer.retailerId(),
+                offer.sourceProviderId(),
+                offer.sourceMode(),
+                offer.fulfillmentContextId(),
+                offer.sku(),
+                offer.productName(),
+                offer.price(),
+                offer.currencyCode(),
+                offer.availability(),
+                offer.observedAt(),
+                offer.sourceReference(),
+                Optional.of(packageQuantity));
     }
 
     private static ObservedOffer offer(

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/DeterministicComparisonRuntimeEvidenceSource.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/DeterministicComparisonRuntimeEvidenceSource.java
@@ -1,7 +1,5 @@
 package io.github.trueruslan.zakupgotov.preview;
 
-import io.github.trueruslan.zakupgotov.basket.PackageQuantityBinding;
-import io.github.trueruslan.zakupgotov.basket.PackageQuantitySet;
 import io.github.trueruslan.zakupgotov.location.ProductLocation;
 import io.github.trueruslan.zakupgotov.provider.AcquisitionMode;
 import io.github.trueruslan.zakupgotov.provider.AvailabilityStatus;
@@ -111,8 +109,7 @@ final class DeterministicComparisonRuntimeEvidenceSource implements ComparisonRu
         return new RetailerRuntimeEvidence(
                 retailerId,
                 new ProviderSearchOutcome(retailerId, Optional.empty(), List.of(), List.of()),
-                List.of(),
-                PackageQuantitySet.of(List.of()));
+                List.of());
     }
 
     private static RetailerRuntimeEvidence successfulEvidence(
@@ -120,32 +117,47 @@ final class DeterministicComparisonRuntimeEvidenceSource implements ComparisonRu
             String fulfillmentContext,
             List<ObservedOffer> offers,
             List<Quantity> packageQuantities) {
+        var normalizedOffers = new ArrayList<ObservedOffer>();
         var snapshots = new ArrayList<OfferSnapshot>();
-        var bindings = new ArrayList<PackageQuantityBinding>();
         for (var index = 0; index < offers.size(); index++) {
-            var snapshot = OfferSnapshot.observationOnly(
+            var offer = withPackageQuantity(offers.get(index), packageQuantities.get(index));
+            normalizedOffers.add(offer);
+            snapshots.add(OfferSnapshot.observationOnly(
                     new OfferSnapshotId(UUID.nameUUIDFromBytes(
                             (retailerId.name() + "-acceptance-" + index).getBytes(StandardCharsets.UTF_8))),
-                    offers.get(index));
-            snapshots.add(snapshot);
-            var packageQuantity = packageQuantities.get(index);
-            if (packageQuantity != null) {
-                bindings.add(new PackageQuantityBinding(snapshot.id(), packageQuantity));
-            }
+                    offer));
         }
         var outcome = new ProviderSearchOutcome(
                 retailerId,
                 Optional.of(new ProviderPathSelection(
                         "fixture-" + retailerId.canonicalId(),
                         AcquisitionMode.DIRECT_API)),
-                offers,
+                normalizedOffers,
                 List.of());
         return RetailerRuntimeEvidence.withFulfillmentContext(
                 retailerId,
                 fulfillmentContext,
                 outcome,
-                snapshots,
-                PackageQuantitySet.of(bindings));
+                snapshots);
+    }
+
+    private static ObservedOffer withPackageQuantity(ObservedOffer offer, Quantity packageQuantity) {
+        if (packageQuantity == null) {
+            return offer;
+        }
+        return new ObservedOffer(
+                offer.retailerId(),
+                offer.sourceProviderId(),
+                offer.sourceMode(),
+                offer.fulfillmentContextId(),
+                offer.sku(),
+                offer.productName(),
+                offer.price(),
+                offer.currencyCode(),
+                offer.availability(),
+                offer.observedAt(),
+                offer.sourceReference(),
+                Optional.of(packageQuantity));
     }
 
     private static ObservedOffer offer(

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimePackageEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimePackageEvidenceTest.java
@@ -1,5 +1,6 @@
 package io.github.trueruslan.zakupgotov.preview;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.trueruslan.zakupgotov.basket.PackageQuantityBinding;
@@ -24,26 +25,28 @@ import org.junit.jupiter.api.Test;
 class RetailerRuntimePackageEvidenceTest {
 
     @Test
-    void rejectsParallelPackageEvidenceThatIsAbsentFromSnapshot() {
-        var observation = new ObservedOffer(
+    void derivesRuntimePackageEvidenceFromStructuredSnapshotEvidence() {
+        var packageQuantity = new Quantity(new BigDecimal("0.97"), QuantityUnit.LITER);
+        var observation = observation(Optional.of(packageQuantity));
+        var snapshotId = new OfferSnapshotId(UUID.fromString("42424242-4242-4242-4242-424242424242"));
+        var snapshot = OfferSnapshot.observationOnly(snapshotId, observation);
+        var outcome = successfulOutcome(observation);
+
+        var evidence = new RetailerRuntimeEvidence(
                 RetailerId.PEREKRESTOK,
-                "fixture-perekrestok",
-                AcquisitionMode.DIRECT_API,
-                "store-42",
-                "sku-milk",
-                "Молоко 970мл",
-                new BigDecimal("89.99"),
-                "RUB",
-                AvailabilityStatus.AVAILABLE,
-                Instant.parse("2026-08-12T16:30:00Z"),
-                "fixture://perekrestok/milk");
+                outcome,
+                List.of(snapshot));
+
+        assertThat(evidence.packageQuantities().quantityFor(snapshotId))
+                .contains(new Quantity(new BigDecimal("970"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void rejectsParallelPackageEvidenceThatIsAbsentFromSnapshot() {
+        var observation = observation(Optional.empty());
         var snapshotId = new OfferSnapshotId(UUID.fromString("41414141-4141-4141-4141-414141414141"));
         var snapshot = OfferSnapshot.observationOnly(snapshotId, observation);
-        var outcome = new ProviderSearchOutcome(
-                RetailerId.PEREKRESTOK,
-                Optional.of(new ProviderPathSelection("fixture-perekrestok", AcquisitionMode.DIRECT_API)),
-                List.of(observation),
-                List.of());
+        var outcome = successfulOutcome(observation);
         var parallelEvidence = PackageQuantitySet.of(List.of(new PackageQuantityBinding(
                 snapshotId,
                 new Quantity(new BigDecimal("970"), QuantityUnit.MILLILITER))));
@@ -56,5 +59,29 @@ class RetailerRuntimePackageEvidenceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("package quantity")
                 .hasMessageContaining("snapshot");
+    }
+
+    private static ObservedOffer observation(Optional<Quantity> packageQuantity) {
+        return new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "fixture-perekrestok",
+                AcquisitionMode.DIRECT_API,
+                "store-42",
+                "sku-milk",
+                "Молоко 970мл",
+                new BigDecimal("89.99"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                Instant.parse("2026-08-12T16:30:00Z"),
+                "fixture://perekrestok/milk",
+                packageQuantity);
+    }
+
+    private static ProviderSearchOutcome successfulOutcome(ObservedOffer observation) {
+        return new ProviderSearchOutcome(
+                RetailerId.PEREKRESTOK,
+                Optional.of(new ProviderPathSelection("fixture-perekrestok", AcquisitionMode.DIRECT_API)),
+                List.of(observation),
+                List.of());
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimePackageEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/preview/RetailerRuntimePackageEvidenceTest.java
@@ -1,0 +1,60 @@
+package io.github.trueruslan.zakupgotov.preview;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.basket.PackageQuantityBinding;
+import io.github.trueruslan.zakupgotov.basket.PackageQuantitySet;
+import io.github.trueruslan.zakupgotov.provider.AcquisitionMode;
+import io.github.trueruslan.zakupgotov.provider.AvailabilityStatus;
+import io.github.trueruslan.zakupgotov.provider.ObservedOffer;
+import io.github.trueruslan.zakupgotov.provider.OfferSnapshot;
+import io.github.trueruslan.zakupgotov.provider.OfferSnapshotId;
+import io.github.trueruslan.zakupgotov.provider.ProviderPathSelection;
+import io.github.trueruslan.zakupgotov.provider.ProviderSearchOutcome;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RetailerRuntimePackageEvidenceTest {
+
+    @Test
+    void rejectsParallelPackageEvidenceThatIsAbsentFromSnapshot() {
+        var observation = new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "fixture-perekrestok",
+                AcquisitionMode.DIRECT_API,
+                "store-42",
+                "sku-milk",
+                "Молоко 970мл",
+                new BigDecimal("89.99"),
+                "RUB",
+                AvailabilityStatus.AVAILABLE,
+                Instant.parse("2026-08-12T16:30:00Z"),
+                "fixture://perekrestok/milk");
+        var snapshotId = new OfferSnapshotId(UUID.fromString("41414141-4141-4141-4141-414141414141"));
+        var snapshot = OfferSnapshot.observationOnly(snapshotId, observation);
+        var outcome = new ProviderSearchOutcome(
+                RetailerId.PEREKRESTOK,
+                Optional.of(new ProviderPathSelection("fixture-perekrestok", AcquisitionMode.DIRECT_API)),
+                List.of(observation),
+                List.of());
+        var parallelEvidence = PackageQuantitySet.of(List.of(new PackageQuantityBinding(
+                snapshotId,
+                new Quantity(new BigDecimal("970"), QuantityUnit.MILLILITER))));
+
+        assertThatThrownBy(() -> new RetailerRuntimeEvidence(
+                        RetailerId.PEREKRESTOK,
+                        outcome,
+                        List.of(snapshot),
+                        parallelEvidence))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("package quantity")
+                .hasMessageContaining("snapshot");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/StructuredPackageEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/StructuredPackageEvidenceTest.java
@@ -1,0 +1,64 @@
+package io.github.trueruslan.zakupgotov.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class StructuredPackageEvidenceTest {
+
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-12T16:30:00Z");
+    private static final Instant PROVIDER_UPDATED_AT = Instant.parse("2026-08-12T16:25:00Z");
+    private static final OfferSnapshotId SNAPSHOT_ID = new OfferSnapshotId(
+            UUID.fromString("91919191-9191-9191-9191-919191919191"));
+
+    @Test
+    void structuredPackageQuantityIsCanonicalizedAndPreservedByEverySnapshotFactory() {
+        var offer = new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "perekrestok-browser",
+                AcquisitionMode.BROWSER_BRIDGE,
+                "656",
+                "3431579",
+                "Молоко 3,2%, 970мл",
+                new BigDecimal("89.99"),
+                "RUB",
+                AvailabilityStatus.UNKNOWN,
+                OBSERVED_AT,
+                "https://www.perekrestok.ru/cat/114/p/moloko-3431579",
+                Optional.of(new Quantity(new BigDecimal("0.97"), QuantityUnit.LITER)));
+
+        var expected = new Quantity(new BigDecimal("970"), QuantityUnit.MILLILITER);
+
+        assertThat(offer.packageQuantity()).contains(expected);
+        assertThat(OfferSnapshot.observationOnly(SNAPSHOT_ID, offer).packageQuantity())
+                .contains(expected);
+        assertThat(OfferSnapshot.withProviderUpdatedAt(SNAPSHOT_ID, offer, PROVIDER_UPDATED_AT).packageQuantity())
+                .contains(expected);
+    }
+
+    @Test
+    void presentationTextNeverCreatesPackageEvidence() {
+        var offer = new ObservedOffer(
+                RetailerId.PEREKRESTOK,
+                "perekrestok-browser",
+                AcquisitionMode.BROWSER_BRIDGE,
+                "656",
+                "3431579",
+                "Молоко 3,2%, 970мл",
+                new BigDecimal("89.99"),
+                "RUB",
+                AvailabilityStatus.UNKNOWN,
+                OBSERVED_AT,
+                "https://www.perekrestok.ru/cat/114/p/moloko-3431579");
+
+        assertThat(offer.packageQuantity()).isEmpty();
+        assertThat(OfferSnapshot.observationOnly(SNAPSHOT_ID, offer).packageQuantity()).isEmpty();
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **trusted structured package evidence plus remaining retailer connectivity/production-access hardening after the accepted #80 critical journey**
+Current focus: **ship #81 structured package-evidence plumbing; then prove the first source-specific structured package field without heuristic parsing or broader browser permissions**
 
 ## Product connectivity invariant
 
@@ -76,18 +76,36 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
    - architecture guards preventing upstream production domains from depending back on `preview` and preventing production preview code from depending on fixture/test-support namespaces;
    - fail-closed JSON deserialization for unknown request fields, matching OpenAPI `additionalProperties: false` and preventing unsupported provider/store-shaped input from silently weakening the public contract.
 
-Acceptance evidence before the docs-only shipping marker:
-- exact candidate `16eff25` passed API CI, Contract CI, Web CI + responsive Web E2E, Retailer Bridge CI, Dependency Review, CodeQL Java + JS/TS, Container Security CI, Release Bundle CI and Release Contract CI;
-- final read-only change review reported **no P0/P1/P2 findings**;
-- the earlier Web E2E ambiguity was an assertion-scoping defect and was corrected without weakening product behavior.
+   Acceptance evidence before the docs-only shipping marker:
+   - exact candidate `16eff25` passed API CI, Contract CI, Web CI + responsive Web E2E, Retailer Bridge CI, Dependency Review, CodeQL Java + JS/TS, Container Security CI, Release Bundle CI and Release Contract CI;
+   - final read-only change review reported **no P0/P1/P2 findings**;
+   - the earlier Web E2E ambiguity was an assertion-scoping defect and was corrected without weakening product behavior.
 
-Design: [`superpowers/specs/2026-08-12-m1-stateless-comparison-preview-design.md`](superpowers/specs/2026-08-12-m1-stateless-comparison-preview-design.md)  
-Implementation plan: [`superpowers/plans/2026-08-12-m1-stateless-comparison-preview.md`](superpowers/plans/2026-08-12-m1-stateless-comparison-preview.md)
+   Design: [`superpowers/specs/2026-08-12-m1-stateless-comparison-preview-design.md`](superpowers/specs/2026-08-12-m1-stateless-comparison-preview-design.md)  
+   Implementation plan: [`superpowers/plans/2026-08-12-m1-stateless-comparison-preview.md`](superpowers/plans/2026-08-12-m1-stateless-comparison-preview.md)
+
+10. **Structured package-evidence plumbing — IMPLEMENTED / SHIPPING (#81)**  
+    #81 adds a provider-neutral internal path for package quantities that are already proven by a source as structured evidence:
+    - `ObservedOffer` can carry optional canonical `Quantity packageQuantity` evidence;
+    - the legacy observation constructor remains source-compatible and produces `Optional.empty()`, so every existing retailer path keeps its previous package-unknown semantics;
+    - `OfferSnapshot` preserves the optional package quantity unchanged through both freshness factories;
+    - `PackageQuantitySet.fromSnapshots(...)` projects only explicitly present package evidence into the existing basket bindings;
+    - product presentation text remains non-authoritative: regression tests prove names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence;
+    - preview/runtime evidence derives package bindings from snapshots, eliminating a second independent source of truth;
+    - compatibility paths that still accept an explicit `PackageQuantitySet` fail closed unless it exactly matches structured snapshot evidence;
+    - deterministic acceptance fixtures now attach package evidence at the provider-observation boundary before snapshotting rather than injecting basket bindings later;
+    - no public API/UI shape, browser permission, network path, production-access state or retailer polling behavior changes in this slice.
+
+    **Important:** #81 does **not** claim that any accepted production retailer adapter already exposes a trustworthy structured package field. The plumbing is ready for such evidence; source-specific extraction remains separate work.
+
+    Design: [`superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md`](superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md)  
+    Implementation plan: [`superpowers/plans/2026-08-12-m1-structured-package-evidence.md`](superpowers/plans/2026-08-12-m1-structured-package-evidence.md)
 
 ## Important M1 limitations
 
 - Production comparison evidence remains deliberately **no-op/fail-closed** in #80. The critical journey proves the product/API/core integration, not live production retailer acquisition.
-- Accepted retailer adapters still do **not** expose a universal structured package-quantity field. Missing package evidence remains `PACKAGE_QUANTITY_UNKNOWN`; presentation text must not be parsed heuristically.
+- The core/provider/snapshot/runtime path can now carry trusted structured package quantity evidence end-to-end internally, but accepted retailer adapters still do **not** prove a supported structured package field. Missing evidence remains `PACKAGE_QUANTITY_UNKNOWN`; presentation text must not be parsed heuristically.
+- Perekrestok and Pyaterochka accepted browser paths remain package-unknown until a separate evidence-backed extractor proves stable field semantics. Do not widen browser permissions or inspect arbitrary response bodies merely to obtain package size.
 - Magnit location/address → public `shopCode` resolution is still unresolved (#69).
 - Magnit recurring production acquisition usage rights remain unresolved (#70); default recurring polling must remain disabled until authoritative acceptance.
 - Browser-bridge persistent-session/store-change lifecycle hardening remains open (#54).
@@ -99,11 +117,11 @@ Implementation plan: [`superpowers/plans/2026-08-12-m1-stateless-comparison-prev
 
 ### Pyaterochka
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. Real first-party gate: 12 normalized observations, one fulfillment context, zero normalized validation failures. Anonymous direct server access remains unsuitable (`store-403`).
+Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. Real first-party gate: 12 normalized observations, one fulfillment context, zero normalized validation failures. Anonymous direct server access remains unsuitable (`store-403`). No accepted structured package-quantity field is proven yet.
 
 ### Perekrestok
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter v2. Repeated first-party evidence: 90 normalized observations, one fulfillment context and zero acceptance-validation failures. #54 remains lifecycle hardening for same-document store changes / SPA navigation.
+Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter v2. Repeated first-party evidence: 90 normalized observations, one fulfillment context and zero acceptance-validation failures. #54 remains lifecycle hardening for same-document store changes / SPA navigation. Current accepted evidence does not prove a dedicated structured package-quantity field.
 
 ### Magnit
 
@@ -123,23 +141,25 @@ Constraints:
 6. `UNKNOWN` availability is never coerced to available/unavailable.
 7. Observation time is never misrepresented as provider freshness; freshness basis must remain structurally valid.
 8. Matching ambiguity never becomes a hidden winner and no fuzzy/AI tie-break is introduced implicitly.
-9. Package quantity is explicit evidence; missing evidence is not guessed from names.
-10. Incomplete baskets never expose a misleading complete-basket total.
-11. Production activation respects usage-rights state.
-12. Ordinary CI and #80 browser acceptance make no live retailer requests.
-13. Production preview evidence fails closed rather than falling back to deterministic fixtures.
-14. Public comparison requests remain stateless and persistence-free in M1.
-15. Unknown public JSON request fields fail closed rather than being ignored.
-16. Universal retailer connectivity remains mandatory for every registry entry.
+9. Package quantity is explicit structured evidence; missing evidence is never guessed from names, URLs or other presentation text.
+10. Package evidence attached to runtime basket calculation must derive from and agree with immutable snapshot evidence.
+11. Incomplete baskets never expose a misleading complete-basket total.
+12. Production activation respects usage-rights state.
+13. Ordinary CI and browser acceptance make no live retailer requests.
+14. Production preview evidence fails closed rather than falling back to deterministic fixtures.
+15. Public comparison requests remain stateless and persistence-free in M1.
+16. Unknown public JSON request fields fail closed rather than being ignored.
+17. Universal retailer connectivity remains mandatory for every registry entry.
 
 ## Immediate next work
 
-1. **Trusted structured package-quantity extraction** where a supported retailer/source proves the field semantics. Do not parse presentation names heuristically.
-2. Continue **#54** browser-bridge lifecycle hardening and **#69** Magnit location → `shopCode` resolution.
-3. Resolve **#70** Magnit production usage rights before recurring polling and continue **#36** Kuper supported-access investigation.
-4. Continue mandatory Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional retailer onboarding.
-5. Prove a successful real `v0.1.0-rc.3` release event.
-6. Move to **M2 Recipes** only after remaining M1 evidence/production constraints are explicitly accepted rather than hidden.
+1. **Finish shipping #81** with exact-head CI/security verification and independent review.
+2. **Prove the first source-specific structured package field** and only then add a retailer/source extractor. Document field semantics, provenance, absence behavior and production-access constraints; do not parse product names or widen browser permissions without separate evidence.
+3. Continue **#54** browser-bridge lifecycle hardening and **#69** Magnit location → `shopCode` resolution.
+4. Resolve **#70** Magnit production usage rights before recurring polling and continue **#36** Kuper supported-access investigation.
+5. Continue mandatory Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional retailer onboarding.
+6. Prove a successful real `v0.1.0-rc.3` release event.
+7. Move to **M2 Recipes** only after remaining M1 evidence/production constraints are explicitly accepted rather than hidden.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - `UNKNOWN` availability remains first-class;
 - observation time is not provider-update time;
 - freshness evidence basis remains explicit and structurally valid;
-- package quantity is explicit evidence, never inferred from product names;
+- package quantity is explicit structured evidence, never inferred from product names or presentation text;
 - production activation respects usage-rights state;
 - ordinary M1 tests make no live retailer requests.
 
@@ -86,11 +86,25 @@ Goal: compare a manually entered grocery list across connected retailers while p
    - architecture guards keep upstream production domains independent of `preview` and prevent production preview code from depending on fixture/test-support namespaces;
    - unknown JSON request fields fail closed, keeping runtime deserialization aligned with OpenAPI `additionalProperties: false`.
 
-Acceptance evidence is recorded in the #80 shipping marker. The reviewed code candidate `16eff25` passed all repository workflow groups and the final read-only review reported no P0/P1/P2 findings before the docs-only marker.
+   Acceptance evidence is recorded in the #80 shipping marker. The reviewed code candidate `16eff25` passed all repository workflow groups and the final read-only review reported no P0/P1/P2 findings before the docs-only marker.
+
+10. **Structured package-evidence plumbing — IMPLEMENTED / SHIPPING (#81)**
+   - `ObservedOffer` carries optional canonical package quantity only when a source has already established structured semantics;
+   - the existing constructor defaults to empty evidence so current retailer integrations retain identical package-unknown behavior;
+   - `OfferSnapshot` preserves the optional package quantity through immutable observation snapshots;
+   - `PackageQuantitySet.fromSnapshots(...)` projects only explicit snapshot evidence into basket bindings;
+   - presentation-text regression tests prove labels such as `970мл` or `1,5л` are not parsed into package quantities;
+   - runtime comparison evidence derives package bindings from snapshots rather than maintaining a second independent source of truth;
+   - compatibility constructors that accept explicit package bindings reject any mismatch with structured snapshot evidence;
+   - deterministic acceptance fixtures now attach package quantity at the provider observation boundary before snapshotting;
+   - no public contract, browser permission, live request, production-access status or retailer polling behavior changes.
+
+   Design: [`superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md`](superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md).  
+   Implementation plan: [`superpowers/plans/2026-08-12-m1-structured-package-evidence.md`](superpowers/plans/2026-08-12-m1-structured-package-evidence.md).
 
 ### Important remaining basket-data limitation
 
-The core can consume trusted package-quantity evidence, but accepted retailer adapters do not yet expose a universal structured package-quantity field. Add provider/source extraction only where supported evidence proves semantics. Do not parse presentation text heuristically.
+The core/provider/snapshot/runtime path can now carry trusted package-quantity evidence internally from source observation to basket planning, but accepted retailer adapters still do **not** prove a supported structured package field. A retailer/source extractor may populate `packageQuantity` only after its field semantics are documented and verified. Missing evidence stays unknown. Do not parse presentation text heuristically or broaden browser permissions merely to obtain package size.
 
 ### M1 exit criteria
 
@@ -102,18 +116,20 @@ The core can consume trusted package-quantity evidence, but accepted retailer ad
 - product location/privacy boundary preserved;
 - provider provenance, fulfillment context and freshness survive into comparison internally without leaking implementation identifiers publicly;
 - freshness evidence basis is visible without invented stale/fresh policy;
+- package quantity, when present, remains structured source evidence through provider → snapshot → basket rather than a presentation-text guess;
 - incomplete baskets cannot masquerade as complete winners;
 - production retailer activation remains separately gated by access, location/context and source-evidence constraints.
 
 ### Next M1 engineering focus
 
-1. **Trusted structured package-quantity extraction** where a specific accepted source proves the field semantics. Missing evidence stays unknown.
-2. **Browser bridge lifecycle hardening (#54)** for persistent sessions, same-document store changes and SPA navigation.
-3. **Magnit location → `shopCode` resolution (#69)** without leaking precise address into default product telemetry or contracts.
-4. **Magnit production usage-rights decision (#70)** before recurring production polling.
-5. **Kuper supported aggregator investigation (#36)**.
-6. Continue mandatory Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional retailer onboarding.
-7. Prove a successful real `v0.1.0-rc.3` release event.
+1. **Ship #81 structured package-evidence plumbing** after exact-head CI/security and independent review.
+2. **Prove the first source-specific structured package field and extractor.** Treat each retailer/source independently; document field semantics, provenance, absence behavior and production-access constraints. Do not parse product names or widen browser permissions without separate evidence.
+3. **Browser bridge lifecycle hardening (#54)** for persistent sessions, same-document store changes and SPA navigation.
+4. **Magnit location → `shopCode` resolution (#69)** without leaking precise address into default product telemetry or contracts.
+5. **Magnit production usage-rights decision (#70)** before recurring production polling.
+6. **Kuper supported aggregator investigation (#36)**.
+7. Continue mandatory Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional retailer onboarding.
+8. Prove a successful real `v0.1.0-rc.3` release event.
 
 ## M2 — Recipes
 

--- a/docs/superpowers/plans/2026-08-12-m1-structured-package-evidence-shipping.md
+++ b/docs/superpowers/plans/2026-08-12-m1-structured-package-evidence-shipping.md
@@ -1,0 +1,85 @@
+# M1 Structured Package Evidence — Shipping Evidence
+
+Date: 2026-08-12  
+PR: #81 `feat(m1): add structured package evidence plumbing`  
+Branch: `feat/m1-structured-package-evidence`
+
+This document is the docs-only shipping marker for the M1 structured package-evidence plumbing slice.
+
+## Accepted scope
+
+The slice establishes one provider-neutral internal evidence path for package quantities that have already been proven by a source as structured product metadata.
+
+- `ObservedOffer` can carry optional canonical `Quantity packageQuantity` evidence.
+- Existing observation construction remains source-compatible and defaults to empty package evidence.
+- `OfferSnapshot` preserves the optional package quantity through immutable snapshot creation.
+- `PackageQuantitySet.fromSnapshots(...)` projects only explicitly present snapshot evidence into basket bindings.
+- Runtime comparison evidence derives package bindings from snapshots and rejects any separately supplied package set that disagrees with those snapshots.
+- Deterministic acceptance fixtures attach package quantity at the provider observation boundary before snapshotting.
+- Presentation text remains non-authoritative; tests explicitly prove names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.
+
+This slice does **not** claim a retailer/source extractor, does not change the public API/UI, does not add live retailer requests, does not broaden browser permissions, and does not change production-access state. Perekrestok, Pyaterochka and the other accepted retailer paths remain package-unknown until a source-specific field is separately proven.
+
+## TDD and hardening completed before acceptance
+
+1. Initial test-only RED required a package-aware provider observation, snapshot preservation and snapshot-to-basket projection; API CI failed on exactly the missing constructor/accessors/factory.
+2. Minimal provider/snapshot/basket GREEN was implemented. Candidate `81e419e1805056354432b866d3b30d01cd8f3bbc` passed all repository workflow groups.
+3. Review of the runtime path found that `RetailerRuntimeEvidence` still accepted a second independent `PackageQuantitySet`. A new test-only RED required disagreement between snapshots and parallel bindings to fail closed.
+4. Runtime evidence was hardened to derive package quantities from snapshots and to reject explicit sets that differ from snapshot evidence.
+5. The hardening correctly exposed one legacy `ComparisonPreviewServiceTest` fixture that still injected bindings after snapshotting. That fixture and the shared deterministic runtime source were migrated to attach package quantities to `ObservedOffer` before snapshot creation; the production invariant was not weakened.
+6. Durable `PROJECT_STATE.md`, `ROADMAP.md` and root `CHANGELOG.md` were synchronized with the implemented plumbing and the explicit limitation that no production retailer extractor is yet accepted.
+
+## Exact reviewed code/docs candidate
+
+Reviewed candidate SHA: `715fcdbb7821311f4490f0dfd8b70904deb4bd82`
+
+All required workflow groups completed successfully on that exact candidate:
+
+- API CI — PASS
+- Contract CI — PASS
+- Web CI — PASS
+- Web E2E — PASS as part of Web CI
+- Retailer Bridge CI — PASS
+- Dependency Review — PASS
+- CodeQL — PASS
+- Container Security CI — PASS
+- Release Bundle CI — PASS
+- Release Contract CI — PASS
+
+The API verify includes Spring Modulith/ArchUnit verification, provider/snapshot regressions, package projection tests, basket planner regressions, preview runtime/service tests and integration tests. Ordinary CI continues to make no live retailer requests.
+
+## Read-only review gate
+
+Verdict: **Looks good**
+
+- P0: none
+- P1: none
+- P2: none
+- P3: `RetailerRuntimeEvidence` retains compatibility overloads that accept an explicit `PackageQuantitySet`. Correctness is protected because the constructor requires exact equality with snapshot-derived bindings and then replaces the field with the canonical snapshot-derived set. After callers have fully migrated, these overloads should be deprecated/removed so the redundant channel disappears from the API surface entirely.
+
+Review scope included:
+
+- specification/non-goal compliance;
+- legacy `ObservedOffer` source compatibility;
+- canonical quantity semantics and immutability;
+- observation → snapshot → basket package-evidence flow;
+- title/presentation-text non-inference;
+- runtime disagreement/fail-closed behavior;
+- deterministic acceptance fixture migration;
+- Spring Modulith/ArchUnit dependency direction;
+- public API/privacy/security surface;
+- live-network and browser-permission boundaries;
+- production-access semantics;
+- durable state/roadmap/changelog consistency.
+
+No blocking security, privacy, API-compatibility, architecture or correctness issue was found.
+
+## Final branch-protection gate
+
+This marker changes documentation only. The final PR head after this commit must re-run and pass the repository branch-protection workflow set before squash merge. Merge must use the exact final head SHA; if the head changes, the gate is invalid and must be repeated.
+
+## Post-merge expectation
+
+After squash merge, verify the resulting `main` SHA and push-triggered workflows.
+
+The next M1 engineering step is **not** name parsing. It is source-specific evidence research: prove one authoritative structured package field for one accepted retailer/source, document its semantics/provenance/absence behavior and production-access constraints, and only then implement an extractor. Browser permissions and response interception must not be broadened merely to obtain package size.

--- a/docs/superpowers/plans/2026-08-12-m1-structured-package-evidence.md
+++ b/docs/superpowers/plans/2026-08-12-m1-structured-package-evidence.md
@@ -1,0 +1,300 @@
+# M1 Structured Package Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry optional trusted structured package quantity from provider observations into immutable snapshots and project it into the existing basket `PackageQuantitySet` without any presentation-text inference.
+
+**Architecture:** Extend the existing provider trust boundary with optional canonical `Quantity` evidence while preserving the legacy constructor as empty evidence. `OfferSnapshot` copies that value unchanged. Basket owns the one-way projection from snapshots into existing `PackageQuantityBinding` records; the planner itself stays unchanged.
+
+**Tech Stack:** Java 25, Spring Boot 4.1, JUnit 5, AssertJ, Spring Modulith, ArchUnit, Maven Wrapper.
+
+## Global Constraints
+
+- No parsing of `productName`, title, slug, SKU, source URL, visible free-form text, or arbitrary HTML for package size.
+- No new live retailer requests.
+- No response-body interception or broader browser-extension permissions.
+- No retailer production-access status changes.
+- Ordinary CI remains live-retailer-free.
+- Existing callers of the 11-argument `ObservedOffer` constructor remain source-compatible and receive empty package evidence.
+- Present package values use the existing canonical positive `shopping.Quantity` semantics.
+
+---
+
+### Task 1: Define provider/snapshot package evidence by test
+
+**Files:**
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/ObservedOfferTest.java`
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/OfferSnapshotTest.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/ObservedOffer.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/OfferSnapshot.java`
+
+**Interfaces:**
+- Produces: `ObservedOffer.packageQuantity(): Optional<Quantity>`
+- Produces: compatibility constructor with the existing 11 arguments and implicit `Optional.empty()`
+- Produces: `OfferSnapshot.packageQuantity(): Optional<Quantity>`
+
+- [ ] **Step 1: Write failing provider tests**
+
+Add tests that construct an observation with explicit `new Quantity(new BigDecimal("0.97"), QuantityUnit.LITER)` and assert it is canonicalized/preserved as `970 MILLILITER`. Add a separate regression observation named `"Молоко 3,2%, 970мл"` through the legacy constructor and assert `packageQuantity()` is empty.
+
+Expected API shape:
+
+```java
+var offer = new ObservedOffer(
+        RetailerId.PEREKRESTOK,
+        "perekrestok-browser",
+        AcquisitionMode.BROWSER_BRIDGE,
+        "656",
+        "3431579",
+        "Молоко 3,2%, 970мл",
+        new BigDecimal("89.99"),
+        "RUB",
+        AvailabilityStatus.UNKNOWN,
+        OBSERVED_AT,
+        "https://www.perekrestok.ru/cat/114/p/moloko-3431579",
+        Optional.of(new Quantity(new BigDecimal("0.97"), QuantityUnit.LITER)));
+
+assertThat(offer.packageQuantity())
+        .contains(new Quantity(new BigDecimal("970"), QuantityUnit.MILLILITER));
+```
+
+- [ ] **Step 2: Write failing snapshot tests**
+
+Create observation-only and provider-updated snapshots from the explicit package observation and assert both expose the exact canonical optional quantity. Also assert the legacy title-only offer produces an empty snapshot package quantity.
+
+- [ ] **Step 3: Run focused tests to verify RED**
+
+Run:
+
+```bash
+cd apps/api
+./mvnw -q -Dtest=ObservedOfferTest,OfferSnapshotTest test
+```
+
+Expected: compilation/test failure because the package-aware constructor/accessors do not exist yet.
+
+- [ ] **Step 4: Implement minimal provider boundary**
+
+Change the record to:
+
+```java
+public record ObservedOffer(
+        RetailerId retailerId,
+        String sourceProviderId,
+        AcquisitionMode sourceMode,
+        String fulfillmentContextId,
+        String sku,
+        String productName,
+        BigDecimal price,
+        String currencyCode,
+        AvailabilityStatus availability,
+        Instant observedAt,
+        String sourceReference,
+        Optional<Quantity> packageQuantity) {
+```
+
+Validate the optional itself as non-null and copy/map it without parsing strings. Add an 11-argument compatibility constructor delegating to `Optional.empty()`.
+
+Add an `Optional<Quantity>` field/accessor to `OfferSnapshot` and assign `observation.packageQuantity()` in its private constructor.
+
+- [ ] **Step 5: Run focused provider tests to verify GREEN**
+
+Run the same Maven command. Expected: PASS.
+
+- [ ] **Step 6: Commit provider/snapshot boundary**
+
+Commit message:
+
+```text
+feat(provider): preserve structured package evidence
+```
+
+---
+
+### Task 2: Project snapshot evidence into basket package bindings
+
+**Files:**
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/basket/PackageQuantitySetTest.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/basket/PackageQuantitySet.java`
+
+**Interfaces:**
+- Consumes: `OfferSnapshot.packageQuantity(): Optional<Quantity>`
+- Produces: `PackageQuantitySet.fromSnapshots(List<OfferSnapshot>)`
+
+- [ ] **Step 1: Write failing projection test**
+
+Build three snapshots in stable order:
+
+1. explicit `500 GRAM` package evidence;
+2. no package evidence despite a title containing `1,5л`;
+3. explicit `2 PIECE` package evidence.
+
+Assert:
+
+```java
+var set = PackageQuantitySet.fromSnapshots(List.of(first, second, third));
+
+assertThat(set.bindings()).extracting(PackageQuantityBinding::snapshotId)
+        .containsExactly(first.id(), third.id());
+assertThat(set.quantityFor(first.id()))
+        .contains(new Quantity(new BigDecimal("500"), QuantityUnit.GRAM));
+assertThat(set.quantityFor(second.id())).isEmpty();
+assertThat(set.quantityFor(third.id()))
+        .contains(new Quantity(new BigDecimal("2"), QuantityUnit.PIECE));
+```
+
+Add null-list and null-snapshot fail-closed assertions.
+
+- [ ] **Step 2: Run focused basket test to verify RED**
+
+Run:
+
+```bash
+cd apps/api
+./mvnw -q -Dtest=PackageQuantitySetTest test
+```
+
+Expected: compilation failure because `fromSnapshots` does not exist.
+
+- [ ] **Step 3: Implement minimal projection factory**
+
+Add:
+
+```java
+public static PackageQuantitySet fromSnapshots(List<OfferSnapshot> snapshots) {
+    var input = Objects.requireNonNull(snapshots, "snapshots must not be null");
+    var bindings = new ArrayList<PackageQuantityBinding>();
+    for (var snapshot : input) {
+        Objects.requireNonNull(snapshot, "snapshot must not be null");
+        snapshot.packageQuantity().ifPresent(quantity ->
+                bindings.add(new PackageQuantityBinding(snapshot.id(), quantity)));
+    }
+    return of(bindings);
+}
+```
+
+Do not inspect any other snapshot field.
+
+- [ ] **Step 4: Run focused basket test to verify GREEN**
+
+Run the same Maven command. Expected: PASS.
+
+- [ ] **Step 5: Run basket planner regressions**
+
+Run:
+
+```bash
+cd apps/api
+./mvnw -q -Dtest=PackageQuantitySetTest,PackageSelectionCalculatorTest,SingleStoreBasketPlannerTest test
+```
+
+Expected: PASS, preserving `PACKAGE_QUANTITY_UNKNOWN` for absent evidence.
+
+- [ ] **Step 6: Commit basket projection**
+
+Commit message:
+
+```text
+feat(basket): project package evidence from snapshots
+```
+
+---
+
+### Task 3: Verify architecture and source compatibility
+
+**Files:**
+- Test existing: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/ApplicationArchitectureTest.java`
+- Test existing: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/basket/BasketBoundaryArchitectureTest.java`
+- Test existing: provider/matching/preview regression suites
+
+**Interfaces:**
+- Confirms provider -> canonical quantity introduces no Modulith cycle.
+- Confirms basket remains downstream of provider/shopping.
+
+- [ ] **Step 1: Run provider/basket/matching/preview regression set**
+
+```bash
+cd apps/api
+./mvnw -q -Dtest='ObservedOffer*,OfferSnapshot*,ProviderPath*,PackageQuantitySetTest,PackageSelectionCalculatorTest,SingleStoreBasketPlannerTest,DeterministicProductMatcherTest,ComparisonPreview*' test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run application architecture verification**
+
+```bash
+cd apps/api
+./mvnw -q -Dtest=ApplicationArchitectureTest,BasketBoundaryArchitectureTest test
+```
+
+Expected: PASS with no new module cycle or upstream basket dependency.
+
+- [ ] **Step 3: Run complete API verification**
+
+```bash
+cd apps/api
+./mvnw -q verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit any test-only hardening if required**
+
+If no additional hardening is required, do not create an empty commit. If a real regression test is added, use:
+
+```text
+test(package): harden structured evidence boundary
+```
+
+---
+
+### Task 4: Synchronize durable project state and open review PR
+
+**Files:**
+- Modify: `docs/PROJECT_STATE.md`
+- Modify: `docs/ROADMAP.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Documents this slice as evidence plumbing, not a retailer extraction claim.
+
+- [ ] **Step 1: Update durable docs**
+
+Record that provider/snapshot/basket plumbing now accepts trusted structured package quantity, while every currently accepted retailer path still remains package-unknown until a separate source-specific extractor is proven.
+
+The roadmap next action must become: prove the first retailer/source structured package field and add its extractor without widening browser permissions or parsing names.
+
+- [ ] **Step 2: Commit documentation**
+
+Commit message:
+
+```text
+docs(state): record structured package evidence plumbing
+```
+
+- [ ] **Step 3: Open a draft PR**
+
+Title:
+
+```text
+feat(m1): add structured package evidence plumbing
+```
+
+PR body must explicitly state:
+
+- no retailer extractor is claimed;
+- no live requests or production activation were added;
+- presentation-text parsing remains forbidden;
+- accepted retailer paths remain package-unknown until source-specific evidence exists.
+
+- [ ] **Step 4: Verify exact-head CI/security gate**
+
+Require API CI, Web CI/E2E, Contract CI, Retailer Bridge CI, CodeQL, Dependency Review, Container Security CI, Release Bundle CI and Release Contract CI all to succeed on the exact PR head.
+
+- [ ] **Step 5: Run independent read-only change review**
+
+Review spec compliance, constructor compatibility, package-evidence semantics, architecture direction, privacy/security and regression coverage. Do not merge if P0/P1/P2 blockers remain.
+
+- [ ] **Step 6: If review and exact-head CI pass, mark ready and squash merge**
+
+Use exact-head protection and then verify push-triggered `main` CI before considering the slice accepted.

--- a/docs/superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md
+++ b/docs/superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md
@@ -1,0 +1,104 @@
+# M1 Structured Package Evidence Design
+
+Updated: 2026-08-12
+Status: approved implementation direction
+
+## Context
+
+M1 basket planning already requires explicit package quantity evidence keyed by `OfferSnapshotId`. Missing evidence produces `PACKAGE_QUANTITY_UNKNOWN`; product presentation text is deliberately not parsed. After the stateless comparison journey shipped in #80, the remaining gap is that provider observations and immutable offer snapshots do not yet carry an optional trusted package quantity, so basket evidence still has to be assembled separately.
+
+Current accepted Perekrestok and Pyaterochka browser paths do not prove a dedicated structured package field. Their accepted contracts intentionally persist only allow-listed normalized page evidence and do not inspect response bodies. Magnit production activation is separately blocked by location/context and usage-rights work. This slice therefore must not invent a retailer extractor or relax any browser/privacy boundary.
+
+## Goal
+
+Create one provider-neutral path by which a source that has already proved structured package semantics can attach that evidence to an observed offer, preserve it through snapshotting, and expose it to basket planning without inference.
+
+## Non-goals
+
+- No parsing of `productName`, title, slug, SKU, source URL, visible free-form text, or arbitrary HTML for package size.
+- No new live retailer requests.
+- No response-body interception or broader browser-extension permissions.
+- No change to retailer production-access status.
+- No activation of Magnit recurring acquisition while #70 remains unresolved.
+- No claim that Perekrestok, Pyaterochka, Magnit, or any other retailer already supports trusted structured package extraction.
+- No API/UI schema change in this slice; package evidence remains an internal comparison input until a production retailer source is accepted.
+
+## Design
+
+### 1. Provider observation boundary
+
+`ObservedOffer` gains an optional `packageQuantity` using the existing canonical `shopping.Quantity` value type.
+
+Rules:
+
+- presence means the provider/source adapter has already established that the value is structured package evidence for the observed SKU;
+- absence is first-class and means unknown;
+- the existing constructor remains available and delegates to an empty package quantity so current providers/fixtures retain identical behavior;
+- no constructor or helper derives the field from `productName` or any presentation string.
+
+Using canonical `Quantity` keeps unit normalization (`kg -> g`, `l -> ml`) in one place and avoids a second amount/unit model. The provider layer may depend on the lower-level canonical quantity value object, while shopping remains independent of provider data.
+
+### 2. Immutable snapshot preservation
+
+`OfferSnapshot` copies the optional package quantity from the validated `ObservedOffer` unchanged. Both observation-only and provider-updated freshness factories preserve the evidence.
+
+Snapshot identity remains independent of the package value; package quantity is evidence attached to that observation, not part of identity generation.
+
+### 3. Basket evidence projection
+
+`PackageQuantitySet.fromSnapshots(List<OfferSnapshot>)` projects only snapshots with an explicit package quantity into existing `PackageQuantityBinding` records.
+
+Rules:
+
+- snapshots without package evidence create no binding;
+- input order is preserved for bindings;
+- null snapshot/list values fail closed;
+- duplicate snapshot IDs continue to fail through the existing set invariant;
+- no fallback inspection of `productName` occurs.
+
+This keeps the basket planner unchanged: it still consumes `PackageQuantitySet`, and `PACKAGE_QUANTITY_UNKNOWN` semantics remain exactly as before for absent evidence.
+
+## Compatibility
+
+The legacy `ObservedOffer` constructor remains source-compatible. Existing provider fixtures, orchestrator tests, retailer probes, preview fixtures and browser bridge behavior need no migration and continue to represent package quantity as unknown.
+
+`OfferSnapshot` adds an accessor only; existing callers continue to work.
+
+## Security and privacy
+
+This slice adds no network, credential, browser permission, address, or provider-routing surface. Package quantity is product metadata and inherits the existing observation provenance (`sourceProviderId`, acquisition mode, fulfillment context, source reference, observation time). Internal provenance remains internal at product/API boundaries.
+
+A future retailer extractor must be reviewed separately and demonstrate that its source field has stable package semantics before populating this value.
+
+## Invariants
+
+1. `packageQuantity` is optional evidence, never an inferred default.
+2. Product names such as `Молоко 3,2%, 970мл` do not create package evidence by themselves.
+3. Present values use canonical positive `Quantity` semantics.
+4. Snapshotting never drops or changes trusted package evidence.
+5. Basket projection includes only explicitly present package evidence.
+6. Missing evidence continues to surface as `PACKAGE_QUANTITY_UNKNOWN` when a matched offer reaches basket planning.
+7. Ordinary CI performs no live retailer requests.
+8. Existing browser-bridge security/privacy boundaries remain unchanged.
+
+## Test strategy
+
+TDD sequence:
+
+1. RED: provider/snapshot tests require optional structured package evidence and preservation while proving presentation text alone remains empty.
+2. RED: basket test requires `PackageQuantitySet.fromSnapshots` to include only explicit evidence and preserve canonical units/order.
+3. GREEN: add the smallest compatible provider/snapshot fields and projection factory.
+4. Run focused API tests, Spring Modulith/ArchUnit rules, then the full repository CI/security gate.
+
+## Exit criteria
+
+- provider observations can carry optional trusted package quantity without breaking existing callers;
+- snapshots preserve the optional evidence exactly;
+- basket package evidence can be constructed directly from snapshots;
+- presentation text is proven non-authoritative by regression test;
+- no retailer extractor, live access, browser permission or production-access status changes;
+- exact-head CI/security checks are green and independent review finds no blocking issue.
+
+## Follow-up
+
+After this plumbing is accepted, investigate one retailer/source at a time for an authoritative structured field. The first extractor is a separate evidence-backed slice and must document field semantics, fixture provenance, failure behavior and production-access constraints before populating `packageQuantity`.


### PR DESCRIPTION
Implements the M1 structured package-evidence plumbing using TDD and fail-closed runtime invariants.

## Delivered

- `ObservedOffer` accepts optional canonical structured `packageQuantity` evidence while the existing constructor remains source-compatible and defaults to unknown.
- `OfferSnapshot` preserves package evidence unchanged through immutable snapshot creation.
- `PackageQuantitySet.fromSnapshots(...)` projects only explicit structured snapshot evidence into basket bindings.
- Runtime comparison evidence derives package quantities from snapshots, eliminating a second independent source of truth.
- Compatibility paths that still accept explicit package bindings reject any mismatch with snapshot evidence.
- Deterministic preview fixtures now attach package evidence at the provider observation boundary before snapshotting.
- Regression tests prove presentation labels such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.

## Boundaries

- No retailer/source extractor is claimed in this PR.
- No live retailer request, production polling or production-access status is added or enabled.
- No browser permissions or response-body interception are added.
- Package quantity is accepted only as explicit structured provider evidence; presentation/product-name parsing remains forbidden.
- Perekrestok, Pyaterochka and other currently accepted retailer paths remain package-unknown until a source-specific extractor is separately proven.

## TDD / hardening

- Initial RED proved the missing provider/snapshot/projection contract.
- First GREEN candidate `81e419e` passed all repository workflow groups.
- A second RED exposed that preview runtime still allowed package bindings independent of snapshots.
- Runtime was hardened to derive package evidence from snapshots and reject disagreement; the legacy service fixture that still injected bindings downstream then failed as expected and was migrated without weakening the invariant.
- Durable PROJECT_STATE, ROADMAP and CHANGELOG are synchronized.

## Shipping gate

- Exact reviewed code/docs candidate: `715fcdbb7821311f4490f0dfd8b70904deb4bd82` — all 9 workflow groups PASS.
- Independent read-only review verdict: **Looks good**; P0/P1/P2 none. P3 only: remove the now-redundant explicit `PackageQuantitySet` compatibility overloads after callers are fully migrated.
- Docs-only shipping marker head: `9f4405d09b0ab15438ab842d79b74b38015afc0f` — all 9 workflow groups PASS again, including Web E2E, CodeQL, container security and release checks.

Design: `docs/superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md`
Plan: `docs/superpowers/plans/2026-08-12-m1-structured-package-evidence.md`
Shipping evidence: `docs/superpowers/plans/2026-08-12-m1-structured-package-evidence-shipping.md`