### PR TITLE
test(magnit): measure package evidence across fixed corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Explicit Magnit package-extraction states `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` so source ambiguity never becomes a guessed basket quantity.
 - Magnit provider/snapshot regression proving a `FOUND` characteristic can populate #81 structured package evidence while multi-dimensional characteristics remain package-unknown.
 - Evidence note documenting official Magnit weight-only, volume-only, multi-dimensional and count-selector examples plus unchanged #69/#70 production gates.
+- Magnit fixed-corpus package-evidence instrumentation that classifies exact-field extraction across the existing 20-product × 2-shop explicit/manual research corpus.
+- Structural `PackageEvidenceSummary` with `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` counters whose sum must equal the eligible package-evidence page count.
+- Aggregate Magnit evidence-line counters for eligible package pages and each package-extraction status without logging HTML, page fragments or arbitrary provider data.
 
 ### Changed
 
@@ -60,13 +63,15 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Deterministic comparison fixtures attach package quantity at the provider observation boundary before snapshotting, mirroring the production evidence flow without live retailer access.
 - Magnit v1 structured package semantics accept only exact weight/volume characteristics; simultaneous dimensions or conflicting/invalid values remain unknown rather than using category/title heuristics.
 - Magnit `Количество в упаковке` remains deferred pending separate source and multi-dimensional domain evidence.
+- Magnit fixed-corpus package metrics classify only HTTP 2xx observations with expected-SKU identity evidence, so transport failures and wrong-product pages cannot dilute metadata quality as false `MISSING` cases.
+- The guarded Magnit live corpus remains exactly 20 fixed products × 2 explicit shop contexts behind `-Dzakup.live.magnit.corpus=true`; no minimum `FOUND` threshold is invented before measurement evidence exists.
 - `UNKNOWN` availability propagates into `AVAILABILITY_UNKNOWN` line state and an `UNCERTAIN` basket rather than a confirmed complete basket.
 - Incomplete single-store baskets expose no aggregate total, preventing partial-price comparisons from masquerading as complete basket prices.
 - Technical retailer connectivity no longer leaks directly into the product/API contract: public readiness uses stable coverage/access/comparison states and finite product-safe reason codes instead of provider IDs, acquisition modes or source references.
 - The home page now makes the stateless comparison preview the primary M1 action instead of the previous readiness-only surface.
 - The critical browser journey is driven through the generated OpenAPI client and the same product-safe comparison vocabulary as the core/read model.
-- Production comparison evidence remains deliberately no-op/fail-closed; deterministic source extraction does not activate recurring retailer polling.
-- Active M1 focus moves to Magnit corpus package-evidence measurement plus retailer connectivity/lifecycle and production-access constraints after #82 ships.
+- Production comparison evidence remains deliberately no-op/fail-closed; deterministic source extraction and corpus instrumentation do not activate recurring retailer polling.
+- Active M1 focus moves to the first explicit/manual Magnit package-status corpus measurement plus retailer connectivity/lifecycle and production-access constraints after #83 ships.
 
 ### Fixed
 
@@ -89,6 +94,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Critical-journey Playwright item-gap assertions are scoped to the relevant retailer card with exact text matching, avoiding collisions between item labels and explanatory retailer reason copy.
 - Runtime evidence rejects an explicit package-quantity set when it differs from the structured quantities preserved by its snapshots, preventing two package-evidence sources from silently diverging.
 - Magnit package extraction ignores title/slug/description/script/style numbers and fails closed on weight+volume or conflicting supported characteristics.
+- Magnit fixed-corpus package reporting excludes non-2xx and wrong-identity observations instead of misclassifying transport/identity failures as missing package metadata.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusPackageEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusPackageEvidenceTest.java
@@ -1,0 +1,76 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MagnitCorpusPackageEvidenceTest {
+
+    @Test
+    void identityValidPageCarriesAcceptedPackageExtraction() {
+        var observation = MagnitCorpusProbe.parseProductPage("""
+                <html><body>
+                  <h1>Макароны Makfa 450г 79,99 ₽ Артикул 3042670099</h1>
+                  <h2>Характеристики</h2>
+                  <div>Вес, кг 0.45</div>
+                  <div>Артикул 3042670099</div>
+                  <h2>Условия хранения</h2>
+                </body></html>
+                """, "3042670099");
+
+        assertThat(observation.skuEvidence()).isTrue();
+        assertThat(observation.packageExtraction().status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(observation.packageExtraction().packageQuantity())
+                .contains(new Quantity(new BigDecimal("450"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void missingExpectedSkuCarriesNoAttributablePackageEvidence() {
+        var observation = MagnitCorpusProbe.parseProductPage("""
+                <html><body>
+                  <h1>Другой товар 79,99 ₽ Артикул 1111111111</h1>
+                  <h2>Характеристики</h2><div>Вес, кг 0.45</div>
+                </body></html>
+                """, "3042670099");
+
+        assertThat(observation.skuEvidence()).isFalse();
+        assertThat(observation.packageExtraction().status()).isEqualTo(MagnitPackageQuantityStatus.MISSING);
+        assertThat(observation.packageExtraction().packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void summarizesEveryExtractionStatusWithoutInventingAQualityThreshold() {
+        var summary = MagnitCorpusProbe.PackageEvidenceSummary.summarize(List.of(
+                found("0.45", QuantityUnit.KILOGRAM),
+                MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.MISSING),
+                MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.AMBIGUOUS_DIMENSIONS),
+                MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.CONFLICTING_VALUES),
+                MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.INVALID_VALUE),
+                found("1.5", QuantityUnit.LITER)));
+
+        assertThat(summary.packageEvidencePages()).isEqualTo(6);
+        assertThat(summary.found()).isEqualTo(2);
+        assertThat(summary.missing()).isEqualTo(1);
+        assertThat(summary.ambiguousDimensions()).isEqualTo(1);
+        assertThat(summary.conflictingValues()).isEqualTo(1);
+        assertThat(summary.invalidValues()).isEqualTo(1);
+        assertThat(summary.classifiedPages()).isEqualTo(summary.packageEvidencePages());
+    }
+
+    @Test
+    void summaryRejectsCountsThatDoNotEqualEligiblePageCount() {
+        assertThatThrownBy(() -> new MagnitCorpusProbe.PackageEvidenceSummary(6, 2, 1, 1, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("package evidence counts")
+                .hasMessageContaining("eligible pages");
+    }
+
+    private static MagnitPackageQuantityExtraction found(String amount, QuantityUnit unit) {
+        return MagnitPackageQuantityExtraction.found(new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -111,6 +112,7 @@ final class MagnitCorpusProbe {
         var nearSkuPromoMarkerObservations = 0;
         var priceBoundPromoMarkerObservations = 0;
         var failedRequirements = new ArrayList<String>();
+        var packageExtractions = new ArrayList<MagnitPackageQuantityExtraction>();
 
         for (var item : FIXED_CORPUS) {
             var first = observe(item, firstShop);
@@ -127,6 +129,12 @@ final class MagnitCorpusProbe {
             }
             if (second.usable()) {
                 secondUsable++;
+            }
+            if (first.packageEvidenceEligible()) {
+                packageExtractions.add(first.observation().packageExtraction());
+            }
+            if (second.packageEvidenceEligible()) {
+                packageExtractions.add(second.observation().packageExtraction());
             }
             if (first.http2xx() && second.http2xx()
                     && first.observation().skuEvidence()
@@ -181,6 +189,7 @@ final class MagnitCorpusProbe {
                 nearSkuMultiplePriceObservations,
                 nearSkuPromoMarkerObservations,
                 priceBoundPromoMarkerObservations,
+                PackageEvidenceSummary.summarize(packageExtractions),
                 List.copyOf(failedRequirements));
     }
 
@@ -243,7 +252,8 @@ final class MagnitCorpusProbe {
                 currentPrice,
                 regularPrice,
                 promo,
-                availability);
+                availability,
+                MagnitPackageQuantityExtractor.extract(html));
     }
 
     static RawShapeEvidence inspectNearSkuRawShape(String html, String expectedSku) {
@@ -379,10 +389,21 @@ final class MagnitCorpusProbe {
             Optional<BigDecimal> currentPrice,
             Optional<BigDecimal> regularPrice,
             boolean promo,
-            Availability availability) {
+            Availability availability,
+            MagnitPackageQuantityExtraction packageExtraction) {
+
+        PageObservation {
+            packageExtraction = Objects.requireNonNull(packageExtraction, "packageExtraction must not be null");
+        }
 
         static PageObservation missingSku() {
-            return new PageObservation(false, Optional.empty(), Optional.empty(), false, Availability.UNKNOWN);
+            return new PageObservation(
+                    false,
+                    Optional.empty(),
+                    Optional.empty(),
+                    false,
+                    Availability.UNKNOWN,
+                    MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.MISSING));
         }
     }
 
@@ -402,6 +423,75 @@ final class MagnitCorpusProbe {
         boolean usable() {
             return http2xx() && observation.skuEvidence() && observation.currentPrice().isPresent();
         }
+
+        boolean packageEvidenceEligible() {
+            return http2xx() && observation.skuEvidence();
+        }
+    }
+
+    record PackageEvidenceSummary(
+            int packageEvidencePages,
+            int found,
+            int missing,
+            int ambiguousDimensions,
+            int conflictingValues,
+            int invalidValues) {
+
+        PackageEvidenceSummary {
+            if (packageEvidencePages < 0
+                    || found < 0
+                    || missing < 0
+                    || ambiguousDimensions < 0
+                    || conflictingValues < 0
+                    || invalidValues < 0) {
+                throw new IllegalArgumentException("package evidence counts must not be negative");
+            }
+            if (classifiedPages(found, missing, ambiguousDimensions, conflictingValues, invalidValues)
+                    != packageEvidencePages) {
+                throw new IllegalArgumentException("package evidence counts must equal eligible pages");
+            }
+        }
+
+        static PackageEvidenceSummary summarize(List<MagnitPackageQuantityExtraction> extractions) {
+            var input = Objects.requireNonNull(extractions, "extractions must not be null");
+            var found = 0;
+            var missing = 0;
+            var ambiguousDimensions = 0;
+            var conflictingValues = 0;
+            var invalidValues = 0;
+
+            for (var extraction : input) {
+                Objects.requireNonNull(extraction, "extraction must not be null");
+                switch (extraction.status()) {
+                    case FOUND -> found++;
+                    case MISSING -> missing++;
+                    case AMBIGUOUS_DIMENSIONS -> ambiguousDimensions++;
+                    case CONFLICTING_VALUES -> conflictingValues++;
+                    case INVALID_VALUE -> invalidValues++;
+                }
+            }
+
+            return new PackageEvidenceSummary(
+                    input.size(),
+                    found,
+                    missing,
+                    ambiguousDimensions,
+                    conflictingValues,
+                    invalidValues);
+        }
+
+        int classifiedPages() {
+            return classifiedPages(found, missing, ambiguousDimensions, conflictingValues, invalidValues);
+        }
+
+        private static int classifiedPages(
+                int found,
+                int missing,
+                int ambiguousDimensions,
+                int conflictingValues,
+                int invalidValues) {
+            return found + missing + ambiguousDimensions + conflictingValues + invalidValues;
+        }
     }
 
     record CorpusResult(
@@ -417,7 +507,12 @@ final class MagnitCorpusProbe {
             int nearSkuMultiplePriceObservations,
             int nearSkuPromoMarkerObservations,
             int priceBoundPromoMarkerObservations,
+            PackageEvidenceSummary packageEvidence,
             List<String> failedRequirements) {
+
+        CorpusResult {
+            packageEvidence = Objects.requireNonNull(packageEvidence, "packageEvidence must not be null");
+        }
 
         String toEvidenceLine() {
             return "MAGNIT_PHASE_B"
@@ -433,6 +528,12 @@ final class MagnitCorpusProbe {
                     + " near_sku_multi_price=" + nearSkuMultiplePriceObservations
                     + " near_sku_promo_marker=" + nearSkuPromoMarkerObservations
                     + " price_bound_promo_marker=" + priceBoundPromoMarkerObservations
+                    + " package_evidence_pages=" + packageEvidence.packageEvidencePages()
+                    + " package_found=" + packageEvidence.found()
+                    + " package_missing=" + packageEvidence.missing()
+                    + " package_ambiguous_dimensions=" + packageEvidence.ambiguousDimensions()
+                    + " package_conflicting_values=" + packageEvidence.conflictingValues()
+                    + " package_invalid_values=" + packageEvidence.invalidValues()
                     + " failed_count=" + failedRequirements.size()
                     + " failed_requirements=" + String.join(",", failedRequirements);
         }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbeTest.java
@@ -110,15 +110,21 @@ class MagnitCorpusProbeTest {
         assertThat(observation.currentPrice()).isEmpty();
         assertThat(observation.regularPrice()).isEmpty();
         assertThat(observation.availability()).isEqualTo(MagnitCorpusProbe.Availability.UNKNOWN);
+        assertThat(observation.packageExtraction().status()).isEqualTo(MagnitPackageQuantityStatus.MISSING);
     }
 
     @Test
-    void evidenceLineIncludesOnlyApprovedFailedRequirementNames() {
+    void evidenceLineIncludesPackageDistributionAndOnlyApprovedFailedRequirementNames() {
+        var packageEvidence = new MagnitCorpusProbe.PackageEvidenceSummary(4, 1, 1, 1, 0, 1);
         var result = new MagnitCorpusProbe.CorpusResult(
-                20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, 2, List.of("tea", "beef/mince"));
-        assertThat(result.toEvidenceLine()).endsWith("failed_count=2 failed_requirements=tea,beef/mince");
+                20, 40, 19, 19, 19, 19, 19, 6, 0, 4, 3, 2, packageEvidence, List.of("tea", "beef/mince"));
+
         assertThat(result.toEvidenceLine()).contains("near_sku_multi_price=4 near_sku_promo_marker=3");
         assertThat(result.toEvidenceLine()).contains("price_bound_promo_marker=2");
+        assertThat(result.toEvidenceLine()).contains(
+                "package_evidence_pages=4 package_found=1 package_missing=1 "
+                        + "package_ambiguous_dimensions=1 package_conflicting_values=0 package_invalid_values=1");
+        assertThat(result.toEvidenceLine()).endsWith("failed_count=2 failed_requirements=tea,beef/mince");
     }
 
     @Test
@@ -139,6 +145,17 @@ class MagnitCorpusProbeTest {
         assertThat(result.nearSkuMultiplePriceObservations()).isBetween(0, 40);
         assertThat(result.nearSkuPromoMarkerObservations()).isBetween(0, 40);
         assertThat(result.priceBoundPromoMarkerObservations()).isBetween(0, 40);
+
+        var packageEvidence = result.packageEvidence();
+        assertThat(packageEvidence.packageEvidencePages()).isBetween(0, 40);
+        assertThat(packageEvidence.packageEvidencePages())
+                .isLessThanOrEqualTo(result.firstHttp2xx() + result.secondHttp2xx());
+        assertThat(packageEvidence.found()).isBetween(0, 40);
+        assertThat(packageEvidence.missing()).isBetween(0, 40);
+        assertThat(packageEvidence.ambiguousDimensions()).isBetween(0, 40);
+        assertThat(packageEvidence.conflictingValues()).isBetween(0, 40);
+        assertThat(packageEvidence.invalidValues()).isBetween(0, 40);
+        assertThat(packageEvidence.classifiedPages()).isEqualTo(packageEvidence.packageEvidencePages());
 
         var approvedRequirements = Set.copyOf(MagnitCorpusProbe.fixedCorpus().stream()
                 .map(MagnitCorpusProbe.CorpusItem::requirement).toList());

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **ship #82 Magnit structured characteristic extraction; then measure it over the explicit/manual Magnit corpus without bypassing #69/#70**
+Current focus: **ship #83 Magnit fixed-corpus package-evidence instrumentation; then obtain an explicit/manual distribution without bypassing #69/#70**
 
 ## Product connectivity invariant
 
@@ -58,50 +58,54 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
    Explicit package evidence, whole-package arithmetic, per-item resolution states, `COMPLETE` / `UNCERTAIN` / `INCOMPLETE` basket states, no total for incomplete baskets and fail-closed mixed-currency behavior.
 
 8. **Failure / coverage / freshness product boundary — COMPLETE (#79)**  
-   All eight canonical retailers remain visible; technical coverage, production access, comparison status, product-safe reasons and freshness are separated. `GET /api/v1/retailers`, OpenAPI/generated client and responsive web readiness behavior are shipped. Provider IDs, acquisition modes, source references and precise addresses remain internal.
+   All eight canonical retailers remain visible; technical coverage, production access, comparison status, product-safe reasons and freshness are separated. Provider IDs, acquisition modes, source references and precise addresses remain internal.
 
 9. **Stateless critical comparison journey — COMPLETE / ACCEPTED (#80)**  
-   `POST /api/v1/comparison-previews`, locality-only public context, repeatable manual-list input, provider/snapshot/matching/basket/read-model orchestration, all eight retailer outcomes, product-safe item gaps, OpenAPI/generated client, responsive UI and desktop/mobile Playwright are merged. Production comparison evidence remains strict no-op/fail-closed and ordinary CI makes no live retailer calls.
+   `POST /api/v1/comparison-previews`, locality-only public context, manual-list input, full deterministic comparison orchestration, generated client, responsive UI and desktop/mobile Playwright are merged. Production comparison evidence remains strict no-op/fail-closed.
 
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**  
-    Merged to `main` as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`.
-    - `ObservedOffer` carries optional canonical structured `packageQuantity` evidence;
-    - the legacy constructor remains source-compatible and defaults to empty evidence;
-    - `OfferSnapshot` preserves the evidence;
-    - `PackageQuantitySet.fromSnapshots(...)` projects only explicit snapshot evidence;
-    - runtime comparison evidence derives package bindings from snapshots and rejects disagreement with any compatibility binding set;
-    - deterministic fixtures now attach package quantity at the provider boundary before snapshotting;
-    - regression tests prove names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.
+    Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`. `ObservedOffer` can carry optional canonical package quantity, snapshots preserve it, basket/runtime bindings derive from snapshots, and presentation text is explicitly non-authoritative. Full PR gate and post-merge `main` gate passed.
 
-    Exact reviewed candidate and docs-only shipping marker both passed the full PR workflow gate; independent review reported no P0/P1/P2 findings. After squash merge, all eight push-triggered `main` workflows completed successfully.
+11. **Magnit structured package characteristics — COMPLETE / ACCEPTED (#82)**  
+    Merged as `3753a9296562354939e86876a8096c15b2957e35`.
+    - pure `MagnitPackageQuantityExtractor`, no HTTP/Spring activation;
+    - exact `Характеристики` fields `Вес, кг` and `Объем, л` only;
+    - canonical kg→g and l→ml conversion;
+    - duplicate equivalent values deduplicated;
+    - weight + volume → `AMBIGUOUS_DIMENSIONS`;
+    - conflicting same-dimension values → `CONFLICTING_VALUES`;
+    - malformed/zero/negative values → `INVALID_VALUE`;
+    - title/slug/description/script/style/out-of-section numbers cannot create package evidence;
+    - `Количество в упаковке` deferred from v1;
+    - `FOUND` output is proven compatible with #81 provider/snapshot evidence while ambiguous output remains unknown.
 
-    Design: [`superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md`](superpowers/specs/2026-08-12-m1-structured-package-evidence-design.md)  
-    Shipping evidence: [`superpowers/plans/2026-08-12-m1-structured-package-evidence-shipping.md`](superpowers/plans/2026-08-12-m1-structured-package-evidence-shipping.md)
-
-11. **Magnit structured package characteristics — IMPLEMENTED / SHIPPING (#82)**  
-    #82 is the first source-specific consumer of #81's package-evidence boundary.
-    - official Magnit public product pages were verified to expose exact `Характеристики` fields `Вес, кг` and `Объем, л` independently of product titles;
-    - pure `MagnitPackageQuantityExtractor` performs no HTTP and has no Spring wiring;
-    - it inspects only the `Характеристики` section and exact supported labels;
-    - `Вес, кг` canonicalizes through `Quantity` to grams; `Объем, л` to milliliters;
-    - duplicate equivalent values are deduplicated;
-    - weight + volume fails closed as `AMBIGUOUS_DIMENSIONS`;
-    - conflicting same-dimension values fail closed as `CONFLICTING_VALUES`;
-    - malformed/zero/negative supported values fail closed as `INVALID_VALUE`;
-    - title/slug/description/script/style numbers cannot create package evidence;
-    - `Количество в упаковке` is deliberately deferred from v1 because its current source surface and multi-dimensional semantics need separate proof;
-    - a provider bridge regression proves `FOUND` evidence can populate `ObservedOffer.packageQuantity` and survive into `OfferSnapshot`, while ambiguous extraction remains package-unknown.
-
-    **#82 does not activate Magnit production acquisition.** #69 location→`shopCode` and #70 recurring production usage-rights remain unchanged blockers. Ordinary CI remains live-retailer-free.
+    Exact reviewed candidate and docs-only shipping marker passed the complete PR workflow gate; read-only review reported no P0/P1/P2 findings. After squash merge, all eight push-triggered `main` workflows completed successfully with zero failures.
 
     Design: [`superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md`](superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md)  
-    Evidence: [`integrations/magnit-structured-package-characteristics-2026-08-12.md`](integrations/magnit-structured-package-characteristics-2026-08-12.md)
+    Evidence: [`integrations/magnit-structured-package-characteristics-2026-08-12.md`](integrations/magnit-structured-package-characteristics-2026-08-12.md)  
+    Shipping: [`superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md`](superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md)
+
+12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**  
+    #83 instruments the pre-existing explicit/manual 20-product × 2-shop Magnit research corpus without changing transport behavior:
+    - identity-valid pages carry the accepted #82 extraction alongside existing price/promo/availability evidence;
+    - package statistics include only HTTP 2xx responses with expected-SKU identity evidence;
+    - non-2xx/error pages and wrong-identity pages are excluded rather than being mislabeled `MISSING`;
+    - a structural `PackageEvidenceSummary` reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
+    - status counts must sum exactly to `packageEvidencePages`;
+    - the aggregate evidence line adds only counters, never HTML/page fragments or sensitive product/provider data;
+    - the guarded live test keeps the same `-Dzakup.live.magnit.corpus=true` opt-in and the same 40-request fixed corpus;
+    - no minimum `FOUND` threshold is invented before the first measurement exists;
+    - ordinary CI remains live-retailer-free.
+
+    Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md)  
+    Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md)
 
 ## Important M1 limitations
 
 - Production comparison evidence remains deliberately **no-op/fail-closed**. The critical journey proves product/API/core integration, not live production retailer acquisition.
 - Perekrestok and Pyaterochka accepted browser paths still do not prove a dedicated structured package field. Do not parse product names or widen browser permissions merely to obtain package size.
-- Magnit now has a technically proven fail-closed extractor for exact labeled weight/volume characteristics, but this is **not production activation**.
+- Magnit has a technically proven exact-field extractor and a fixed-corpus measurement harness, but this is **not production activation**.
+- The first package-status distribution has not yet been accepted as evidence until the guarded live corpus is explicitly run.
 - Magnit location/address → public `shopCode` resolution remains unresolved (#69).
 - Magnit recurring production acquisition usage rights remain unresolved (#70); recurring polling remains disabled until authoritative acceptance.
 - `Количество в упаковке` support is deferred pending separate source/domain evidence.
@@ -110,25 +114,16 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
 - Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer paths still require onboarding/hardening.
 - A successful real `v0.1.0-rc.3` GitHub Release proof remains outstanding.
 
-## Accepted retailer paths
+## Magnit status
 
-### Pyaterochka
+Technical path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**. Existing Phase B proved stable usable observations in explicit `shopCode` contexts; availability remains `UNKNOWN` where stock semantics are not proven.
 
-Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter `pyaterochka-browser` v1. Real first-party gate: 12 normalized observations, one fulfillment context, zero normalized validation failures. Anonymous direct server access remains unsuitable (`store-403`). No accepted structured package-quantity field is proven yet.
-
-### Perekrestok
-
-Status: **`AVAILABLE_BROWSER_BRIDGE`**, adapter v2. Repeated first-party evidence: 90 normalized observations, one fulfillment context and zero acceptance-validation failures. #54 remains lifecycle hardening for same-document store changes / SPA navigation. Current accepted evidence does not prove a dedicated structured package-quantity field.
-
-### Magnit
-
-Status: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context technical feasibility**. Phase B proved stable usable observations in explicit `shopCode` contexts. Availability remains `UNKNOWN` where stock semantics are not proven.
-
-Structured package evidence status:
-- exact characteristic `Вес, кг` — supported by #82 extractor when unambiguous;
-- exact characteristic `Объем, л` — supported by #82 extractor when unambiguous;
-- simultaneous weight + volume — package-unknown / fail closed;
-- `Количество в упаковке` — deferred.
+Structured package evidence:
+- `Вес, кг` — supported when unambiguous;
+- `Объем, л` — supported when unambiguous;
+- simultaneous weight + volume — fail closed / unknown;
+- `Количество в упаковке` — deferred;
+- corpus instrumentation — implemented in #83, live distribution pending explicit run.
 
 Constraints:
 - **#69** — automatic location/address → public `shopCode` resolution not proven;
@@ -146,19 +141,20 @@ Constraints:
 8. Matching ambiguity never becomes a hidden winner and no fuzzy/AI tie-break is introduced implicitly.
 9. Package quantity is explicit structured evidence; missing evidence is never guessed from names, URLs, category or other presentation text.
 10. Package evidence attached to runtime basket calculation derives from immutable snapshot evidence.
-11. Source-specific extraction must fail closed on conflicting or multi-dimensional fields unless a separate domain rule is explicitly proven.
-12. Incomplete baskets never expose a misleading complete-basket total.
-13. Production activation respects usage-rights state.
-14. Ordinary CI and browser acceptance make no live retailer requests.
-15. Production preview evidence fails closed rather than falling back to deterministic fixtures.
-16. Unknown public JSON request fields fail closed rather than being ignored.
-17. Universal retailer connectivity remains mandatory for every registry entry.
+11. Source-specific extraction fails closed on conflicting or multi-dimensional fields unless a separate domain rule is explicitly proven.
+12. Corpus package metrics classify only transport-successful, identity-valid product pages.
+13. Incomplete baskets never expose a misleading complete-basket total.
+14. Production activation respects usage-rights state.
+15. Ordinary CI and browser acceptance make no live retailer requests.
+16. Production preview evidence fails closed rather than falling back to deterministic fixtures.
+17. Unknown public JSON request fields fail closed rather than being ignored.
+18. Universal retailer connectivity remains mandatory for every registry entry.
 
 ## Immediate next work
 
-1. **Finish shipping #82** with exact-head CI/security verification and independent review.
-2. After #82 acceptance, run an **explicit/manual Magnit fixed-corpus package-characteristic evidence pass** to measure `FOUND` / `MISSING` / `AMBIGUOUS_DIMENSIONS` / `CONFLICTING_VALUES` / `INVALID_VALUE` distribution. This is research evidence, not production polling.
-3. Use that corpus evidence to decide whether v1 weight/volume extraction is sufficient and whether `Количество в упаковке` needs a multi-dimensional domain extension.
+1. **Finish shipping #83** with exact-head CI/security and independent review.
+2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence, not recurring production polling.
+3. Use the measured distribution to decide whether weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions need a domain extension.
 4. Continue **#69** Magnit location → `shopCode`, **#70** usage-rights resolution and **#54** browser-bridge lifecycle hardening.
 5. Continue **#36** Kuper supported-access investigation and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
 6. Prove a successful real `v0.1.0-rc.3` release event.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - observation time is not provider-update time;
 - package quantity is explicit structured evidence, never inferred from product names, slugs, category or presentation text;
 - source-specific extraction fails closed on ambiguity/conflict;
+- corpus quality metrics classify only transport-successful, identity-valid pages;
 - production activation respects usage-rights state;
 - ordinary M1 tests make no live retailer requests.
 
@@ -46,34 +47,41 @@ Goal: compare a manually entered grocery list across connected retailers while p
 9. **Critical product journey — COMPLETE / ACCEPTED (#80)**
    - stateless manual-list comparison API and responsive web journey;
    - all eight retailers remain visible with explicit comparison states;
-   - item-level gaps remain product-safe;
-   - production runtime evidence is strict no-op/fail-closed;
+   - product-safe item gaps;
+   - production runtime evidence strict no-op/fail-closed;
    - desktop/mobile deterministic Playwright without hidden live retailer access.
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**
    - optional canonical `ObservedOffer.packageQuantity`;
    - immutable snapshot preservation;
    - snapshot-derived `PackageQuantitySet`;
    - runtime rejects a parallel package set that disagrees with snapshots;
-   - title/presentation parsing explicitly prohibited and regression-tested;
-   - merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`, then all eight push-triggered main workflows passed.
-11. **Magnit exact characteristic package extraction — IMPLEMENTED / SHIPPING (#82)**
-   - pure source-specific extractor for exact `Характеристики` fields `Вес, кг` and `Объем, л`;
-   - kg/l canonicalization reuses `Quantity`;
-   - identical duplicates deduplicate;
-   - weight + volume → `AMBIGUOUS_DIMENSIONS` and no package quantity;
-   - conflicting same-dimension values → `CONFLICTING_VALUES`;
-   - malformed/zero/negative supported values → `INVALID_VALUE`;
-   - title/slug/description/script/style numbers do not create evidence;
-   - `Количество в упаковке` is deferred from v1;
-   - a provider/snapshot regression proves `FOUND` output can enter the #81 evidence path and ambiguous output remains unknown;
-   - no HTTP exists in the production extractor and no production Magnit polling/access state is changed.
+   - title/presentation parsing explicitly prohibited and regression-tested.
+11. **Magnit exact characteristic package extraction — COMPLETE / ACCEPTED (#82)**
+   - pure exact-field extractor for `Вес, кг` / `Объем, л` inside `Характеристики`;
+   - canonical kg→g / l→ml;
+   - fail-closed ambiguity/conflict/invalid states;
+   - title/slug/description/script/style/out-of-section data cannot create evidence;
+   - count semantics deferred;
+   - no HTTP/Spring activation;
+   - merged as `3753a9296562354939e86876a8096c15b2957e35`, then all eight push-triggered `main` workflows passed with zero failures.
+12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**
+   - existing explicit/manual 20-product × 2-shop corpus remains unchanged in request count and transport policy;
+   - identity-valid pages carry #82 package extraction alongside existing price/promo/availability evidence;
+   - package status metrics include only HTTP 2xx + expected-SKU observations;
+   - transport/error and wrong-identity pages are excluded rather than counted as `MISSING`;
+   - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
+   - status counts must equal `packageEvidencePages` exactly;
+   - evidence line exposes only aggregate counters;
+   - existing guarded live property remains `-Dzakup.live.magnit.corpus=true`;
+   - no pre-evidence minimum `FOUND` threshold is invented;
+   - ordinary CI remains live-retailer-free.
 
-   Design: [`superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md`](superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md).  
-   Evidence: [`integrations/magnit-structured-package-characteristics-2026-08-12.md`](integrations/magnit-structured-package-characteristics-2026-08-12.md).
+   Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md).  
+   Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md).
 
 ### Important remaining basket-data limitation
 
-Provider/snapshot/basket plumbing can carry trusted package evidence, and Magnit now has a narrowly supported weight/volume characteristic extractor. This does **not** mean every Magnit SKU yields a usable quantity: products with both weight and volume remain unknown under the current single-`Quantity` model, count is deferred, and other retailers still lack an accepted structured field.
+Magnit now has accepted weight/volume semantics and an instrumented fixed-corpus measurement path, but the first live package-status distribution is still pending. Products with both weight and volume remain unknown under the current single-`Quantity` model; count is deferred; other retailers still lack an accepted structured field.
 
 Never replace this with product-name parsing.
 
@@ -88,14 +96,15 @@ Never replace this with product-name parsing.
 - provenance/context/freshness survive internally without leaking implementation IDs;
 - package evidence remains structured source evidence through provider → snapshot → basket;
 - source-specific ambiguity/conflict never becomes a guessed quantity;
+- evidence-quality measurements separate transport/identity failure from missing metadata;
 - incomplete baskets cannot masquerade as complete winners;
 - production activation remains separately gated by access, location/context and source semantics.
 
 ### Next M1 engineering focus
 
-1. **Ship #82** after exact-head CI/security and independent review.
-2. **Run an explicit/manual Magnit fixed-corpus package-evidence pass** after #82 acceptance. Extend the existing research probe to report `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` counts without enabling recurring polling.
-3. Use corpus evidence to decide whether weight/volume support is sufficient and whether `Количество в упаковке` requires multi-dimensional package modeling.
+1. **Ship #83** after exact-head CI/security and independent review.
+2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence and does not enable recurring polling.
+3. Use the measured distribution to decide whether exact weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions require a domain extension.
 4. **Magnit location → `shopCode` (#69)** and **production usage-rights decision (#70)** remain mandatory before production activation.
 5. **Browser bridge lifecycle hardening (#54)** for persistent sessions/store changes/SPA navigation.
 6. **Kuper supported aggregator investigation (#36)**.

--- a/docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus-shipping.md
+++ b/docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus-shipping.md
@@ -1,0 +1,77 @@
+# Magnit Package Evidence Corpus — Shipping Evidence
+
+Date: 2026-08-12  
+PR: #83 `test(magnit): measure package evidence across fixed corpus`
+
+## Accepted scope
+
+- instrument the existing explicit/manual Magnit 20-product × 2-shop corpus with the already accepted #82 package extractor;
+- preserve request count, shop contexts, URLs, headers, timeout, price/promo/availability parsing and live-enable property;
+- count package metadata quality only for HTTP 2xx observations whose expected SKU identity is proven;
+- exclude transport/error and wrong-identity observations rather than classifying them as package `MISSING`;
+- structurally summarize `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
+- require classified status counts to equal `packageEvidencePages` exactly;
+- expose aggregate counters only in the evidence line;
+- keep the live run explicit/manual behind `-Dzakup.live.magnit.corpus=true`;
+- invent no minimum `FOUND` threshold before the first measured distribution exists;
+- make no production provider/Spring/polling/access-state change and leave #69/#70 unchanged.
+
+## TDD evidence
+
+RED head: `0a6ab52a3e3e4e377585ecdeac6c412021a54092`
+
+API test compilation failed exactly because the new instrumentation contract did not yet exist:
+- `PageObservation.packageExtraction()` missing;
+- `MagnitCorpusProbe.PackageEvidenceSummary` missing.
+
+GREEN implementation then:
+- attached #82 extraction to identity-valid `PageObservation`;
+- added fail-closed package-evidence eligibility (`http2xx && skuEvidence`);
+- added structural status summary and aggregate evidence-line counters;
+- extended existing deterministic/live-test assertions without changing network behavior.
+
+## Exact reviewed candidate
+
+SHA: `578ad640500f08b7b3767f1a3b427a0c5f8ae1a6`
+
+All required PR workflow groups passed:
+- API CI — PASS
+- Contract CI — PASS
+- Web CI + responsive Web E2E — PASS
+- Retailer Bridge CI — PASS
+- Dependency Review — PASS
+- CodeQL — PASS
+- Container Security CI — PASS
+- Release Bundle CI — PASS
+- Release Contract CI — PASS
+
+Ordinary CI made no live Magnit corpus request.
+
+## Read-only review
+
+Verdict: **Looks good**
+
+- P0: none
+- P1: none
+- P2: none
+- P3: the new transport eligibility predicate itself has no dedicated unit-test hook. It is intentionally private/test-tool-local and consists only of `http2xx() && observation.skuEvidence()`. Exposing the private HTTP observation shape or using reflection solely for that assertion would increase test coupling. The surrounding deterministic tests cover identity failure, status summary invariants and evidence-line behavior; the guarded live test additionally verifies package page/count bounds. Revisit only if eligibility logic becomes more complex than this two-condition fail-closed predicate.
+
+Review scope included:
+- eligibility semantics and separation of transport failure from metadata absence;
+- exact status-count invariant;
+- existing price/promo/availability regression preservation;
+- live opt-in and request-count preservation;
+- evidence-line privacy/content;
+- no production/runtime wiring;
+- #69/#70 production-access constraints;
+- durable PROJECT_STATE/ROADMAP/CHANGELOG consistency.
+
+No blocking correctness, security, privacy, architecture or access-policy issue was found.
+
+## Final gate
+
+This marker changes documentation only. The final PR head must pass the full branch-protection workflow set again before squash merge. Merge must use the exact final head SHA.
+
+## Post-merge next step
+
+Run the guarded fixed corpus explicitly once and record the first package-status distribution as research evidence. The run remains finite/manual and must not be interpreted as recurring production polling or as resolution of #69/#70.

--- a/docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md
+++ b/docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md
@@ -1,0 +1,40 @@
+# Magnit Package Evidence Corpus Implementation Plan
+
+## Goal
+
+Instrument the existing explicit/manual Magnit fixed-corpus probe with #82 package-extraction status measurement while keeping transport and production activation unchanged.
+
+## Task 1 — TDD contract
+
+Add `MagnitCorpusPackageEvidenceTest` requiring:
+
+- `PageObservation.packageExtraction()` for an identity-valid page;
+- `PackageEvidenceSummary.summarize(...)` classification for all five statuses;
+- summary invariant: status counts sum exactly to eligible page count;
+- evidence-line fields `package_evidence_pages`, `package_found`, `package_missing`, `package_ambiguous_dimensions`, `package_conflicting_values`, `package_invalid_values`.
+
+Run focused API test and confirm RED because the probe does not expose this instrumentation yet.
+
+## Task 2 — Minimal probe instrumentation
+
+Modify test-only `MagnitCorpusProbe`:
+
+- attach #82 extraction to identity-valid `PageObservation`;
+- define a package-evidence summary value with structural count invariant;
+- classify only HTTP 2xx + expected-SKU observations;
+- add aggregate counters to `CorpusResult` and evidence line;
+- do not change request headers, timeouts, shop codes, URLs, price/promo/availability parsing or live-enable property.
+
+Run focused tests and full Magnit probe regressions.
+
+## Task 3 — Live-test bounds
+
+Extend the existing guarded live test only with safe bounds and the aggregate invariant. Do not introduce a minimum FOUND threshold before evidence exists.
+
+Ordinary CI must still skip the live network test.
+
+## Task 4 — Shipping
+
+Update PROJECT_STATE/ROADMAP/CHANGELOG only after deterministic instrumentation is green. Open draft PR, require exact-head full CI/security, independent read-only review and squash merge. Post-merge verify `main`.
+
+An explicit live corpus run, if performed, remains controlled research evidence and does not change #69/#70 or production activation.

--- a/docs/superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md
+++ b/docs/superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md
@@ -1,0 +1,85 @@
+# Magnit Package Evidence Corpus Measurement Design
+
+Updated: 2026-08-12
+Status: implementation direction
+
+## Context
+
+#82 accepted a pure fail-closed `MagnitPackageQuantityExtractor` for exact official `Характеристики` fields `Вес, кг` and `Объем, л`. Production activation remains blocked by #69 and #70. The next question is empirical: how useful are those accepted semantics across the existing fixed 20-product Magnit corpus and two explicit shop contexts?
+
+The existing `MagnitCorpusProbe` is already explicit/manual live research tooling guarded by `-Dzakup.live.magnit.corpus=true`; ordinary CI never runs the network corpus.
+
+## Goal
+
+Instrument the existing fixed-corpus probe so each identity-valid HTTP 2xx product page is classified by the accepted #82 extractor and the final evidence line reports the distribution of:
+
+- `FOUND`
+- `MISSING`
+- `AMBIGUOUS_DIMENSIONS`
+- `CONFLICTING_VALUES`
+- `INVALID_VALUE`
+
+This is measurement only. It must not alter request frequency, URLs, headers, shop codes, price/availability semantics, retailer coverage/access state or production wiring.
+
+## Eligibility rule
+
+A page participates in package-evidence statistics only when:
+
+1. the HTTP response is 2xx; and
+2. the expected SKU identity is proven by the existing page parser.
+
+Non-2xx/error pages must not be counted as `MISSING`, because that would conflate transport failure with absent package metadata.
+
+A 2xx page without expected-SKU evidence is also excluded because the extractor result cannot safely be attributed to the requested corpus item.
+
+`packageEvidencePages` is therefore the count of identity-valid HTTP 2xx observations across both shop contexts.
+
+Invariant:
+
+`FOUND + MISSING + AMBIGUOUS_DIMENSIONS + CONFLICTING_VALUES + INVALID_VALUE == packageEvidencePages`
+
+## Probe integration
+
+`MagnitCorpusProbe.parseProductPage(...)` preserves its current price/promo/availability behavior and additionally attaches `MagnitPackageQuantityExtractor.extract(html)` when expected-SKU evidence exists. `missingSku()` carries an empty `MISSING` extraction only as a safe placeholder; it is never counted because identity eligibility is false.
+
+`runFixedCorpus(...)` collects extraction results only from eligible observations and summarizes them once at the end.
+
+The evidence line adds only aggregate counters; it must not print product HTML, source page fragments, titles, prices, addresses or arbitrary provider data.
+
+## Deterministic tests
+
+- page parser with expected SKU + exact weight characteristic carries `FOUND 450 GRAM`;
+- expected SKU missing never becomes package-evidence eligible;
+- summary classifies all five statuses correctly;
+- summary invariant rejects inconsistent manual construction;
+- evidence line emits the five aggregate counters plus eligible page count;
+- existing price/promo/availability tests remain unchanged and passing.
+
+## Live evidence behavior
+
+The existing live test remains guarded by:
+
+`-Dzakup.live.magnit.corpus=true`
+
+When explicitly run, it continues exactly 40 requests: 20 fixed products × 2 explicit shop contexts.
+
+The live assertion only checks bounds/invariants, not a predetermined FOUND threshold. The first measured distribution is evidence, not an acceptance target.
+
+## Production/access constraints
+
+- no recurring polling;
+- no production Spring/provider activation;
+- no new browser path or permissions;
+- no location/address resolution changes;
+- #69 and #70 unchanged;
+- ordinary CI live-retailer-free.
+
+## Exit criteria
+
+- deterministic instrumentation tests pass;
+- existing Magnit price/availability probe regressions pass;
+- evidence summary cannot classify transport/identity failures as package `MISSING`;
+- aggregate status invariant is structural/tested;
+- exact-head CI/security passes;
+- independent review has no blocking findings;
+- optional explicit/manual live corpus run may be performed after instrumentation is accepted or as controlled evidence during review, but its result must not be presented as recurring production support.


### PR DESCRIPTION
Implements package-evidence measurement on the existing explicit/manual Magnit fixed corpus after #82.

## Delivered

- Identity-valid `PageObservation` values carry the accepted #82 `MagnitPackageQuantityExtraction` alongside existing price/promo/availability evidence.
- Package statistics count only HTTP 2xx observations with expected-SKU identity evidence.
- Non-2xx/error pages and wrong-product 2xx pages are excluded instead of being mislabeled package `MISSING`.
- `PackageEvidenceSummary` reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE` and structurally requires their sum to equal `packageEvidencePages`.
- The existing evidence line adds only aggregate package counters; it does not print page HTML/fragments or arbitrary provider data.
- Existing price/promo/availability parsing, request headers, URLs, shop contexts, timeouts and request count are unchanged.
- The live corpus remains opt-in behind `-Dzakup.live.magnit.corpus=true` and exactly 20 fixed products × 2 explicit shop contexts.
- No minimum `FOUND` threshold is invented before the first measurement exists.

## Boundaries

- Ordinary CI remains live-retailer-free.
- No recurring production polling or Spring/provider activation is added.
- #69 location→`shopCode` and #70 production usage rights remain unchanged blockers.
- This PR instruments evidence quality; it does not claim a measured live distribution yet.

## TDD / review

- RED head `0a6ab52` failed API test compilation exactly because `PageObservation.packageExtraction()` and `PackageEvidenceSummary` did not exist.
- GREEN instrumentation preserves transport behavior and adds eligibility/status invariants.
- PROJECT_STATE, ROADMAP and CHANGELOG reflect #82 as accepted and #83 as implemented/shipping.
- Exact reviewed candidate `578ad640500f08b7b3767f1a3b427a0c5f8ae1a6`: all 9 workflow groups PASS.
- Independent read-only review: **Looks good**, P0/P1/P2 none. P3 only: the simple private/test-tool eligibility predicate (`http2xx && skuEvidence`) has no dedicated unit hook; exposing private transport internals solely for that assertion would increase test coupling.
- Docs-only shipping marker head `e31013d6caad6ed98cdab5483c69a41fa0c57b45`: all 9 workflow groups PASS again.

Design: `docs/superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`
Plan: `docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`
Shipping evidence: `docs/superpowers/plans/2026-08-12-magnit-package-evidence-corpus-shipping.md`