### PR TITLE
feat(magnit): extract SKU-bound JSON-LD package evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,17 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Snapshot-driven `PackageQuantitySet.fromSnapshots(...)` projection that creates basket bindings only for explicit structured package evidence.
 - Runtime package-evidence derivation from snapshots so comparison fixtures and future provider paths carry one provenance-preserving source of package truth.
 - Regression coverage proving presentation names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.
-- Pure Magnit source-specific `MagnitPackageQuantityExtractor` for exact `Характеристики` fields `Вес, кг` and `Объем, л`, with canonical kg→g and l→ml conversion.
+- Pure Magnit source-specific `MagnitPackageQuantityExtractor` for exact visible `Характеристики` fields `Вес, кг` and `Объем, л`, with canonical kg→g and l→ml conversion.
 - Explicit Magnit package-extraction states `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` so source ambiguity never becomes a guessed basket quantity.
 - Magnit provider/snapshot regression proving a `FOUND` characteristic can populate #81 structured package evidence while multi-dimensional characteristics remain package-unknown.
 - Evidence note documenting official Magnit weight-only, volume-only, multi-dimensional and count-selector examples plus unchanged #69/#70 production gates.
-- Magnit fixed-corpus package-evidence instrumentation that classifies exact-field extraction across the existing 20-product × 2-shop explicit/manual research corpus.
+- Magnit fixed-corpus package-evidence instrumentation that classifies package extraction across the existing 20-product × 2-shop explicit/manual research corpus.
 - Structural `PackageEvidenceSummary` with `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` counters whose sum must equal the eligible package-evidence page count.
 - Aggregate Magnit evidence-line counters for eligible package pages and each package-extraction status without logging HTML, page fragments or arbitrary provider data.
+- SKU-bound Magnit JSON-LD package extractor over the same raw PUBLIC_WEB response: exact JSON-LD `Product.sku`, scalar `Product.weight` as proven kilograms and exact `additionalProperty[name="Объем, л"]` as proven liters, without browser execution or another retailer request.
+- Deterministic JSON-LD regressions for foreign-SKU isolation, duplicate deduplication, conflicts, invalid values, multi-dimensional ambiguity, malformed JSON, script media-type boundaries and rejection of title/name/description/URL/count/generic-size heuristics.
+- Finite same-corpus JSON-LD evidence: 36/40 `FOUND`, 0 `MISSING`, 4 explicit `AMBIGUOUS_DIMENSIONS`, 0 conflicts, 0 invalid values, with 40/40 HTTP 2xx and usable observations and 20/20 stable product identity.
+- Sanitized one-shop diagnostic proving the four two-shop ambiguity observations are exactly milk SKU `1000013732` and kefir SKU `1000330180`; the other fixed requirements produce structured weight/volume evidence.
 
 ### Changed
 
@@ -61,17 +65,20 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Existing provider integrations remain source-compatible and package-unknown unless they explicitly supply a proven structured package quantity.
 - Runtime comparison package bindings now derive from immutable snapshot evidence instead of being independently injected downstream.
 - Deterministic comparison fixtures attach package quantity at the provider observation boundary before snapshotting, mirroring the production evidence flow without live retailer access.
-- Magnit v1 structured package semantics accept only exact weight/volume characteristics; simultaneous dimensions or conflicting/invalid values remain unknown rather than using category/title heuristics.
-- Magnit `Количество в упаковке` remains deferred pending separate source and multi-dimensional domain evidence.
+- Magnit structured package semantics accept only proven source fields; simultaneous dimensions or conflicting/invalid values remain unknown rather than using category/title/density heuristics.
+- Magnit `Количество в упаковке` remains deferred pending separate source and multi-dimensional domain evidence; structured egg mass is not treated as count.
 - Magnit fixed-corpus package metrics classify only HTTP 2xx observations with expected-SKU identity evidence, so transport failures and wrong-product pages cannot dilute metadata quality as false `MISSING` cases.
-- The guarded Magnit live corpus remains exactly 20 fixed products × 2 explicit shop contexts behind `-Dzakup.live.magnit.corpus=true`; no minimum `FOUND` threshold is invented before measurement evidence exists.
+- The guarded Magnit live corpus remains exactly 20 fixed products × 2 explicit shop contexts behind an explicit opt-in; finite research evidence does not authorize recurring production polling.
+- The first visible-text corpus result (`0 FOUND / 40 MISSING`) is now correctly treated as a visible-rendering blind spot: the same raw HTTP responses expose SKU-bound JSON-LD package metadata.
+- Magnit fixed-corpus package projection now consumes the SKU-bound JSON-LD extractor while preserving the existing price/promo/availability request and identity path.
+- Package arithmetic continues to require canonical unit equality, so structured mass/volume evidence cannot satisfy a `PIECE` requirement.
 - `UNKNOWN` availability propagates into `AVAILABILITY_UNKNOWN` line state and an `UNCERTAIN` basket rather than a confirmed complete basket.
 - Incomplete single-store baskets expose no aggregate total, preventing partial-price comparisons from masquerading as complete basket prices.
 - Technical retailer connectivity no longer leaks directly into the product/API contract: public readiness uses stable coverage/access/comparison states and finite product-safe reason codes instead of provider IDs, acquisition modes or source references.
 - The home page now makes the stateless comparison preview the primary M1 action instead of the previous readiness-only surface.
 - The critical browser journey is driven through the generated OpenAPI client and the same product-safe comparison vocabulary as the core/read model.
 - Production comparison evidence remains deliberately no-op/fail-closed; deterministic source extraction and corpus instrumentation do not activate recurring retailer polling.
-- Active M1 focus moves to the first explicit/manual Magnit package-status corpus measurement plus retailer connectivity/lifecycle and production-access constraints after #83 ships.
+- Active Magnit engineering focus moves from package-source discovery to shipping #85, then location → public `shopCode` (#69), while production usage rights (#70) remain separately unresolved.
 
 ### Fixed
 
@@ -95,6 +102,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Runtime evidence rejects an explicit package-quantity set when it differs from the structured quantities preserved by its snapshots, preventing two package-evidence sources from silently diverging.
 - Magnit package extraction ignores title/slug/description/script/style numbers and fails closed on weight+volume or conflicting supported characteristics.
 - Magnit fixed-corpus package reporting excludes non-2xx and wrong-identity observations instead of misclassifying transport/identity failures as missing package metadata.
+- Magnit JSON-LD extraction ignores foreign Product nodes and unproven schema/presentation fields, preserving exact-SKU provenance through package evidence.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitJsonLdPackageQuantityExtractor.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitJsonLdPackageQuantityExtractor.java
@@ -1,0 +1,184 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+public final class MagnitJsonLdPackageQuantityExtractor {
+
+    private static final String JSON_LD_MEDIA_TYPE = "application/ld+json";
+    private static final String PRODUCT_TYPE = "Product";
+    private static final String VOLUME_LABEL = "Объем, л";
+    private static final Pattern SCRIPT = Pattern.compile(
+            "(?is)<script\\b([^>]*)>(.*?)</script\\s*>");
+    private static final Pattern TYPE_ATTRIBUTE = Pattern.compile(
+            "(?is)\\btype\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s>]+))");
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private MagnitJsonLdPackageQuantityExtractor() {}
+
+    public static MagnitPackageQuantityExtraction extract(String html, String expectedSku) {
+        if (expectedSku == null || expectedSku.isBlank()) {
+            throw new IllegalArgumentException("expectedSku must not be blank");
+        }
+
+        var evidence = new Evidence();
+        var matcher = SCRIPT.matcher(html == null ? "" : html);
+        while (matcher.find()) {
+            if (!isJsonLdScript(matcher.group(1))) {
+                continue;
+            }
+            try {
+                collect(JSON.readTree(matcher.group(2)), expectedSku.trim(), evidence);
+            } catch (Exception ignored) {
+                // Malformed JSON-LD is not repaired heuristically and cannot create evidence.
+            }
+        }
+        return evidence.toExtraction();
+    }
+
+    private static boolean isJsonLdScript(String attributes) {
+        var matcher = TYPE_ATTRIBUTE.matcher(attributes == null ? "" : attributes);
+        if (!matcher.find()) {
+            return false;
+        }
+        var type = matcher.group(1) != null
+                ? matcher.group(1)
+                : matcher.group(2) != null ? matcher.group(2) : matcher.group(3);
+        return JSON_LD_MEDIA_TYPE.equalsIgnoreCase(type.trim());
+    }
+
+    private static void collect(JsonNode node, String expectedSku, Evidence evidence) {
+        if (node == null) {
+            return;
+        }
+        if (node.getNodeType().name().equals("OBJECT") && isMatchingProduct(node, expectedSku)) {
+            collectProduct(node, evidence);
+        }
+        if (node.getNodeType().name().equals("OBJECT") || node.getNodeType().name().equals("ARRAY")) {
+            for (var child : node) {
+                collect(child, expectedSku, evidence);
+            }
+        }
+    }
+
+    private static boolean isMatchingProduct(JsonNode node, String expectedSku) {
+        return hasProductType(node.get("@type")) && expectedSku.equals(scalarText(node.get("sku")));
+    }
+
+    private static boolean hasProductType(JsonNode type) {
+        if (type == null) {
+            return false;
+        }
+        if (isString(type)) {
+            return PRODUCT_TYPE.equals(type.asString());
+        }
+        if (type.getNodeType().name().equals("ARRAY")) {
+            for (var candidate : type) {
+                if (isString(candidate) && PRODUCT_TYPE.equals(candidate.asString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void collectProduct(JsonNode product, Evidence evidence) {
+        var weight = product.get("weight");
+        if (weight != null && isScalarNumberOrString(weight)) {
+            evidence.addWeight(weight.asString());
+        }
+
+        var additionalProperty = product.get("additionalProperty");
+        if (additionalProperty == null) {
+            return;
+        }
+        if (additionalProperty.getNodeType().name().equals("ARRAY")) {
+            for (var property : additionalProperty) {
+                collectAdditionalProperty(property, evidence);
+            }
+        } else {
+            collectAdditionalProperty(additionalProperty, evidence);
+        }
+    }
+
+    private static void collectAdditionalProperty(JsonNode property, Evidence evidence) {
+        if (property == null || !property.getNodeType().name().equals("OBJECT")) {
+            return;
+        }
+        if (!VOLUME_LABEL.equals(scalarText(property.get("name")))) {
+            return;
+        }
+
+        var value = property.get("value");
+        if (value == null || !isScalarNumberOrString(value)) {
+            evidence.invalid = true;
+            return;
+        }
+        evidence.addVolume(value.asString());
+    }
+
+    private static String scalarText(JsonNode node) {
+        return node != null && isScalarNumberOrString(node) ? node.asString().trim() : null;
+    }
+
+    private static boolean isScalarNumberOrString(JsonNode node) {
+        var type = node.getNodeType().name();
+        return type.equals("STRING") || type.equals("NUMBER");
+    }
+
+    private static boolean isString(JsonNode node) {
+        return node.getNodeType().name().equals("STRING");
+    }
+
+    private static final class Evidence {
+        private final Set<Quantity> weights = new LinkedHashSet<>();
+        private final Set<Quantity> volumes = new LinkedHashSet<>();
+        private boolean invalid;
+
+        private void addWeight(String raw) {
+            add(raw, QuantityUnit.KILOGRAM, weights);
+        }
+
+        private void addVolume(String raw) {
+            add(raw, QuantityUnit.LITER, volumes);
+        }
+
+        private void add(String raw, QuantityUnit unit, Set<Quantity> target) {
+            try {
+                var amount = new BigDecimal(raw.trim().replace(',', '.'));
+                if (amount.signum() <= 0) {
+                    invalid = true;
+                    return;
+                }
+                target.add(new Quantity(amount, unit));
+            } catch (IllegalArgumentException exception) {
+                invalid = true;
+            }
+        }
+
+        private MagnitPackageQuantityExtraction toExtraction() {
+            if (invalid) {
+                return MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.INVALID_VALUE);
+            }
+            if (weights.size() > 1 || volumes.size() > 1) {
+                return MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.CONFLICTING_VALUES);
+            }
+            if (!weights.isEmpty() && !volumes.isEmpty()) {
+                return MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.AMBIGUOUS_DIMENSIONS);
+            }
+            if (weights.size() == 1) {
+                return MagnitPackageQuantityExtraction.found(weights.iterator().next());
+            }
+            if (volumes.size() == 1) {
+                return MagnitPackageQuantityExtraction.found(volumes.iterator().next());
+            }
+            return MagnitPackageQuantityExtraction.empty(MagnitPackageQuantityStatus.MISSING);
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusPackageEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusPackageEvidenceTest.java
@@ -12,15 +12,22 @@ import org.junit.jupiter.api.Test;
 class MagnitCorpusPackageEvidenceTest {
 
     @Test
-    void identityValidPageCarriesAcceptedPackageExtraction() {
+    void identityValidPageCarriesSkuBoundJsonLdPackageExtraction() {
         var observation = MagnitCorpusProbe.parseProductPage("""
-                <html><body>
-                  <h1>Макароны Makfa 450г 79,99 ₽ Артикул 3042670099</h1>
-                  <h2>Характеристики</h2>
-                  <div>Вес, кг 0.45</div>
-                  <div>Артикул 3042670099</div>
-                  <h2>Условия хранения</h2>
-                </body></html>
+                <html>
+                  <head>
+                    <script type="application/ld+json">
+                      {"@type":"Product","sku":"3042670099","weight":"0.45"}
+                    </script>
+                  </head>
+                  <body>
+                    <h1>Макароны Makfa 450г 79,99 ₽ Артикул 3042670099</h1>
+                    <h2>Характеристики</h2>
+                    <div>Бренд Makfa</div>
+                    <div>Артикул 3042670099</div>
+                    <h2>Условия хранения</h2>
+                  </body>
+                </html>
                 """, "3042670099");
 
         assertThat(observation.skuEvidence()).isTrue();
@@ -32,10 +39,16 @@ class MagnitCorpusPackageEvidenceTest {
     @Test
     void missingExpectedSkuCarriesNoAttributablePackageEvidence() {
         var observation = MagnitCorpusProbe.parseProductPage("""
-                <html><body>
-                  <h1>Другой товар 79,99 ₽ Артикул 1111111111</h1>
-                  <h2>Характеристики</h2><div>Вес, кг 0.45</div>
-                </body></html>
+                <html>
+                  <head>
+                    <script type="application/ld+json">
+                      {"@type":"Product","sku":"3042670099","weight":"0.45"}
+                    </script>
+                  </head>
+                  <body>
+                    <h1>Другой товар 79,99 ₽ Артикул 1111111111</h1>
+                  </body>
+                </html>
                 """, "3042670099");
 
         assertThat(observation.skuEvidence()).isFalse();

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitCorpusProbe.java
@@ -253,7 +253,7 @@ final class MagnitCorpusProbe {
                 regularPrice,
                 promo,
                 availability,
-                MagnitPackageQuantityExtractor.extract(html));
+                MagnitJsonLdPackageQuantityExtractor.extract(html, expectedSku));
     }
 
     static RawShapeEvidence inspectNearSkuRawShape(String html, String expectedSku) {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitJsonLdPackageQuantityExtractorTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitJsonLdPackageQuantityExtractorTest.java
@@ -1,0 +1,223 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class MagnitJsonLdPackageQuantityExtractorTest {
+
+    @Test
+    void extractsCanonicalWeightFromExactSkuProduct() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {
+                  "@context": "https://schema.org/",
+                  "@type": "Product",
+                  "sku": "3042670099",
+                  "name": "Макароны Makfa Виток 450г",
+                  "weight": "0.45"
+                }
+                """)), "3042670099");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(result.packageQuantity())
+                .contains(new Quantity(new BigDecimal("450"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void extractsCanonicalVolumeFromExactAdditionalProperty() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {
+                  "@context": "https://schema.org/",
+                  "@type": "Product",
+                  "sku": "1000273122",
+                  "additionalProperty": [
+                    {"@type": "PropertyValue", "name": "Объем, л", "value": "0.5"},
+                    {"@type": "PropertyValue", "name": "Срок годности, дней", "value": "730"}
+                  ]
+                }
+                """)), "1000273122");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(result.packageQuantity())
+                .contains(new Quantity(new BigDecimal("500"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void failsClosedWhenMatchingProductPublishesWeightAndVolume() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {
+                  "@type": "Product",
+                  "sku": "1000548435",
+                  "weight": "1.028",
+                  "additionalProperty": [
+                    {"name": "Объем, л", "value": "1"}
+                  ]
+                }
+                """)), "1000548435");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.AMBIGUOUS_DIMENSIONS);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void ignoresForeignSkuAndNonProductNodes() {
+        var html = page(
+                product("""
+                        {"@type":"Product","sku":"foreign","weight":"9"}
+                        """),
+                product("""
+                        {"@type":"Offer","sku":"wanted","weight":"8"}
+                        """));
+
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "wanted");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.MISSING);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void acceptsProductWhenTypeArrayContainsProduct() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {"@type":["Thing","Product"],"sku":"42","weight":0.8}
+                """)), "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(result.packageQuantity())
+                .contains(new Quantity(new BigDecimal("800"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void deduplicatesEquivalentEvidenceAcrossMatchingProductNodes() {
+        var html = page(
+                product("""
+                        {"@type":"Product","sku":"42","weight":"0.45"}
+                        """),
+                product("""
+                        {"@type":"Product","sku":"42","weight":0.450}
+                        """));
+
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(result.packageQuantity())
+                .contains(new Quantity(new BigDecimal("450"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void failsClosedForConflictingEvidenceAcrossMatchingProductNodes() {
+        var html = page(
+                product("""
+                        {"@type":"Product","sku":"42","weight":"0.45"}
+                        """),
+                product("""
+                        {"@type":"Product","sku":"42","weight":"0.50"}
+                        """));
+
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.CONFLICTING_VALUES);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void failsClosedForInvalidRecognizedScalarValues() {
+        for (var value : new String[] {"0", "-1", "unknown"}) {
+            var html = page(product("""
+                    {"@type":"Product","sku":"42","weight":"%s"}
+                    """.formatted(value)));
+
+            var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "42");
+
+            assertThat(result.status()).as(value).isEqualTo(MagnitPackageQuantityStatus.INVALID_VALUE);
+            assertThat(result.packageQuantity()).as(value).isEmpty();
+        }
+    }
+
+    @Test
+    void failsClosedForRecognizedVolumeWithoutScalarValue() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {
+                  "@type":"Product",
+                  "sku":"42",
+                  "additionalProperty":[{"name":"Объем, л","value":{"value":1,"unitText":"л"}}]
+                }
+                """)), "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.INVALID_VALUE);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void doesNotGuessObjectValuedWeightOrUnprovenFields() {
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(page(product("""
+                {
+                  "@type":"Product",
+                  "sku":"42",
+                  "name":"Молоко 1л",
+                  "description":"упаковка 1000 мл",
+                  "url":"https://magnit.ru/product/42-moloko-1l",
+                  "weight":{"@type":"QuantitativeValue","value":1,"unitText":"kg"},
+                  "volume":"1",
+                  "size":"1л",
+                  "additionalProperty":[{"name":"Количество в упаковке","value":10}]
+                }
+                """)), "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.MISSING);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void malformedJsonLdAndOrdinaryScriptsCannotCreateEvidence() {
+        var html = """
+                <html><body>
+                  <script type="application/ld+json">{"@type":"Product","sku":"42","weight":</script>
+                  <script type="application/json">{"@type":"Product","sku":"42","weight":"0.45"}</script>
+                  <script>window.product={"@type":"Product","sku":"42","weight":"0.45"}</script>
+                </body></html>
+                """;
+
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.MISSING);
+        assertThat(result.packageQuantity()).isEmpty();
+    }
+
+    @Test
+    void toleratesJsonLdTypeAttributeOrderQuotingAndCase() {
+        var html = """
+                <html><head>
+                  <script nonce='abc' TYPE='Application/LD+JSON' data-x="1">
+                    {"@type":"Product","sku":"42","weight":"0.2"}
+                  </script>
+                </head></html>
+                """;
+
+        var result = MagnitJsonLdPackageQuantityExtractor.extract(html, "42");
+
+        assertThat(result.status()).isEqualTo(MagnitPackageQuantityStatus.FOUND);
+        assertThat(result.packageQuantity())
+                .contains(new Quantity(new BigDecimal("200"), QuantityUnit.GRAM));
+    }
+
+    @Test
+    void validatesExpectedSkuBoundary() {
+        for (var sku : new String[] {"", "   "}) {
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                            () -> MagnitJsonLdPackageQuantityExtractor.extract("", sku))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("expectedSku must not be blank");
+        }
+    }
+
+    private static String product(String json) {
+        return "<script type=\"application/ld+json\">" + json + "</script>";
+    }
+
+    private static String page(String... scripts) {
+        return "<html><head>" + String.join("", scripts) + "</head><body><h1>fixture</h1></body></html>";
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -11,7 +11,7 @@ Visibility: Public
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **ship #83 Magnit fixed-corpus package-evidence instrumentation; then obtain an explicit/manual distribution without bypassing #69/#70**
+Current focus: **ship #85 SKU-bound Magnit JSON-LD package evidence; then continue #69 location → `shopCode` without bypassing #70 production-access gating**
 
 ## Product connectivity invariant
 
@@ -66,49 +66,73 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**  
     Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`. `ObservedOffer` can carry optional canonical package quantity, snapshots preserve it, basket/runtime bindings derive from snapshots, and presentation text is explicitly non-authoritative. Full PR gate and post-merge `main` gate passed.
 
-11. **Magnit structured package characteristics — COMPLETE / ACCEPTED (#82)**  
+11. **Magnit structured visible-characteristic semantics — COMPLETE / ACCEPTED (#82)**  
     Merged as `3753a9296562354939e86876a8096c15b2957e35`.
     - pure `MagnitPackageQuantityExtractor`, no HTTP/Spring activation;
-    - exact `Характеристики` fields `Вес, кг` and `Объем, л` only;
+    - exact visible `Характеристики` fields `Вес, кг` and `Объем, л` only;
     - canonical kg→g and l→ml conversion;
     - duplicate equivalent values deduplicated;
     - weight + volume → `AMBIGUOUS_DIMENSIONS`;
     - conflicting same-dimension values → `CONFLICTING_VALUES`;
     - malformed/zero/negative values → `INVALID_VALUE`;
     - title/slug/description/script/style/out-of-section numbers cannot create package evidence;
-    - `Количество в упаковке` deferred from v1;
-    - `FOUND` output is proven compatible with #81 provider/snapshot evidence while ambiguous output remains unknown.
+    - `Количество в упаковке` deferred from v1.
 
-    Exact reviewed candidate and docs-only shipping marker passed the complete PR workflow gate; read-only review reported no P0/P1/P2 findings. After squash merge, all eight push-triggered `main` workflows completed successfully with zero failures.
+    This slice remains useful as the accepted semantic rule set, but later live evidence showed that the fixed Magnit server-side product corpus does not render those fields reliably as visible text.
 
-    Design: [`superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md`](superpowers/specs/2026-08-12-magnit-structured-package-characteristics-design.md)  
-    Evidence: [`integrations/magnit-structured-package-characteristics-2026-08-12.md`](integrations/magnit-structured-package-characteristics-2026-08-12.md)  
-    Shipping: [`superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md`](superpowers/plans/2026-08-12-magnit-structured-package-characteristics-shipping.md)
-
-12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**  
-    #83 instruments the pre-existing explicit/manual 20-product × 2-shop Magnit research corpus without changing transport behavior:
-    - identity-valid pages carry the accepted #82 extraction alongside existing price/promo/availability evidence;
+12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**  
+    Merged as `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6` and passed the full post-merge `main` gate.
+    - reuses the explicit/manual 20-product × 2-shop Magnit research corpus;
     - package statistics include only HTTP 2xx responses with expected-SKU identity evidence;
-    - non-2xx/error pages and wrong-identity pages are excluded rather than being mislabeled `MISSING`;
-    - a structural `PackageEvidenceSummary` reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
+    - non-2xx/error pages and wrong-identity pages are excluded rather than mislabeled `MISSING`;
+    - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
     - status counts must sum exactly to `packageEvidencePages`;
-    - the aggregate evidence line adds only counters, never HTML/page fragments or sensitive product/provider data;
-    - the guarded live test keeps the same `-Dzakup.live.magnit.corpus=true` opt-in and the same 40-request fixed corpus;
-    - no minimum `FOUND` threshold is invented before the first measurement exists;
-    - ordinary CI remains live-retailer-free.
+    - aggregate evidence contains counters rather than committed HTML/provider-page dumps;
+    - guarded live execution remains explicit/manual and ordinary CI remains live-retailer-free.
 
-    Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md)  
-    Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md)
+    First accepted visible-text measurement: 40/40 eligible pages, `FOUND=0`, `MISSING=40`, no ambiguity/conflict/invalid status. This was subsequently reinterpreted correctly as a **visible-text extraction blind spot**, not absence of structured package metadata in the raw response.
+
+13. **Magnit SKU-bound JSON-LD package evidence — IMPLEMENTED / LIVE EVIDENCE PROVEN / SHIPPING (#85)**  
+    Current feature slice parses the **same raw PUBLIC_WEB response** without another retailer request or browser execution.
+    - only `<script type="application/ld+json">` bodies are parsed;
+    - only JSON-LD `Product` nodes with exact expected `sku` participate;
+    - scalar `Product.weight` is accepted as kilograms based on proven Magnit examples;
+    - exact `additionalProperty.name="Объем, л"` scalar values are accepted as liters;
+    - generic `volume`, `size`, title/name/description/URL/category and count-looking presentation data are ignored;
+    - malformed JSON-LD is not repaired heuristically;
+    - duplicate equivalent structured values deduplicate;
+    - recognized invalid values → `INVALID_VALUE`;
+    - conflicting same-dimension values → `CONFLICTING_VALUES`;
+    - simultaneous weight + volume → `AMBIGUOUS_DIMENSIONS`;
+    - output remains canonical `Quantity` evidence compatible with #81 snapshots/basket path.
+
+    Same fixed-corpus replay, still exactly 40 requests across shop contexts `139147` and `773577`:
+    - HTTP 2xx: 20/20 + 20/20;
+    - usable: 20/20 + 20/20;
+    - stable identity: 20/20;
+    - package pages: 40;
+    - `FOUND=36`;
+    - `MISSING=0`;
+    - `AMBIGUOUS_DIMENSIONS=4`;
+    - `CONFLICTING_VALUES=0`;
+    - `INVALID_VALUE=0`;
+    - failed requirements: 0.
+
+    A separate finite one-shop diagnostic identified the four cross-shop ambiguity observations as exactly two products in both contexts: milk SKU `1000013732` and kefir SKU `1000330180`. All other fixed requirements returned `FOUND`. Eggs yield structured mass evidence (`700 g`), **not count evidence**; basket arithmetic requires canonical unit compatibility and therefore cannot use that mass for a `PIECE` requirement.
+
+    Design: [`superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`](superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md)  
+    Plan: [`superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md`](superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md)  
+    Evidence: [`integrations/magnit-jsonld-package-evidence-2026-08-12.md`](integrations/magnit-jsonld-package-evidence-2026-08-12.md)
 
 ## Important M1 limitations
 
 - Production comparison evidence remains deliberately **no-op/fail-closed**. The critical journey proves product/API/core integration, not live production retailer acquisition.
 - Perekrestok and Pyaterochka accepted browser paths still do not prove a dedicated structured package field. Do not parse product names or widen browser permissions merely to obtain package size.
-- Magnit has a technically proven exact-field extractor and a fixed-corpus measurement harness, but this is **not production activation**.
-- The first package-status distribution has not yet been accepted as evidence until the guarded live corpus is explicitly run.
+- Magnit JSON-LD package evidence is strong on the measured fixed corpus but is **not universal-catalog proof** and is not production activation.
+- Magnit multi-dimensional milk/kefir observations remain explicitly unknown under the current single-`Quantity` package model; no density/category heuristic is permitted.
+- `Количество в упаковке` remains unproven in the accepted JSON-LD path and is deferred. Structured mass for eggs is not equivalent to count.
 - Magnit location/address → public `shopCode` resolution remains unresolved (#69).
 - Magnit recurring production acquisition usage rights remain unresolved (#70); recurring polling remains disabled until authoritative acceptance.
-- `Количество в упаковке` support is deferred pending separate source/domain evidence.
 - Browser-bridge persistent-session/store-change lifecycle hardening remains open (#54).
 - Kuper supported aggregator access remains open (#36).
 - Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer paths still require onboarding/hardening.
@@ -116,16 +140,16 @@ M0 completion is **technical feasibility**, not blanket production-data-access a
 
 ## Magnit status
 
-Technical path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**. Existing Phase B proved stable usable observations in explicit `shopCode` contexts; availability remains `UNKNOWN` where stock semantics are not proven.
+Technical path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**.
 
-Structured package evidence:
-- `Вес, кг` — supported when unambiguous;
-- `Объем, л` — supported when unambiguous;
-- simultaneous weight + volume — fail closed / unknown;
-- `Количество в упаковке` — deferred;
-- corpus instrumentation — implemented in #83, live distribution pending explicit run.
+Package evidence now has two distinct evidence layers:
 
-Constraints:
+1. accepted visible-characteristic semantics (#82), useful for deterministic source rules;
+2. SKU-bound JSON-LD extraction (#85), which matches the actual measured server-side public response far better.
+
+Measured #85 fixed-corpus distribution: **36/40 FOUND, 0/40 MISSING, 4/40 explicit multi-dimensional ambiguity** with no conflict/invalid cases.
+
+Constraints remain:
 - **#69** — automatic location/address → public `shopCode` resolution not proven;
 - **#70** — recurring production catalog acquisition usage rights `UNRESOLVED`.
 
@@ -143,20 +167,21 @@ Constraints:
 10. Package evidence attached to runtime basket calculation derives from immutable snapshot evidence.
 11. Source-specific extraction fails closed on conflicting or multi-dimensional fields unless a separate domain rule is explicitly proven.
 12. Corpus package metrics classify only transport-successful, identity-valid product pages.
-13. Incomplete baskets never expose a misleading complete-basket total.
-14. Production activation respects usage-rights state.
-15. Ordinary CI and browser acceptance make no live retailer requests.
-16. Production preview evidence fails closed rather than falling back to deterministic fixtures.
-17. Unknown public JSON request fields fail closed rather than being ignored.
-18. Universal retailer connectivity remains mandatory for every registry entry.
+13. Structured package evidence must remain unit-compatible with the shopping requirement; mass, volume and count are not interchangeable.
+14. Incomplete baskets never expose a misleading complete-basket total.
+15. Production activation respects usage-rights state.
+16. Ordinary CI and browser acceptance make no live retailer requests.
+17. Production preview evidence fails closed rather than falling back to deterministic fixtures.
+18. Unknown public JSON request fields fail closed rather than being ignored.
+19. Universal retailer connectivity remains mandatory for every registry entry.
 
 ## Immediate next work
 
-1. **Finish shipping #83** with exact-head CI/security and independent review.
-2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence, not recurring production polling.
-3. Use the measured distribution to decide whether weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions need a domain extension.
-4. Continue **#69** Magnit location → `shopCode`, **#70** usage-rights resolution and **#54** browser-bridge lifecycle hardening.
-5. Continue **#36** Kuper supported-access investigation and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
+1. **Finish shipping #85** with exact-head CI/security and independent review; do not call it ACCEPTED until squash merge and post-merge `main` verification succeed.
+2. After #85 acceptance, prioritize **#69 Magnit location → public `shopCode`** as the highest-leverage implementable Magnit product blocker.
+3. Keep **#70 production usage-rights** as an independent mandatory decision; technical success must not silently authorize recurring acquisition.
+4. Keep multi-dimensional package-domain extension and `Количество в упаковке` evidence as separate work only when source/product evidence justifies it.
+5. Continue **#54** browser-bridge lifecycle hardening, **#36** Kuper supported-access investigation and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
 6. Prove a successful real `v0.1.0-rc.3` release event.
 7. Move to **M2 Recipes** only after remaining M1 evidence/production constraints are explicitly accepted rather than hidden.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,7 @@ Goal: compare a manually entered grocery list across connected retailers while p
 - observation time is not provider-update time;
 - package quantity is explicit structured evidence, never inferred from product names, slugs, category or presentation text;
 - source-specific extraction fails closed on ambiguity/conflict;
+- mass, volume and count are not interchangeable;
 - corpus quality metrics classify only transport-successful, identity-valid pages;
 - production activation respects usage-rights state;
 - ordinary M1 tests make no live retailer requests.
@@ -56,34 +57,46 @@ Goal: compare a manually entered grocery list across connected retailers while p
    - snapshot-derived `PackageQuantitySet`;
    - runtime rejects a parallel package set that disagrees with snapshots;
    - title/presentation parsing explicitly prohibited and regression-tested.
-11. **Magnit exact characteristic package extraction — COMPLETE / ACCEPTED (#82)**
-   - pure exact-field extractor for `Вес, кг` / `Объем, л` inside `Характеристики`;
+11. **Magnit visible exact-characteristic semantics — COMPLETE / ACCEPTED (#82)**
+   - pure exact-field semantics for `Вес, кг` / `Объем, л` inside visible `Характеристики`;
    - canonical kg→g / l→ml;
    - fail-closed ambiguity/conflict/invalid states;
    - title/slug/description/script/style/out-of-section data cannot create evidence;
    - count semantics deferred;
-   - no HTTP/Spring activation;
-   - merged as `3753a9296562354939e86876a8096c15b2957e35`, then all eight push-triggered `main` workflows passed with zero failures.
-12. **Magnit fixed-corpus package-evidence instrumentation — IMPLEMENTED / SHIPPING (#83)**
+   - no HTTP/Spring activation.
+12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**
    - existing explicit/manual 20-product × 2-shop corpus remains unchanged in request count and transport policy;
-   - identity-valid pages carry #82 package extraction alongside existing price/promo/availability evidence;
    - package status metrics include only HTTP 2xx + expected-SKU observations;
    - transport/error and wrong-identity pages are excluded rather than counted as `MISSING`;
    - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
-   - status counts must equal `packageEvidencePages` exactly;
-   - evidence line exposes only aggregate counters;
-   - existing guarded live property remains `-Dzakup.live.magnit.corpus=true`;
-   - no pre-evidence minimum `FOUND` threshold is invented;
-   - ordinary CI remains live-retailer-free.
+   - status counts equal `packageEvidencePages` exactly;
+   - ordinary CI remains live-retailer-free;
+   - first visible-text live measurement: `FOUND=0`, `MISSING=40`, with 40 eligible pages and no ambiguity/conflict/invalid values.
+13. **Magnit SKU-bound JSON-LD package evidence — IMPLEMENTED / LIVE EVIDENCE PROVEN / SHIPPING (#85)**
+   - same raw PUBLIC_WEB response, no extra retailer request and no browser execution;
+   - exact JSON-LD `Product` + exact expected `sku` identity;
+   - scalar `Product.weight` accepted as kilograms only because Magnit provenance was explicitly proven;
+   - exact `additionalProperty.name="Объем, л"` scalar value accepted as liters;
+   - generic fields and presentation text remain non-authoritative;
+   - duplicate equivalent values deduplicate;
+   - invalid/conflicting/multi-dimensional source evidence remains fail-closed;
+   - count remains deferred;
+   - corpus projection uses the JSON-LD extractor without changing price/promo/availability transport logic;
+   - deterministic extractor/corpus tests and full API verification are green;
+   - same finite 40-request replay produced `FOUND=36`, `MISSING=0`, `AMBIGUOUS_DIMENSIONS=4`, `CONFLICTING_VALUES=0`, `INVALID_VALUE=0`, failed requirements `0`;
+   - the four ambiguity observations are exactly milk SKU `1000013732` and kefir SKU `1000330180` in both shop contexts;
+   - all other fixed requirements are `FOUND` in the one-shop diagnostic;
+   - egg evidence is structured mass, not package count, and canonical unit mismatch prevents mass from satisfying `PIECE` requirements.
 
-   Design: [`superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md`](superpowers/specs/2026-08-12-magnit-package-evidence-corpus-design.md).  
-   Plan: [`superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md`](superpowers/plans/2026-08-12-magnit-package-evidence-corpus.md).
+   Design: [`superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`](superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md).  
+   Plan: [`superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md`](superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md).  
+   Evidence: [`integrations/magnit-jsonld-package-evidence-2026-08-12.md`](integrations/magnit-jsonld-package-evidence-2026-08-12.md).
 
 ### Important remaining basket-data limitation
 
-Magnit now has accepted weight/volume semantics and an instrumented fixed-corpus measurement path, but the first live package-status distribution is still pending. Products with both weight and volume remain unknown under the current single-`Quantity` model; count is deferred; other retailers still lack an accepted structured field.
+Magnit now has strong structured weight/volume coverage on the measured fixed corpus, but this is not universal-catalog proof. Products with both weight and volume remain unknown under the current single-`Quantity` model; count is deferred; other retailers still lack an accepted structured package field.
 
-Never replace this with product-name parsing.
+Never replace this with product-name parsing or density/category guesses.
 
 ### M1 exit criteria
 
@@ -96,16 +109,17 @@ Never replace this with product-name parsing.
 - provenance/context/freshness survive internally without leaking implementation IDs;
 - package evidence remains structured source evidence through provider → snapshot → basket;
 - source-specific ambiguity/conflict never becomes a guessed quantity;
+- package dimensions remain unit-compatible and count is never inferred from mass/volume;
 - evidence-quality measurements separate transport/identity failure from missing metadata;
 - incomplete baskets cannot masquerade as complete winners;
 - production activation remains separately gated by access, location/context and source semantics.
 
 ### Next M1 engineering focus
 
-1. **Ship #83** after exact-head CI/security and independent review.
-2. Run the existing guarded **explicit/manual Magnit fixed corpus** once and record the first accepted package-status distribution. This remains research evidence and does not enable recurring polling.
-3. Use the measured distribution to decide whether exact weight/volume support is sufficient and whether `Количество в упаковке` / multiple package dimensions require a domain extension.
-4. **Magnit location → `shopCode` (#69)** and **production usage-rights decision (#70)** remain mandatory before production activation.
+1. **Ship #85** after exact-head CI/security and independent review; require post-merge `main` verification before calling it ACCEPTED.
+2. Then prioritize **Magnit location → `shopCode` (#69)** as the highest-leverage implementable blocker for converting explicit-store feasibility into location-aware product use.
+3. Keep **production usage-rights decision (#70)** independent and mandatory before recurring acquisition; technical feasibility is not authorization.
+4. Keep multi-dimensional package-domain extension and `Количество в упаковке` as separate evidence-driven work, not blockers for shipping current mass/volume support.
 5. **Browser bridge lifecycle hardening (#54)** for persistent sessions/store changes/SPA navigation.
 6. **Kuper supported aggregator investigation (#36)**.
 7. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer onboarding.

--- a/docs/integrations/magnit-jsonld-package-evidence-2026-08-12.md
+++ b/docs/integrations/magnit-jsonld-package-evidence-2026-08-12.md
@@ -1,0 +1,140 @@
+# Magnit SKU-bound JSON-LD package evidence — 2026-08-12
+
+Status: implementation/live-evidence record for M1 research; **not production activation**.
+
+## Why this investigation was necessary
+
+The accepted #82 visible-characteristic extractor deliberately read only visible `Характеристики` text and ignored scripts. The #83 finite corpus instrumentation then ran 20 fixed products across two explicit Magnit `shopCode` contexts (40 total requests).
+
+That first live measurement was transport-healthy and identity-stable, but visible-text package extraction produced:
+
+- eligible package pages: 40;
+- `FOUND`: 0;
+- `MISSING`: 40;
+- `AMBIGUOUS_DIMENSIONS`: 0;
+- `CONFLICTING_VALUES`: 0;
+- `INVALID_VALUE`: 0.
+
+The correct conclusion was therefore **visible-text blind spot**, not absence of structured data in the raw response.
+
+## Provenance finding
+
+Finite follow-up diagnostics inspected only the already-fetched public product-page response and proved that Magnit emits SKU-bound JSON-LD `Product` objects in `<script type="application/ld+json">`.
+
+Observed source semantics:
+
+| Evidence | Proven example | Accepted v1 meaning |
+|---|---|---|
+| `Product.sku` | `3042670099`, `1000166929`, etc. | exact product identity boundary |
+| scalar `Product.weight` | `0.45`, `0.5` | kilograms |
+| exact `additionalProperty.name = "Объем, л"` with scalar `value` | water SKU `1000273122`, value `0.5` | liters |
+| both weight and exact volume | milk SKU `1000548435` | two dimensions exist; do **not** choose one |
+
+The investigated count example did not expose a separately proven count field in JSON-LD. `Количество в упаковке` therefore remains outside v1.
+
+The extractor does not use product title, slug, name, description, URL, category, generic `size`, generic `volume`, density assumptions, or malformed-JSON recovery.
+
+## Implemented extraction contract
+
+`MagnitJsonLdPackageQuantityExtractor`:
+
+1. reads only `script[type="application/ld+json"]` from the same raw HTTP response;
+2. parses each script as JSON with Jackson tree model rather than executing JavaScript;
+3. recursively considers only nodes whose `@type` is `Product` (or an array containing `Product`);
+4. requires scalar `sku` to equal the caller's expected SKU exactly after surrounding-whitespace trimming;
+5. accepts only scalar string/number `weight` as kilograms;
+6. accepts only exact `additionalProperty.name="Объем, л"` with scalar string/number `value` as liters;
+7. canonicalizes through the shared `Quantity` model (`kg→g`, `l→ml`);
+8. deduplicates equivalent structured values;
+9. returns `INVALID_VALUE`, `CONFLICTING_VALUES`, `AMBIGUOUS_DIMENSIONS`, `FOUND`, or `MISSING` fail-closed;
+10. ignores malformed JSON-LD instead of attempting regex recovery.
+
+No extra retailer request and no browser execution is introduced. The corpus parser simply projects package evidence from the raw response it already owns.
+
+## Same-corpus live replay
+
+After deterministic RED→GREEN tests and full API verification, the exact same finite research corpus was replayed:
+
+- 20 fixed product requirements;
+- explicit shop contexts `139147` and `773577`;
+- exactly 40 HTTP requests;
+- no schedule;
+- no recurring polling;
+- no production provider activation.
+
+Package result:
+
+| Metric | Visible-text baseline | SKU-bound JSON-LD |
+|---|---:|---:|
+| eligible pages | 40 | 40 |
+| `FOUND` | 0 | **36** |
+| `MISSING` | 40 | **0** |
+| `AMBIGUOUS_DIMENSIONS` | 0 | **4** |
+| `CONFLICTING_VALUES` | 0 | **0** |
+| `INVALID_VALUE` | 0 | **0** |
+
+Transport/identity remained healthy in the JSON-LD replay:
+
+- first-shop HTTP 2xx: 20/20;
+- second-shop HTTP 2xx: 20/20;
+- first-shop usable: 20/20;
+- second-shop usable: 20/20;
+- stable identity: 20/20;
+- failed requirements: 0.
+
+This is a practical coverage increase from 0/40 attributable package quantities to 36/40, while the remaining four observations remain explicit uncertainty rather than guessed data.
+
+## Ambiguity diagnostic
+
+A separate one-shop finite diagnostic over the same 20 requirements identified the ambiguous products without storing HTML:
+
+- `milk`, SKU `1000013732` → `AMBIGUOUS_DIMENSIONS`;
+- `kefir`, SKU `1000330180` → `AMBIGUOUS_DIMENSIONS`;
+- every other requirement → `FOUND`.
+
+Because each of those two products is ambiguous in both shop contexts, they account exactly for `4/40` ambiguous observations. No same-dimension conflict or invalid structured value appeared.
+
+Selected structured results from that diagnostic include:
+
+- eggs `2047000014` → `700 g` mass evidence (not count evidence);
+- bread `1000134831` → `450 g`;
+- bananas `9072651501` → `1000 g`;
+- potatoes `9072651210` → `2000 g`;
+- pasta `1000166929` → `500 g`;
+- sunflower oil `1000029331` → `900 ml`;
+- butter `1855599922` → `180 g`;
+- sugar `3133780401` → `1000 g`;
+- tea `1000534756` → `200 g`.
+
+Mass evidence for eggs does not imply package count. The basket calculator requires canonical unit compatibility, so `700 g` cannot satisfy a `PIECE` requirement.
+
+## Interpretation
+
+### Accepted
+
+- The existing Magnit PUBLIC_WEB response is sufficient for high-coverage package weight/volume evidence on the measured fixed corpus.
+- Browser acquisition is unnecessary for this package-evidence slice.
+- Exact SKU binding prevents unrelated JSON-LD Product nodes from becoming package evidence.
+- Fail-closed multi-dimensional handling is exercised by real data, not only fixtures.
+- Existing single-`Quantity` basket semantics can consume the 36 `FOUND` observations when required and package units are compatible.
+
+### Not accepted / still unresolved
+
+- This is not evidence for universal Magnit catalog coverage outside the measured corpus.
+- `Количество в упаковке` remains unproven and unsupported.
+- Multi-dimensional products remain package-unknown under the current single-quantity model; no density/category heuristic is allowed.
+- Automatic user location/address → public `shopCode` remains unresolved (#69).
+- Recurring production acquisition usage rights remain unresolved (#70).
+- The result does not enable scheduled polling or production retailer traffic.
+
+## Security/privacy/operational boundary
+
+The live work was finite and explicit. Durable evidence stores only aggregate status counts and sanitized requirement/SKU/status diagnostics; product-page HTML was not committed. Ordinary CI remains retailer-network-free.
+
+Temporary one-shot evidence workflows/tests were isolated on an evidence branch and are not part of the product PR or `main`.
+
+## Decision
+
+**GO for shipping the SKU-bound JSON-LD extraction slice (#85), subject to exact-head CI/security and independent review.**
+
+After #85 is accepted, the highest-leverage Magnit engineering blocker becomes #69 location → public `shopCode`. #70 remains a separate mandatory production-access decision and must not be inferred from technical feasibility.

--- a/docs/superpowers/plans/2026-08-12-magnit-jsonld-package-evidence-shipping.md
+++ b/docs/superpowers/plans/2026-08-12-magnit-jsonld-package-evidence-shipping.md
@@ -1,0 +1,105 @@
+# Magnit SKU-bound JSON-LD Package Evidence Shipping Evidence
+
+Updated: 2026-08-12
+PR: #85
+Reviewed code/docs candidate: `6c817ff6e562846f28a00d3a29873261e5054919`
+Status: ready for final docs-only branch-protection gate
+
+## Scope reviewed
+
+- new pure `MagnitJsonLdPackageQuantityExtractor`;
+- deterministic extractor tests;
+- one-line Magnit corpus package-projection switch from visible text to exact-SKU JSON-LD;
+- deterministic corpus regressions;
+- design/plan/evidence documents;
+- PROJECT_STATE / ROADMAP / CHANGELOG synchronization.
+
+Temporary live-evidence workflow/test files were isolated on `evidence/magnit-jsonld-corpus-2026-08-12` and are not present in the feature branch diff or intended `main` history.
+
+## TDD evidence
+
+- extractor RED: API verification failed specifically because the new extractor contract did not exist;
+- extractor GREEN: full API verification passed after the minimal pure implementation;
+- corpus-projection RED: a JSON-LD-only fixture failed while the corpus still called the visible-text extractor;
+- corpus-projection GREEN: changing only package projection to `MagnitJsonLdPackageQuantityExtractor.extract(html, expectedSku)` restored full API verification while preserving existing price/promo/availability regressions.
+
+## Finite live evidence
+
+Same existing fixed corpus:
+
+- 20 requirements;
+- two explicit shops `139147` and `773577`;
+- exactly 40 requests;
+- 40 package-evidence eligible pages;
+- 20/20 + 20/20 HTTP 2xx;
+- 20/20 + 20/20 usable observations;
+- 20/20 stable product identity;
+- failed requirements: 0.
+
+Package distribution:
+
+- `FOUND=36`;
+- `MISSING=0`;
+- `AMBIGUOUS_DIMENSIONS=4`;
+- `CONFLICTING_VALUES=0`;
+- `INVALID_VALUE=0`.
+
+Earlier visible-text baseline on the same eligible-page count was `FOUND=0 / MISSING=40`.
+
+One-shop sanitized diagnostic identified ambiguity only for:
+
+- milk SKU `1000013732`;
+- kefir SKU `1000330180`.
+
+Both are ambiguous in both shop contexts, accounting for exactly 4/40 observations. The other fixed requirements were `FOUND` in the diagnostic.
+
+Egg SKU `2047000014` produced structured mass evidence (`700 g`) rather than count evidence. Existing basket regression coverage requires canonical-unit equality and rejects `PIECE` vs `GRAM`, so mass cannot silently satisfy a count requirement.
+
+## Independent review verdict
+
+Verdict: **Looks good**.
+
+Blocking findings:
+
+- P0: none;
+- P1: none;
+- P2: none.
+
+Non-blocking P3:
+
+- JSON-LD script discovery intentionally uses a minimal exact-media-type HTML scanner rather than a DOM parser. This depends on the proven Magnit `application/ld+json` surface and would ignore an unproven media-type variant such as additional parameters. The fixed 40-page replay nevertheless classified every eligible page (`36 FOUND + 4 explicit ambiguity`) and no additional HTML dependency is justified by current evidence. Revisit only if future evidence shows missed JSON-LD scripts.
+
+Review-specific checks passed:
+
+- exact expected SKU binds JSON-LD Product evidence;
+- foreign Product nodes cannot contaminate the result;
+- title/name/description/URL/category/generic-size/count-looking fields cannot create quantity;
+- malformed JSON-LD cannot be regex-repaired into evidence;
+- object-valued weight is not guessed;
+- invalid/conflicting/multi-dimensional values fail closed;
+- no browser acquisition or additional retailer request was introduced;
+- ordinary CI remains live-retailer-free;
+- #69 and #70 remain explicit production blockers;
+- package quantities remain canonical-unit compatible through #81 snapshot/basket semantics.
+
+## Exact reviewed-candidate CI/security
+
+All pull-request workflow groups completed successfully on `6c817ff6e562846f28a00d3a29873261e5054919`:
+
+1. API CI — PASS
+2. Contract CI — PASS
+3. Web CI / responsive Web E2E — PASS
+4. CodeQL — PASS
+5. Dependency Review — PASS
+6. Container Security CI — PASS
+7. Retailer Bridge CI — PASS
+8. Release Contract CI — PASS
+9. Release Bundle CI — PASS
+
+No failed workflow group remained on the reviewed candidate.
+
+## Final gate
+
+This shipping record changes only documentation. The resulting final head must independently pass the full branch-protection/CI/security set before #85 is marked ready and squash-merged.
+
+After merge, `main` push-triggered workflows must pass before the slice is called **ACCEPTED**.

--- a/docs/superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md
+++ b/docs/superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md
@@ -1,0 +1,101 @@
+# Magnit SKU-bound JSON-LD Package Evidence Implementation Plan
+
+Updated: 2026-08-12
+Status: executable plan
+
+Design: `docs/superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`
+Baseline: `main@bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6`
+Branch: `feat/magnit-jsonld-package-evidence`
+
+## Task 1 — RED: define JSON-LD extraction contract
+
+Create `MagnitJsonLdPackageQuantityExtractorTest` before production code.
+
+Cover:
+
+- exact-SKU `Product.weight = 0.45` → `FOUND 450 GRAM`;
+- exact-SKU `additionalProperty(name="Объем, л", value=0.5)` → `FOUND 500 MILLILITER`;
+- exact-SKU weight + volume → `AMBIGUOUS_DIMENSIONS`;
+- foreign SKU and non-Product nodes ignored;
+- equivalent duplicate Product evidence deduplicated;
+- conflicting weight values → `CONFLICTING_VALUES`;
+- recognized malformed/zero/negative values → `INVALID_VALUE`;
+- object-valued weight, generic volume/size/count/title/name/description/URL and non-JSON-LD scripts cannot create evidence;
+- malformed JSON-LD cannot create evidence.
+
+Commit test-only RED and verify the API compile/test gate fails specifically because `MagnitJsonLdPackageQuantityExtractor` does not exist.
+
+## Task 2 — GREEN: implement the smallest pure extractor
+
+Create `MagnitJsonLdPackageQuantityExtractor` under the existing Magnit provider package.
+
+Implementation boundaries:
+
+- extract only `script[type="application/ld+json"]` bodies;
+- parse with Jackson 3 tree model (`tools.jackson.databind`), already supplied by Spring Boot 4.1 web stack;
+- recursively inspect JSON-LD nodes;
+- exact `Product` + exact expected SKU identity;
+- support only scalar `weight` as kg and exact `additionalProperty.name="Объем, л"` scalar value as liters;
+- aggregate through the existing `MagnitPackageQuantityExtraction` status model;
+- no network, Spring bean, browser, title parsing or production wiring.
+
+Run focused tests, then full API verification.
+
+## Task 3 — RED/GREEN: project JSON-LD evidence into the existing corpus parser
+
+Add/extend deterministic corpus tests so `MagnitCorpusProbe.parseProductPage(html, expectedSku)` must carry JSON-LD package evidence while preserving existing price/promo/availability behavior.
+
+RED must fail while corpus still calls the visible-text extractor.
+
+Then replace only package extraction with the JSON-LD extractor. Do not alter request construction, eligibility, price/promo/availability parsing, fixed corpus or request count.
+
+Run focused Magnit tests and full API verification.
+
+## Task 4 — finite live replay
+
+After deterministic GREEN:
+
+- execute the same explicit/manual fixed corpus against the same two shop contexts;
+- exactly 40 requests;
+- capture only aggregate `MAGNIT_PHASE_B` evidence;
+- compare status distribution with visible-text baseline `FOUND=0 / MISSING=40`;
+- do not introduce a schedule or merge one-shot workflow plumbing.
+
+If the live result exposes unexpected structured cases, add deterministic regressions before shipping rather than weakening fail-closed rules.
+
+## Task 5 — durable evidence/docs
+
+Add a durable Magnit JSON-LD evidence note containing:
+
+- provenance observations;
+- old visible-text baseline;
+- new finite JSON-LD corpus distribution;
+- exact accepted source semantics;
+- limitations/count deferral;
+- #69/#70 production gates.
+
+Update `docs/PROJECT_STATE.md`, `docs/ROADMAP.md`, and root `CHANGELOG.md` only to the level actually proven by implementation/live evidence.
+
+## Task 6 — review and shipping
+
+Run exact-head branch-protection workflows/security gates.
+
+Perform independent change review for:
+
+- identity binding;
+- fail-closed precedence;
+- malformed JSON handling;
+- no title/slug fallback;
+- no extra network/browser behavior;
+- corpus request-count preservation;
+- documentation accuracy.
+
+Fix P0/P1/P2 findings. Record P3 follow-ups if non-blocking.
+
+When exact reviewed head is green:
+
+- add shipping evidence marker;
+- rerun final docs-only exact-head gate if marker changes the branch;
+- mark PR ready;
+- squash merge using expected exact head SHA;
+- verify post-merge `main` head and push-triggered CI before calling the slice accepted.

--- a/docs/superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md
+++ b/docs/superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md
@@ -1,0 +1,181 @@
+# Magnit SKU-bound JSON-LD Package Evidence Design
+
+Updated: 2026-08-12
+Status: implementation direction
+
+## Context
+
+#82 accepted package-quantity semantics for exact Magnit weight/volume characteristics and #83 instrumented those semantics over the existing finite 20-product × 2-shop corpus. The first explicit live run was transport-healthy but the visible-text extractor reported `0 FOUND / 40 MISSING`.
+
+Follow-up finite provenance diagnostics proved that the conclusion must be narrower: the same raw PUBLIC_WEB HTTP response contains SKU-bound JSON-LD `Product` data inside `script[type="application/ld+json"]`.
+
+Observed examples:
+
+- SKU `3042670099`: `Product.weight = "0.45"`, matching official `Вес, кг = 0.45`;
+- SKU `1000166929`: `Product.weight = "0.5"`, matching a 500 g package;
+- SKU `1000273122`: `Product.additionalProperty` contains exact `name = "Объем, л"`, `value = "0.5"`;
+- SKU `1000548435`: both `weight = "1.028"` and exact `additionalProperty["Объем, л"] = "1"`, proving that multi-dimensional ambiguity must remain fail-closed;
+- the investigated egg/count example exposed weight but no proven count field, so `Количество в упаковке` remains deferred.
+
+No browser execution is required to obtain these JSON-LD nodes.
+
+## Goal
+
+Add a deterministic, SKU-bound extractor for package quantity from Magnit's raw JSON-LD `Product` evidence and use it in the existing finite corpus measurement.
+
+The extractor reuses the accepted `MagnitPackageQuantityExtraction` / `MagnitPackageQuantityStatus` contract so downstream #81 snapshot/basket behavior does not change.
+
+## Non-goals
+
+- no production provider activation;
+- no recurring polling or scheduled retailer requests;
+- no location/address → `shopCode` resolution;
+- no usage-rights decision;
+- no browser acquisition;
+- no title, slug, description, URL or product-name quantity parsing;
+- no generic schema.org unit inference beyond fields specifically proven on Magnit;
+- no `Количество в упаковке` support in this version.
+
+## Accepted source boundary
+
+Only standalone JSON bodies from HTML `<script>` elements whose `type` attribute is exactly `application/ld+json` (case-insensitive media type comparison) are considered.
+
+Other scripts, Nuxt bootstrap JSON, JavaScript literals and rendered text remain outside this extractor. Nuxt data may be investigated later, but is unnecessary for the currently proven v1 path.
+
+## Identity rule
+
+Extraction requires an `expectedSku` supplied by the caller.
+
+Only JSON-LD nodes satisfying both conditions participate:
+
+1. `@type` is `Product`, or an array containing `Product`;
+2. scalar `sku`, converted to text without presentation heuristics, equals `expectedSku` exactly after surrounding-whitespace trimming.
+
+Foreign Product nodes are ignored. Non-Product JSON-LD nodes are ignored.
+
+If no matching Product node exists, result is `MISSING`.
+
+Multiple matching Product nodes are allowed only as duplicated structured evidence; their supported dimensions are aggregated under the same conflict rules below.
+
+## Supported dimensions
+
+### Weight
+
+Accepted field: exact JSON-LD Product member `weight` when its value is a JSON string or JSON number.
+
+Proven Magnit semantics: decimal kilograms.
+
+Rules:
+
+- parse as positive `BigDecimal`;
+- construct `Quantity(amount, KILOGRAM)` so the existing canonical model converts to grams;
+- object-valued schema.org QuantitativeValue forms are **not** accepted until separately proven on Magnit;
+- malformed, zero or negative supported values make the extraction `INVALID_VALUE`.
+
+### Volume
+
+Accepted field: Product `additionalProperty` entries that are objects with exact scalar `name = "Объем, л"` and scalar string/number `value`.
+
+Proven Magnit semantics: decimal liters.
+
+Rules:
+
+- parse as positive `BigDecimal`;
+- construct `Quantity(amount, LITER)` so the existing canonical model converts to milliliters;
+- `propertyID`, approximate labels, generic `volume`, `size`, URL/title text and other properties are ignored until separately proven;
+- a recognized exact volume property with a missing/non-scalar/malformed/zero/negative value makes the extraction `INVALID_VALUE`.
+
+## Aggregation and fail-closed status rules
+
+Evidence is collected across all matching Product nodes.
+
+For each supported dimension:
+
+- equivalent canonical quantities deduplicate;
+- more than one distinct canonical value in the same dimension => `CONFLICTING_VALUES`;
+- any invalid recognized supported value => `INVALID_VALUE`;
+- one valid weight and one valid volume, even when numerically convertible by density assumptions, => `AMBIGUOUS_DIMENSIONS`;
+- exactly one valid dimension/value => `FOUND`;
+- no supported valid or invalid dimension => `MISSING`.
+
+Precedence follows the accepted #82 contract:
+
+1. `INVALID_VALUE`;
+2. `CONFLICTING_VALUES`;
+3. `AMBIGUOUS_DIMENSIONS`;
+4. `FOUND`;
+5. `MISSING`.
+
+No density conversion or domain guessing is permitted.
+
+## HTML / JSON parsing safety
+
+The implementation must not interpret arbitrary JavaScript. It extracts only text content of `application/ld+json` script elements and parses each body as JSON with Jackson.
+
+Malformed JSON-LD scripts are ignored unless they are the only source; they do not become package evidence and cannot create a quantity. The extractor remains fail-closed rather than recovering values with regex from malformed JSON.
+
+The HTML scanner must tolerate attribute order, quoting and additional attributes while never reading non-JSON-LD script bodies as evidence.
+
+## Corpus integration
+
+`MagnitCorpusProbe.parseProductPage(html, expectedSku)` already receives the full raw HTTP response and separately proves expected-SKU page identity for the existing price/availability observation.
+
+Replace only package extraction in that observation with:
+
+`MagnitJsonLdPackageQuantityExtractor.extract(html, expectedSku)`
+
+Transport, request count, URLs, headers, price parsing, promo parsing and availability behavior remain unchanged.
+
+The existing #83 package eligibility rule remains unchanged: only HTTP 2xx + expected-SKU observations enter package metrics.
+
+## Deterministic acceptance tests
+
+At minimum:
+
+- exact matching Product weight `0.45` => `450 GRAM`;
+- exact `additionalProperty` volume `0.5` => `500 MILLILITER`;
+- matching Product with weight + volume => `AMBIGUOUS_DIMENSIONS`;
+- foreign SKU Product is ignored;
+- non-Product node is ignored;
+- multiple matching nodes with equivalent weight deduplicate;
+- conflicting matching weights => `CONFLICTING_VALUES`;
+- malformed/zero/negative supported value => `INVALID_VALUE`;
+- object-valued weight is not guessed;
+- generic `volume`, `size`, title/name/description/URL and count-looking fields do not create evidence;
+- malformed JSON-LD cannot create evidence;
+- non-JSON-LD scripts cannot create evidence;
+- corpus page parser projects JSON-LD package evidence without changing price/promo/availability behavior.
+
+## Live replay gate
+
+After deterministic tests and the normal API regression suite pass, run the same finite corpus:
+
+- 20 fixed products;
+- two explicit shop contexts;
+- exactly 40 requests;
+- no schedule;
+- no production wiring.
+
+Compare the new aggregate distribution against the earlier visible-text baseline (`FOUND=0`, `MISSING=40`). The measurement is evidence, not a predetermined pass-rate target.
+
+A non-zero `FOUND` confirms practical value of the raw JSON-LD path. Any unexpected conflicts/invalid/multi-dimensional cases are retained as explicit uncertainty rather than coerced to FOUND.
+
+## Production/access constraints
+
+Even if corpus replay is strong:
+
+- #69 location → public `shopCode` remains unresolved;
+- #70 recurring production acquisition usage rights remain unresolved;
+- production comparison evidence remains fail-closed/no-op until its own activation decision;
+- ordinary CI remains live-retailer-free.
+
+## Exit criteria
+
+- deterministic JSON-LD extraction tests pass;
+- package extraction is exact-SKU-bound and presentation-text-independent;
+- existing Magnit price/promo/availability tests pass unchanged;
+- full API verification passes;
+- finite 40-request corpus replay is captured as aggregate evidence;
+- docs distinguish visible-text failure from raw JSON-LD success/failure accurately;
+- exact-head CI/security passes;
+- independent review has no blocking findings.


### PR DESCRIPTION
## Goal

Add deterministic **SKU-bound JSON-LD package evidence** for Magnit over the same raw PUBLIC_WEB response, then prove it on the existing finite 20-product × 2-shop corpus.

## Implemented

- pure `MagnitJsonLdPackageQuantityExtractor`;
- only `script[type="application/ld+json"]` is parsed;
- only JSON-LD `Product` nodes with exact expected `sku` participate;
- proven scalar `Product.weight` → kg → canonical grams;
- exact `additionalProperty.name="Объем, л"` scalar `value` → liters → canonical ml;
- equivalent duplicates deduplicate;
- invalid values, same-dimension conflicts and weight+volume ambiguity fail closed;
- foreign Product nodes, malformed JSON-LD, title/name/description/URL/category, generic volume/size and count-looking fields cannot create evidence;
- corpus package projection now uses JSON-LD evidence from the raw response it already owns; transport, price/promo/availability and request count are unchanged.

## TDD evidence

1. RED extractor contract: API verification failed only because `MagnitJsonLdPackageQuantityExtractor` did not exist.
2. GREEN extractor: full API `./mvnw verify` passed.
3. RED corpus projection: JSON-LD-only fixture failed while the corpus still used visible text.
4. GREEN corpus projection: one-line projection change and full API verification passed.

## Finite live evidence

Same fixed corpus, same explicit shops `139147` and `773577`, exactly 40 requests:

- HTTP 2xx: 20/20 + 20/20;
- usable: 20/20 + 20/20;
- stable identity: 20/20;
- package pages: 40;
- `FOUND=36`;
- `MISSING=0`;
- `AMBIGUOUS_DIMENSIONS=4`;
- `CONFLICTING_VALUES=0`;
- `INVALID_VALUE=0`;
- failed requirements: 0.

Old visible-text baseline was `FOUND=0 / MISSING=40` on the same 40 eligible pages.

A separate finite one-shop diagnostic identified the ambiguity as exactly milk SKU `1000013732` and kefir SKU `1000330180`; therefore the four observations are those two products across both shop contexts. All other fixed requirements were `FOUND`.

Egg SKU `2047000014` yields structured `700 g` mass evidence, **not count evidence**. Basket arithmetic requires canonical unit equality, so that mass cannot satisfy a `PIECE` requirement.

## Boundaries unchanged

- no browser acquisition;
- no additional retailer request in product/corpus projection;
- no recurring polling;
- no production activation;
- #69 location → public `shopCode` remains unresolved;
- #70 production usage-rights remains unresolved;
- `Количество в упаковке` remains deferred.

## Durable docs

- `docs/superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`
- `docs/superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md`
- `docs/integrations/magnit-jsonld-package-evidence-2026-08-12.md`
- PROJECT_STATE / ROADMAP / CHANGELOG synchronized to current proof level.

## Current gate

**IMPLEMENTED / LIVE EVIDENCE PROVEN / SHIPPING**.

Do not call ACCEPTED until independent review, exact-head CI/security, squash merge and post-merge `main` verification all pass.