### PR TITLE
docs(magnit): record package corpus no-go and next provenance gate

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **ship #83 Magnit fixed-corpus package-evidence instrumentation; then obtain an explicit/manual distribution without bypassing #69/#70**
+Current focus: **Magnit package-characteristics provenance investigation: determine whether exact structured characteristics live in embedded/bootstrap data, a separate public page request, or browser-rendered DOM; do not parse product names or activate recurring polling**
 
 ## Product connectivity invariant
 
@@ -61,10 +61,10 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
    All eight canonical retailers remain visible; technical coverage, production access, comparison status, product-safe reasons and freshness are separated. Provider IDs, acquisition modes, source references and precise addresses remain internal.
 
 9. **Stateless critical comparison journey — COMPLETE / ACCEPTED (#80)**  
-   `POST /api/v1/comparison-previews`, locality-only public context, manual-list input, full deterministic comparison orchestration, generated client, responsive UI and desktop/mobile Playwright are merged. Production comparison evidence remains strict no-op/fail-closed.
+   `POST /api/v1/comparison-previews`, locality-only public context, manual-list input, deterministic comparison orchestration, generated client, responsive UI and desktop/mobile Playwright are merged. Production comparison evidence remains strict no-op/fail-closed.
 
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**  
-    Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`. `ObservedOffer` can carry optional canonical package quantity, snapshots preserve it, basket/runtime bindings derive from snapshots, and presentation text is explicitly non-authoritative. Full PR gate and post-merge `main` gate passed.
+    Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`. `ObservedOffer` can carry optional canonical package quantity, snapshots preserve it, basket/runtime bindings derive from snapshots, and presentation text is explicitly non-authoritative. Full PR and post-merge gates passed.
 
 11. **Magnit structured package characteristics — COMPLETE / ACCEPTED (#82)**  
     Merged as `3753a9296562354939e86876a8096c15b2957e35`.
@@ -77,38 +77,59 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
     - malformed/zero/negative values → `INVALID_VALUE`;
     - title/slug/description/script/style/out-of-section numbers cannot create package evidence;
     - `Количество в упаковке` deferred from v1;
-    - `FOUND` output is proven compatible with #81 provider/snapshot evidence while ambiguous output remains unknown.
+    - `FOUND` output is compatible with #81 provider/snapshot evidence while ambiguous output stays unknown.
 
-    Exact reviewed candidate and docs-only shipping marker passed the complete PR workflow gate; read-only review reported no P0/P1/P2 findings. After squash merge, all eight push-triggered `main` workflows completed successfully with zero failures.
-
-    Design: [`superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md`](superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md)  
-    Evidence: [`integrations/magnit-structured-package-characteristics-2026-08-12.md`](integrations/magnit-structured-package-characteristics-2026-08-12.md)  
-    Shipping: [`superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md`](superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md)
-
-12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**  
-    #83 instruments the pre-existing explicit/manual 20-product × 2-shop Magnit research corpus without changing transport behavior:
-    - identity-valid pages carry the accepted #82 extraction alongside existing price/promo/availability evidence;
-    - package statistics include only HTTP 2xx responses with expected-SKU identity evidence;
-    - non-2xx/error pages and wrong-identity pages are excluded rather than being mislabeled `MISSING`;
-    - a structural `PackageEvidenceSummary` reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
-    - status counts must sum exactly to `packageEvidencePages`;
-    - the aggregate evidence line adds only counters, never HTML/page fragments or sensitive product/provider data;
-    - the guarded live test keeps the same `-Dzakup.live.magnit.corpus=true` opt-in and the same 40-request fixed corpus;
-    - no minimum `FOUND` threshold is invented before the first measurement exists;
+12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**  
+    Merged as `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6`.
+    - existing explicit/manual 20-product × 2-shop corpus keeps its transport behavior and 40-request bound;
+    - identity-valid pages carry #82 extraction alongside price/promo/availability evidence;
+    - package metrics include only HTTP 2xx + expected-SKU observations;
+    - transport/error and wrong-identity pages are excluded instead of becoming false `MISSING` cases;
+    - `PackageEvidenceSummary` reports all five extraction states and structurally requires classified counts to equal eligible pages;
+    - evidence output contains aggregate counters only;
+    - guarded live run remains opt-in via `-Dzakup.live.magnit.corpus=true`;
     - ordinary CI remains live-retailer-free.
 
+    Exact reviewed candidate and final shipping marker passed all PR workflow groups; independent review found no P0/P1/P2 issues. After squash merge, all eight push-triggered `main` workflows passed with zero failures.
+
     Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md)  
-    Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md)
+    Shipping: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus-shipping.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus-shipping.md)
+
+## Magnit live package corpus — ACCEPTED RESEARCH EVIDENCE / CURRENT NO-GO
+
+A deliberate one-shot run was executed from accepted #83 `main` using temporary evidence commit `bf129c0aae3fdd80f043bfec90eafe8c545a8f7e`, GitHub Actions run `31623235860`.
+
+The run remained finite and explicit:
+- 20 fixed products;
+- shop contexts `139147` and `773577`;
+- exactly 40 public product-page requests;
+- no schedule or recurring polling;
+- package quality counted only for HTTP 2xx + expected-SKU observations.
+
+Exact aggregate result:
+
+```text
+MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=20 second_http_2xx=20 first_usable=20 second_usable=20 stable_identity=20 known_availability=6 promo_observations=40 near_sku_multi_price=0 near_sku_promo_marker=40 price_bound_promo_marker=40 package_evidence_pages=40 package_found=0 package_missing=40 package_ambiguous_dimensions=0 package_conflicting_values=0 package_invalid_values=0 failed_count=0 failed_requirements=
+```
+
+Interpretation:
+- transport was healthy: 40/40 HTTP 2xx;
+- price/SKU surface was healthy: 40/40 usable observations and stable identity for all 20 products across both contexts;
+- package metadata on the **current raw/server-side PUBLIC_WEB HTML surface** was absent for every eligible observation: **0 FOUND / 40 MISSING**;
+- therefore #82 semantics remain valid, but the current Java `HttpClient` public-page path is **NO-GO for Magnit package quantity**;
+- do not wire this raw HTML path into production basket package evidence and do not compensate with title/slug parsing.
+
+Durable evidence: [`integrations/magnit-package-evidence-corpus-live-2026-08-12.md`](integrations/magnit-package-evidence-corpus-live-2026-08-12.md).
 
 ## Important M1 limitations
 
 - Production comparison evidence remains deliberately **no-op/fail-closed**. The critical journey proves product/API/core integration, not live production retailer acquisition.
-- Perekrestok and Pyaterochka accepted browser paths still do not prove a dedicated structured package field. Do not parse product names or widen browser permissions merely to obtain package size.
-- Magnit has a technically proven exact-field extractor and a fixed-corpus measurement harness, but this is **not production activation**.
-- The first package-status distribution has not yet been accepted as evidence until the guarded live corpus is explicitly run.
-- Magnit location/address → public `shopCode` resolution remains unresolved (#69).
-- Magnit recurring production acquisition usage rights remain unresolved (#70); recurring polling remains disabled until authoritative acceptance.
-- `Количество в упаковке` support is deferred pending separate source/domain evidence.
+- Perekrestok and Pyaterochka accepted browser paths still do not prove a dedicated structured package field.
+- Magnit's current raw PUBLIC_WEB HTML supports SKU/current-price feasibility but yielded **0/40** structured package fields in the fixed live corpus.
+- Official rendered Magnit pages can expose labeled characteristics, so their provenance must be established before choosing a package acquisition path.
+- Magnit location/address → public `shopCode` remains unresolved (#69).
+- Magnit recurring production acquisition usage rights remain unresolved (#70); recurring polling stays disabled.
+- `Количество в упаковке` support remains deferred; do not pursue it until the provenance question and multi-dimensional model are understood.
 - Browser-bridge persistent-session/store-change lifecycle hardening remains open (#54).
 - Kuper supported aggregator access remains open (#36).
 - Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer paths still require onboarding/hardening.
@@ -116,14 +137,15 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
 
 ## Magnit status
 
-Technical path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**. Existing Phase B proved stable usable observations in explicit `shopCode` contexts; availability remains `UNKNOWN` where stock semantics are not proven.
+Technical price/SKU path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**.
 
-Structured package evidence:
-- `Вес, кг` — supported when unambiguous;
-- `Объем, л` — supported when unambiguous;
-- simultaneous weight + volume — fail closed / unknown;
-- `Количество в упаковке` — deferred;
-- corpus instrumentation — implemented in #83, live distribution pending explicit run.
+Package evidence path:
+- exact weight/volume semantics — accepted in #82;
+- current raw `HttpClient` HTML corpus — **NO-GO, 0/40 FOUND**;
+- embedded/bootstrap structured data — not yet proven;
+- separate browser page request — not yet proven;
+- browser-rendered DOM — not yet proven;
+- count semantics — deferred.
 
 Constraints:
 - **#69** — automatic location/address → public `shopCode` resolution not proven;
@@ -143,18 +165,19 @@ Constraints:
 10. Package evidence attached to runtime basket calculation derives from immutable snapshot evidence.
 11. Source-specific extraction fails closed on conflicting or multi-dimensional fields unless a separate domain rule is explicitly proven.
 12. Corpus package metrics classify only transport-successful, identity-valid product pages.
-13. Incomplete baskets never expose a misleading complete-basket total.
-14. Production activation respects usage-rights state.
-15. Ordinary CI and browser acceptance make no live retailer requests.
-16. Production preview evidence fails closed rather than falling back to deterministic fixtures.
-17. Unknown public JSON request fields fail closed rather than being ignored.
-18. Universal retailer connectivity remains mandatory for every registry entry.
+13. A successful price/SKU transport does not imply structured package metadata availability.
+14. Incomplete baskets never expose a misleading complete-basket total.
+15. Production activation respects usage-rights state.
+16. Ordinary CI and browser acceptance make no live retailer requests.
+17. Production preview evidence fails closed rather than falling back to deterministic fixtures.
+18. Unknown public JSON request fields fail closed rather than being ignored.
+19. Universal retailer connectivity remains mandatory for every registry entry.
 
 ## Immediate next work
 
-1. **Finish shipping #83** with exact-head CI/security and independent review.
-2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence, not recurring production polling.
-3. Use the measured distribution to decide whether weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions need a domain extension.
+1. **Magnit package-characteristics provenance investigation — NEXT.** Distinguish raw HTML, embedded/bootstrap machine data, separate public page requests and browser-rendered DOM using sanitized/aggregate evidence. Do not change acquisition mode until a reproducible surface is proven.
+2. If structured data exists in raw/bootstrap/public request form, design a narrow exact-field extractor and replay it over the same fixed corpus before any production wiring.
+3. If characteristics exist only after browser execution, treat a Magnit browser-based acquisition path as a separate architecture/evidence decision rather than silently changing `AVAILABLE_PUBLIC_WEB` semantics.
 4. Continue **#69** Magnit location → `shopCode`, **#70** usage-rights resolution and **#54** browser-bridge lifecycle hardening.
 5. Continue **#36** Kuper supported-access investigation and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
 6. Prove a successful real `v0.1.0-rc.3` release event.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - observation time is not provider-update time;
 - package quantity is explicit structured evidence, never inferred from product names, slugs, category or presentation text;
 - source-specific extraction fails closed on ambiguity/conflict;
+- transport success never implies metadata availability;
 - corpus quality metrics classify only transport-successful, identity-valid pages;
 - production activation respects usage-rights state;
 - ordinary M1 tests make no live retailer requests.
@@ -45,45 +46,31 @@ Goal: compare a manually entered grocery list across connected retailers while p
 7. **Complete single-store basket comparison — COMPLETE (#78)**
 8. **Failure / coverage / freshness product + API + UX boundary — COMPLETE (#79)**
 9. **Critical product journey — COMPLETE / ACCEPTED (#80)**
-   - stateless manual-list comparison API and responsive web journey;
-   - all eight retailers remain visible with explicit comparison states;
-   - product-safe item gaps;
-   - production runtime evidence strict no-op/fail-closed;
-   - desktop/mobile deterministic Playwright without hidden live retailer access.
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**
-   - optional canonical `ObservedOffer.packageQuantity`;
-   - immutable snapshot preservation;
-   - snapshot-derived `PackageQuantitySet`;
-   - runtime rejects a parallel package set that disagrees with snapshots;
-   - title/presentation parsing explicitly prohibited and regression-tested.
-11. **Magnit exact characteristic package extraction — COMPLETE / ACCEPTED (#82)**
-   - pure exact-field extractor for `Вес, кг` / `Объем, л` inside `Характеристики`;
-   - canonical kg→g / l→ml;
-   - fail-closed ambiguity/conflict/invalid states;
-   - title/slug/description/script/style/out-of-section data cannot create evidence;
-   - count semantics deferred;
-   - no HTTP/Spring activation;
-   - merged as `3753a9296562354939e86876a8096c15b2957e35`, then all eight push-triggered `main` workflows passed with zero failures.
-12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**
-   - existing explicit/manual 20-product × 2-shop corpus remains unchanged in request count and transport policy;
-   - identity-valid pages carry #82 package extraction alongside existing price/promo/availability evidence;
-   - package status metrics include only HTTP 2xx + expected-SKU observations;
-   - transport/error and wrong-identity pages are excluded rather than counted as `MISSING`;
-   - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
-   - status counts must equal `packageEvidencePages` exactly;
-   - evidence line exposes only aggregate counters;
-   - existing guarded live property remains `-Dzakup.live.magnit.corpus=true`;
-   - no pre-evidence minimum `FOUND` threshold is invented;
-   - ordinary CI remains live-retailer-free.
+11. **Magnit exact characteristic package semantics — COMPLETE / ACCEPTED (#82)**
+12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**
+   - explicit/manual 20-product × 2-shop corpus;
+   - package metrics only for HTTP 2xx + expected-SKU observations;
+   - five fail-closed extraction states with structural count invariant;
+   - no recurring polling or production activation;
+   - merged as `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6`, then all eight push-triggered `main` workflows passed.
+13. **Magnit live package corpus — RESEARCH EVIDENCE COMPLETE / CURRENT NO-GO for raw PUBLIC_WEB package extraction**
+   - one explicit finite run: 20 products × 2 shop contexts = 40 requests;
+   - 40/40 HTTP 2xx;
+   - 40/40 usable observations;
+   - stable identity 20/20 across contexts;
+   - 40 package-evidence-eligible pages;
+   - `FOUND = 0`, `MISSING = 40`, all other package states = 0;
+   - zero failed corpus requirements;
+   - therefore the current Java `HttpClient` server-side PUBLIC_WEB HTML surface is not an accepted package-quantity path despite remaining valid for SKU/current-price feasibility.
 
-   Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md).  
-   Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md).
+   Evidence: [`integrations/magnit-package-evidence-corpus-live-2026-08-12.md`](integrations/magnit-package-evidence-corpus-live-2026-08-12.md).
 
 ### Important remaining basket-data limitation
 
-Magnit now has accepted weight/volume semantics and an instrumented fixed-corpus measurement path, but the first live package-status distribution is still pending. Products with both weight and volume remain unknown under the current single-`Quantity` model; count is deferred; other retailers still lack an accepted structured field.
+#81 can carry trusted package evidence and #82 defines exact Magnit weight/volume semantics, but the current raw Magnit PUBLIC_WEB surface yielded **0/40** supported fields in a clean live corpus. Do not wire that path into basket package evidence and never replace missing metadata with product-name parsing.
 
-Never replace this with product-name parsing.
+The unresolved question is provenance: official rendered pages can expose labeled characteristics, but current raw server HTML does not expose them to the accepted extractor. Determine whether they live in embedded/bootstrap structured data, a separate public page request, or only browser-rendered DOM.
 
 ### M1 exit criteria
 
@@ -97,19 +84,18 @@ Never replace this with product-name parsing.
 - package evidence remains structured source evidence through provider → snapshot → basket;
 - source-specific ambiguity/conflict never becomes a guessed quantity;
 - evidence-quality measurements separate transport/identity failure from missing metadata;
+- acquisition mode used for package evidence is explicitly proven rather than inferred from a different successful data field;
 - incomplete baskets cannot masquerade as complete winners;
 - production activation remains separately gated by access, location/context and source semantics.
 
 ### Next M1 engineering focus
 
-1. **Ship #83** after exact-head CI/security and independent review.
-2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence and does not enable recurring polling.
-3. Use the measured distribution to decide whether exact weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions require a domain extension.
-4. **Magnit location → `shopCode` (#69)** and **production usage-rights decision (#70)** remain mandatory before production activation.
-5. **Browser bridge lifecycle hardening (#54)** for persistent sessions/store changes/SPA navigation.
-6. **Kuper supported aggregator investigation (#36)**.
-7. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer onboarding.
-8. Prove a successful real `v0.1.0-rc.3` release event.
+1. **Magnit package-characteristics provenance investigation — NEXT.** Compare raw HTML markers, embedded/bootstrap machine data, separate public page requests and hydrated browser DOM with finite sanitized diagnostics.
+2. If a stable raw/bootstrap/public-request structured field exists, build a narrow extractor/replay corpus before any production wiring.
+3. If characteristics exist only after browser execution, treat Magnit browser acquisition as a separate design/evidence decision; do not silently redefine the accepted PUBLIC_WEB path.
+4. Keep **#69 location → `shopCode`** and **#70 production usage-rights** as mandatory blockers before recurring Magnit activation.
+5. Continue **#54 browser bridge lifecycle hardening**, **#36 Kuper supported aggregator investigation**, and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
+6. Prove a successful real `v0.1.0-rc.3` release event.
 
 ## M2 — Recipes
 

--- a/docs/integrations/magnit-package-evidence-corpus-live-2026-08-12.md
+++ b/docs/integrations/magnit-package-evidence-corpus-live-2026-08-12.md
@@ -1,0 +1,88 @@
+# Magnit Package Evidence Fixed Corpus — Live Result
+
+Date: 2026-08-12  
+Base `main`: `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6`  
+One-shot evidence commit: `bf129c0aae3fdd80f043bfec90eafe8c545a8f7e`  
+GitHub Actions run: `31623235860`  
+Mode: explicit finite research run, **not recurring production polling**
+
+## Purpose
+
+Measure how often the accepted #82 Magnit exact-characteristic extractor can recover structured package quantity from the same server-side public HTML surface already used by the fixed Magnit Phase B corpus.
+
+The run used the #83 methodology:
+
+- 20 fixed grocery products;
+- two explicit shop contexts (`139147`, `773577`);
+- exactly 40 public product-page requests;
+- package metadata classified only for HTTP 2xx observations whose expected SKU identity was proven;
+- transport/error and wrong-identity responses excluded from package-quality metrics;
+- no threshold for `FOUND` was assumed before the measurement.
+
+## Exact aggregate result
+
+```text
+MAGNIT_PHASE_B total_requirements=20 total_requests=40 first_http_2xx=20 second_http_2xx=20 first_usable=20 second_usable=20 stable_identity=20 known_availability=6 promo_observations=40 near_sku_multi_price=0 near_sku_promo_marker=40 price_bound_promo_marker=40 package_evidence_pages=40 package_found=0 package_missing=40 package_ambiguous_dimensions=0 package_conflicting_values=0 package_invalid_values=0 failed_count=0 failed_requirements=
+```
+
+The guarded JUnit evidence test completed successfully with 1 test, 0 failures, 0 errors and 0 skipped.
+
+## Interpretation
+
+### Transport and product identity are not the cause
+
+Both shop contexts returned:
+
+- 20/20 HTTP 2xx;
+- 20/20 usable product observations;
+- 20/20 stable product identity across the pair of contexts;
+- zero failed corpus requirements.
+
+Therefore the package result cannot be explained by broad HTTP failure, wrong-product routing or loss of the existing price/SKU surface.
+
+### Current server-side public HTML is not sufficient for package extraction
+
+All 40 package-evidence-eligible observations classified as:
+
+- `FOUND`: **0**
+- `MISSING`: **40**
+- `AMBIGUOUS_DIMENSIONS`: 0
+- `CONFLICTING_VALUES`: 0
+- `INVALID_VALUE`: 0
+
+This is a clean **NO-GO for claiming package quantity from the current server-side PUBLIC_WEB HTML path**. The exact `Вес, кг` / `Объем, л` semantics accepted in #82 remain valid as source semantics, but those labels are not present in the parser-visible HTML returned to the current Java `HttpClient` corpus for these observations.
+
+Do not compensate by parsing quantities from product titles, slugs or descriptions.
+
+## What this does and does not prove
+
+It proves:
+
+- the current raw/public server-side product-page acquisition path is still excellent for the existing SKU/current-price corpus (40/40 usable in this run);
+- it does not expose any #82-supported package characteristic in the 40 eligible observations;
+- package extraction therefore must not be wired into production Magnit basket evidence through this raw HTML path yet.
+
+It does **not** prove that Magnit has no structured package metadata. Official rendered product pages have separately labeled characteristic examples, so the remaining question is where those fields originate relative to the raw server response.
+
+## Root-cause hypotheses to test next
+
+1. **Client-side rendering/hydration:** `Характеристики` or its values are fetched/rendered only after JavaScript executes.
+2. **Embedded bootstrap/JSON data:** structured values exist in the raw response, but as machine data rather than visible `Характеристики` labels.
+3. **Alternate public data request:** the browser obtains characteristics from a separate public request made during page load.
+4. **Corpus-specific absence:** the fixed corpus genuinely lacks those fields while other official product pages expose them.
+
+The next diagnostic must distinguish these hypotheses with safe aggregate markers or sanitized fixtures. It must not dump raw production HTML into the repository, parse product-name quantities, broaden browser permissions, or turn the finite evidence run into recurring polling.
+
+## Production/access constraints unchanged
+
+- #69 location/address → `shopCode` remains unresolved.
+- #70 recurring production acquisition usage rights remain unresolved.
+- production comparison evidence remains fail-closed/no-op.
+- no recurring Magnit job was created.
+- no browser permission or authenticated session was added.
+
+## Decision
+
+**Do not activate Magnit structured package evidence on the current server-side PUBLIC_WEB path.**
+
+Proceed with a focused package-characteristics provenance investigation: raw HTML markers → embedded/bootstrap structured data → browser-rendered DOM/public request boundary. Choose a new acquisition/extraction path only after one of those surfaces is reproducible and its semantics remain exact and fail-closed.


### PR DESCRIPTION
Superseded by stronger provenance evidence gathered after the initial 40-request corpus.

The live corpus result itself remains valid:
- 20 products × 2 explicit shop contexts = 40 requests;
- HTTP 2xx: 40/40;
- usable observations: 40/40;
- stable identity: 20/20;
- package-evidence eligible: 40;
- visible-text characteristic extractor: `FOUND=0`, `MISSING=40`.

However, the earlier conclusion that the raw PUBLIC_WEB response is a package-data NO-GO was too broad. Follow-up finite diagnostics proved that the same raw HTTP response contains SKU-bound JSON-LD `Product` data:
- pasta examples expose `Product.weight` (`0.45`, `0.5`);
- water exposes `additionalProperty["Объем, л"] = 0.5`;
- a multidimensional milk example exposes both `weight=1.028` and `additionalProperty["Объем, л"] = 1`, so fail-closed ambiguous-dimension semantics remain necessary;
- the egg/count example does not expose a proven count field in JSON-LD, so count remains deferred.

Decision: close this draft instead of merging stale wording. The replacement implementation/documentation slice will build a deterministic SKU-bound JSON-LD extractor over the existing PUBLIC_WEB response, replay the fixed corpus, and preserve #69/#70 production gates. No title/slug parsing, browser acquisition, recurring polling, or production activation is introduced.