### PR TITLE
feat(magnit): add fail-closed public shopCode resolution

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitFulfillmentContextBindings.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitFulfillmentContextBindings.java
@@ -1,0 +1,53 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
+import io.github.trueruslan.zakupgotov.provider.FulfillmentContextBinding;
+import io.github.trueruslan.zakupgotov.provider.FulfillmentContextSelectionMode;
+import io.github.trueruslan.zakupgotov.provider.LocationContext;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class MagnitFulfillmentContextBindings {
+
+    public static final String SOURCE_PROVIDER_ID = "magnit-public-page";
+
+    private MagnitFulfillmentContextBindings() {}
+
+    public static Optional<FulfillmentContextBinding> autoResolved(
+            ProductLocationId productLocationId,
+            String locality,
+            MagnitStoreResolution resolution) {
+        var result = Objects.requireNonNull(resolution, "resolution must not be null");
+        if (result.status() != MagnitStoreResolutionStatus.RESOLVED) {
+            return Optional.empty();
+        }
+        return result.candidate().map(candidate -> binding(
+                productLocationId,
+                locality,
+                candidate,
+                FulfillmentContextSelectionMode.RESOLVED));
+    }
+
+    public static FulfillmentContextBinding manual(
+            ProductLocationId productLocationId,
+            String locality,
+            MagnitStoreCandidate candidate) {
+        return binding(
+                productLocationId,
+                locality,
+                Objects.requireNonNull(candidate, "candidate must not be null"),
+                FulfillmentContextSelectionMode.MANUAL);
+    }
+
+    private static FulfillmentContextBinding binding(
+            ProductLocationId productLocationId,
+            String locality,
+            MagnitStoreCandidate candidate,
+            FulfillmentContextSelectionMode mode) {
+        var context = new LocationContext(SOURCE_PROVIDER_ID, candidate.shopCode(), locality);
+        return new FulfillmentContextBinding(
+                Objects.requireNonNull(productLocationId, "productLocationId must not be null"),
+                context,
+                mode);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitGeoBoundingBox.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitGeoBoundingBox.java
@@ -1,0 +1,17 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.Objects;
+
+public record MagnitGeoBoundingBox(MagnitGeoPoint leftTopPoint, MagnitGeoPoint rightBottomPoint) {
+
+    public MagnitGeoBoundingBox {
+        leftTopPoint = Objects.requireNonNull(leftTopPoint, "leftTopPoint must not be null");
+        rightBottomPoint = Objects.requireNonNull(rightBottomPoint, "rightBottomPoint must not be null");
+        if (leftTopPoint.latitude() <= rightBottomPoint.latitude()) {
+            throw new IllegalArgumentException("leftTopPoint latitude must be greater than rightBottomPoint latitude");
+        }
+        if (leftTopPoint.longitude() >= rightBottomPoint.longitude()) {
+            throw new IllegalArgumentException("leftTopPoint longitude must be less than rightBottomPoint longitude");
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitGeoPoint.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitGeoPoint.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+public record MagnitGeoPoint(double latitude, double longitude) {
+
+    public MagnitGeoPoint {
+        if (!Double.isFinite(latitude) || latitude < -90.0 || latitude > 90.0) {
+            throw new IllegalArgumentException("latitude must be finite and between -90 and 90");
+        }
+        if (!Double.isFinite(longitude) || longitude < -180.0 || longitude > 180.0) {
+            throw new IllegalArgumentException("longitude must be finite and between -180 and 180");
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreCandidate.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreCandidate.java
@@ -1,0 +1,14 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.Objects;
+
+public record MagnitStoreCandidate(String shopCode, MagnitGeoPoint coordinates) {
+
+    public MagnitStoreCandidate {
+        if (shopCode == null || shopCode.isBlank()) {
+            throw new IllegalArgumentException("shopCode must not be blank");
+        }
+        shopCode = shopCode.trim();
+        coordinates = Objects.requireNonNull(coordinates, "coordinates must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolution.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolution.java
@@ -1,0 +1,29 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record MagnitStoreResolution(MagnitStoreResolutionStatus status, Optional<MagnitStoreCandidate> candidate) {
+
+    public MagnitStoreResolution {
+        status = Objects.requireNonNull(status, "status must not be null");
+        candidate = Objects.requireNonNull(candidate, "candidate must not be null");
+        if (status == MagnitStoreResolutionStatus.RESOLVED && candidate.isEmpty()) {
+            throw new IllegalArgumentException("RESOLVED resolution must carry a candidate");
+        }
+        if (status != MagnitStoreResolutionStatus.RESOLVED && candidate.isPresent()) {
+            throw new IllegalArgumentException("non-RESOLVED resolution must not carry a candidate");
+        }
+    }
+
+    public static MagnitStoreResolution resolved(MagnitStoreCandidate candidate) {
+        return new MagnitStoreResolution(MagnitStoreResolutionStatus.RESOLVED, Optional.of(candidate));
+    }
+
+    public static MagnitStoreResolution empty(MagnitStoreResolutionStatus status) {
+        if (status == MagnitStoreResolutionStatus.RESOLVED) {
+            throw new IllegalArgumentException("use resolved(...) for RESOLVED status");
+        }
+        return new MagnitStoreResolution(status, Optional.empty());
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolutionStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolutionStatus.java
@@ -1,0 +1,8 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+public enum MagnitStoreResolutionStatus {
+    RESOLVED,
+    NO_STORES,
+    AMBIGUOUS,
+    CONFLICTING_STORE_EVIDENCE
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolver.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolver.java
@@ -1,0 +1,20 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.Objects;
+
+public final class MagnitStoreResolver {
+
+    private MagnitStoreResolver() {}
+
+    public static MagnitStoreResolution resolve(MagnitStoreSearchEvidence evidence) {
+        var input = Objects.requireNonNull(evidence, "evidence must not be null");
+        if (input.conflictingStoreEvidence()) {
+            return MagnitStoreResolution.empty(MagnitStoreResolutionStatus.CONFLICTING_STORE_EVIDENCE);
+        }
+        return switch (input.candidates().size()) {
+            case 0 -> MagnitStoreResolution.empty(MagnitStoreResolutionStatus.NO_STORES);
+            case 1 -> MagnitStoreResolution.resolved(input.candidates().getFirst());
+            default -> MagnitStoreResolution.empty(MagnitStoreResolutionStatus.AMBIGUOUS);
+        };
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchEvidence.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchEvidence.java
@@ -1,0 +1,22 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.List;
+import java.util.Objects;
+
+public record MagnitStoreSearchEvidence(List<MagnitStoreCandidate> candidates, boolean conflictingStoreEvidence) {
+
+    public MagnitStoreSearchEvidence {
+        candidates = List.copyOf(Objects.requireNonNull(candidates, "candidates must not be null"));
+        if (conflictingStoreEvidence && !candidates.isEmpty()) {
+            throw new IllegalArgumentException("conflicting store evidence must not expose candidates");
+        }
+    }
+
+    public static MagnitStoreSearchEvidence empty() {
+        return new MagnitStoreSearchEvidence(List.of(), false);
+    }
+
+    public static MagnitStoreSearchEvidence conflict() {
+        return new MagnitStoreSearchEvidence(List.of(), true);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchRequest.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchRequest.java
@@ -27,6 +27,9 @@ public record MagnitStoreSearchRequest(Filters filters) {
         public Filters {
             geo = Objects.requireNonNull(geo, "geo must not be null");
             storeTypeListV2 = List.copyOf(Objects.requireNonNull(storeTypeListV2, "storeTypeListV2 must not be null"));
+            if (!STORE_TYPES.equals(storeTypeListV2)) {
+                throw new IllegalArgumentException("storeTypeListV2 must match the proven Magnit public contract");
+            }
         }
     }
 
@@ -37,6 +40,7 @@ public record MagnitStoreSearchRequest(Filters filters) {
             }
             leftTopPoint = Objects.requireNonNull(leftTopPoint, "leftTopPoint must not be null");
             rightBottomPoint = Objects.requireNonNull(rightBottomPoint, "rightBottomPoint must not be null");
+            new MagnitGeoBoundingBox(leftTopPoint, rightBottomPoint);
         }
     }
 }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchRequest.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchRequest.java
@@ -1,0 +1,42 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.List;
+import java.util.Objects;
+
+public record MagnitStoreSearchRequest(Filters filters) {
+
+    private static final List<String> STORE_TYPES =
+            List.of("MM", "GM", "DG", "MO", "ME", "MC", "DARKSTORE", "MM_MINI", "ZARYAD");
+
+    public MagnitStoreSearchRequest {
+        filters = Objects.requireNonNull(filters, "filters must not be null");
+    }
+
+    public static MagnitStoreSearchRequest forBoundingBox(MagnitGeoBoundingBox boundingBox) {
+        var box = Objects.requireNonNull(boundingBox, "boundingBox must not be null");
+        return new MagnitStoreSearchRequest(new Filters(
+                new GeoFilter("box", box.leftTopPoint(), box.rightBottomPoint()),
+                STORE_TYPES));
+    }
+
+    public static List<String> storeTypes() {
+        return STORE_TYPES;
+    }
+
+    public record Filters(GeoFilter geo, List<String> storeTypeListV2) {
+        public Filters {
+            geo = Objects.requireNonNull(geo, "geo must not be null");
+            storeTypeListV2 = List.copyOf(Objects.requireNonNull(storeTypeListV2, "storeTypeListV2 must not be null"));
+        }
+    }
+
+    public record GeoFilter(String typeName, MagnitGeoPoint leftTopPoint, MagnitGeoPoint rightBottomPoint) {
+        public GeoFilter {
+            if (!"box".equals(typeName)) {
+                throw new IllegalArgumentException("typeName must be box");
+            }
+            leftTopPoint = Objects.requireNonNull(leftTopPoint, "leftTopPoint must not be null");
+            rightBottomPoint = Objects.requireNonNull(rightBottomPoint, "rightBottomPoint must not be null");
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchResponseParser.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchResponseParser.java
@@ -1,0 +1,88 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+public final class MagnitStoreSearchResponseParser {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private MagnitStoreSearchResponseParser() {}
+
+    public static MagnitStoreSearchEvidence parse(String json) {
+        try {
+            var root = JSON.readTree(json == null ? "" : json);
+            var items = root == null ? null : root.path("items").path("items");
+            if (items == null || !"ARRAY".equals(items.getNodeType().name())) {
+                return MagnitStoreSearchEvidence.empty();
+            }
+
+            Map<String, MagnitGeoPoint> byCode = new HashMap<>();
+            for (var item : items) {
+                var candidate = parseCandidate(item);
+                if (candidate == null) {
+                    continue;
+                }
+                var previous = byCode.putIfAbsent(candidate.shopCode(), candidate.coordinates());
+                if (previous != null && !previous.equals(candidate.coordinates())) {
+                    return MagnitStoreSearchEvidence.conflict();
+                }
+            }
+
+            var candidates = new ArrayList<MagnitStoreCandidate>();
+            byCode.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> candidates.add(new MagnitStoreCandidate(entry.getKey(), entry.getValue())));
+            return new MagnitStoreSearchEvidence(candidates, false);
+        } catch (Exception ignored) {
+            return MagnitStoreSearchEvidence.empty();
+        }
+    }
+
+    private static MagnitStoreCandidate parseCandidate(JsonNode item) {
+        if (item == null || !"OBJECT".equals(item.getNodeType().name())) {
+            return null;
+        }
+
+        var code = scalarText(item.path("externalId").path("storeCode"));
+        var latitude = scalarDouble(item.path("coordinates").path("latitude"));
+        var longitude = scalarDouble(item.path("coordinates").path("longitude"));
+        if (code == null || code.isBlank() || latitude == null || longitude == null) {
+            return null;
+        }
+
+        try {
+            return new MagnitStoreCandidate(code, new MagnitGeoPoint(latitude, longitude));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private static String scalarText(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        var type = node.getNodeType().name();
+        if (!"STRING".equals(type) && !"NUMBER".equals(type)) {
+            return null;
+        }
+        var value = node.asString().trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    private static Double scalarDouble(JsonNode node) {
+        var value = scalarText(node);
+        if (value == null) {
+            return null;
+        }
+        try {
+            var parsed = Double.parseDouble(value);
+            return Double.isFinite(parsed) ? parsed : null;
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolverTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolverTest.java
@@ -1,0 +1,121 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.location.ProductLocationId;
+import io.github.trueruslan.zakupgotov.provider.FulfillmentContextSelectionMode;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MagnitStoreResolverTest {
+
+    private static final ProductLocationId LOCATION_ID =
+            new ProductLocationId(UUID.fromString("69696969-6969-6969-6969-696969696969"));
+
+    @Test
+    void resolvesExactlyOneCandidate() {
+        var candidate = candidate("992301", 45.067057, 38.973527);
+
+        var resolution = MagnitStoreResolver.resolve(new MagnitStoreSearchEvidence(List.of(candidate), false));
+
+        assertThat(resolution.status()).isEqualTo(MagnitStoreResolutionStatus.RESOLVED);
+        assertThat(resolution.candidate()).contains(candidate);
+    }
+
+    @Test
+    void zeroCandidatesFailClosedAsNoStores() {
+        var resolution = MagnitStoreResolver.resolve(MagnitStoreSearchEvidence.empty());
+
+        assertThat(resolution.status()).isEqualTo(MagnitStoreResolutionStatus.NO_STORES);
+        assertThat(resolution.candidate()).isEmpty();
+    }
+
+    @Test
+    void multipleCandidatesRemainAmbiguousRegardlessOfInputOrder() {
+        var first = candidate("100", 55.70, 37.60);
+        var second = candidate("200", 55.71, 37.61);
+
+        var left = MagnitStoreResolver.resolve(new MagnitStoreSearchEvidence(List.of(first, second), false));
+        var right = MagnitStoreResolver.resolve(new MagnitStoreSearchEvidence(List.of(second, first), false));
+
+        assertThat(left.status()).isEqualTo(MagnitStoreResolutionStatus.AMBIGUOUS);
+        assertThat(right.status()).isEqualTo(MagnitStoreResolutionStatus.AMBIGUOUS);
+        assertThat(left.candidate()).isEmpty();
+        assertThat(right.candidate()).isEmpty();
+    }
+
+    @Test
+    void parserConflictRemainsAnExplicitResolutionState() {
+        var resolution = MagnitStoreResolver.resolve(MagnitStoreSearchEvidence.conflict());
+
+        assertThat(resolution.status()).isEqualTo(MagnitStoreResolutionStatus.CONFLICTING_STORE_EVIDENCE);
+        assertThat(resolution.candidate()).isEmpty();
+    }
+
+    @Test
+    void automaticBindingUsesExistingProviderIdentityAndResolvedMode() {
+        var candidate = candidate("992301", 45.067057, 38.973527);
+        var resolution = MagnitStoreResolver.resolve(new MagnitStoreSearchEvidence(List.of(candidate), false));
+
+        var binding = MagnitFulfillmentContextBindings.autoResolved(LOCATION_ID, "Краснодар", resolution).orElseThrow();
+
+        assertThat(binding.productLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(binding.locationContext().sourceProviderId()).isEqualTo("magnit-public-page");
+        assertThat(binding.locationContext().fulfillmentContextId()).isEqualTo("992301");
+        assertThat(binding.locationContext().locality()).isEqualTo("Краснодар");
+        assertThat(binding.selectionMode()).isEqualTo(FulfillmentContextSelectionMode.RESOLVED);
+        assertThat(binding.toString()).doesNotContain("45.067057").doesNotContain("38.973527");
+    }
+
+    @Test
+    void nonResolvedResultsCannotCreateAutomaticBindings() {
+        assertThat(MagnitFulfillmentContextBindings.autoResolved(
+                        LOCATION_ID,
+                        "Москва",
+                        MagnitStoreResolver.resolve(MagnitStoreSearchEvidence.empty())))
+                .isEmpty();
+        assertThat(MagnitFulfillmentContextBindings.autoResolved(
+                        LOCATION_ID,
+                        "Москва",
+                        MagnitStoreResolver.resolve(new MagnitStoreSearchEvidence(
+                                List.of(candidate("100", 55.70, 37.60), candidate("200", 55.71, 37.61)),
+                                false))))
+                .isEmpty();
+        assertThat(MagnitFulfillmentContextBindings.autoResolved(
+                        LOCATION_ID,
+                        "Москва",
+                        MagnitStoreResolver.resolve(MagnitStoreSearchEvidence.conflict())))
+                .isEmpty();
+    }
+
+    @Test
+    void explicitManualSelectionUsesTheSameProviderScopedShopCode() {
+        var binding = MagnitFulfillmentContextBindings.manual(
+                LOCATION_ID,
+                "Москва",
+                candidate("011830", 55.75, 37.62));
+
+        assertThat(binding.locationContext().sourceProviderId()).isEqualTo("magnit-public-page");
+        assertThat(binding.locationContext().fulfillmentContextId()).isEqualTo("011830");
+        assertThat(binding.locationContext().locality()).isEqualTo("Москва");
+        assertThat(binding.selectionMode()).isEqualTo(FulfillmentContextSelectionMode.MANUAL);
+    }
+
+    @Test
+    void impossibleResolutionShapesFailAtConstruction() {
+        assertThatThrownBy(() -> new MagnitStoreResolution(
+                        MagnitStoreResolutionStatus.RESOLVED,
+                        java.util.Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new MagnitStoreResolution(
+                        MagnitStoreResolutionStatus.AMBIGUOUS,
+                        java.util.Optional.of(candidate("100", 55.7, 37.6))))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static MagnitStoreCandidate candidate(String code, double latitude, double longitude) {
+        return new MagnitStoreCandidate(code, new MagnitGeoPoint(latitude, longitude));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolverTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreResolverTest.java
@@ -62,10 +62,10 @@ class MagnitStoreResolverTest {
         var binding = MagnitFulfillmentContextBindings.autoResolved(LOCATION_ID, "Краснодар", resolution).orElseThrow();
 
         assertThat(binding.productLocationId()).isEqualTo(LOCATION_ID);
-        assertThat(binding.locationContext().sourceProviderId()).isEqualTo("magnit-public-page");
-        assertThat(binding.locationContext().fulfillmentContextId()).isEqualTo("992301");
-        assertThat(binding.locationContext().locality()).isEqualTo("Краснодар");
-        assertThat(binding.selectionMode()).isEqualTo(FulfillmentContextSelectionMode.RESOLVED);
+        assertThat(binding.context().sourceProviderId()).isEqualTo("magnit-public-page");
+        assertThat(binding.context().fulfillmentContextId()).isEqualTo("992301");
+        assertThat(binding.context().locality()).isEqualTo("Краснодар");
+        assertThat(binding.mode()).isEqualTo(FulfillmentContextSelectionMode.RESOLVED);
         assertThat(binding.toString()).doesNotContain("45.067057").doesNotContain("38.973527");
     }
 
@@ -97,10 +97,10 @@ class MagnitStoreResolverTest {
                 "Москва",
                 candidate("011830", 55.75, 37.62));
 
-        assertThat(binding.locationContext().sourceProviderId()).isEqualTo("magnit-public-page");
-        assertThat(binding.locationContext().fulfillmentContextId()).isEqualTo("011830");
-        assertThat(binding.locationContext().locality()).isEqualTo("Москва");
-        assertThat(binding.selectionMode()).isEqualTo(FulfillmentContextSelectionMode.MANUAL);
+        assertThat(binding.context().sourceProviderId()).isEqualTo("magnit-public-page");
+        assertThat(binding.context().fulfillmentContextId()).isEqualTo("011830");
+        assertThat(binding.context().locality()).isEqualTo("Москва");
+        assertThat(binding.mode()).isEqualTo(FulfillmentContextSelectionMode.MANUAL);
     }
 
     @Test

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchContractTest.java
@@ -1,0 +1,88 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+class MagnitStoreSearchContractTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void buildsTheProvenPublicBoundingBoxRequestWithoutUserAddressData() throws Exception {
+        var box = new MagnitGeoBoundingBox(
+                new MagnitGeoPoint(45.069, 38.967),
+                new MagnitGeoPoint(45.065, 38.980));
+
+        var request = MagnitStoreSearchRequest.forBoundingBox(box);
+        var tree = JSON.valueToTree(request);
+
+        assertThat(tree.at("/filters/geo/typeName").asString()).isEqualTo("box");
+        assertThat(tree.at("/filters/geo/leftTopPoint/latitude").asDouble()).isEqualTo(45.069);
+        assertThat(tree.at("/filters/geo/leftTopPoint/longitude").asDouble()).isEqualTo(38.967);
+        assertThat(tree.at("/filters/geo/rightBottomPoint/latitude").asDouble()).isEqualTo(45.065);
+        assertThat(tree.at("/filters/geo/rightBottomPoint/longitude").asDouble()).isEqualTo(38.980);
+        assertThat(tree.at("/filters/storeTypeListV2"))
+                .extracting(node -> node.asString())
+                .containsExactly("MM", "GM", "DG", "MO", "ME", "MC", "DARKSTORE", "MM_MINI", "ZARYAD");
+
+        var serialized = JSON.writeValueAsString(request);
+        assertThat(serialized)
+                .doesNotContainIgnoringCase("address")
+                .doesNotContainIgnoringCase("locality")
+                .doesNotContainIgnoringCase("cookie")
+                .doesNotContainIgnoringCase("token");
+    }
+
+    @Test
+    void storeTypeContractIsImmutableAndOrdered() {
+        assertThat(MagnitStoreSearchRequest.storeTypes())
+                .containsExactly("MM", "GM", "DG", "MO", "ME", "MC", "DARKSTORE", "MM_MINI", "ZARYAD");
+        assertThatThrownBy(() -> MagnitStoreSearchRequest.storeTypes().add("OTHER"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void geoPointRejectsNonFiniteAndOutOfRangeCoordinates() {
+        for (var latitude : List.of(Double.NaN, Double.POSITIVE_INFINITY, -90.0001, 90.0001)) {
+            assertThatThrownBy(() -> new MagnitGeoPoint(latitude, 37.6))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("latitude");
+        }
+        for (var longitude : List.of(Double.NaN, Double.NEGATIVE_INFINITY, -180.0001, 180.0001)) {
+            assertThatThrownBy(() -> new MagnitGeoPoint(55.7, longitude))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("longitude");
+        }
+    }
+
+    @Test
+    void boundingBoxRejectsDegenerateOrInvertedGeometry() {
+        assertThatThrownBy(() -> new MagnitGeoBoundingBox(
+                        new MagnitGeoPoint(55.0, 37.0),
+                        new MagnitGeoPoint(55.0, 38.0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("latitude");
+
+        assertThatThrownBy(() -> new MagnitGeoBoundingBox(
+                        new MagnitGeoPoint(54.0, 37.0),
+                        new MagnitGeoPoint(55.0, 38.0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("latitude");
+
+        assertThatThrownBy(() -> new MagnitGeoBoundingBox(
+                        new MagnitGeoPoint(55.0, 38.0),
+                        new MagnitGeoPoint(54.0, 38.0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("longitude");
+
+        assertThatThrownBy(() -> new MagnitGeoBoundingBox(
+                        new MagnitGeoPoint(55.0, 39.0),
+                        new MagnitGeoPoint(54.0, 38.0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("longitude");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchContractTest.java
@@ -46,6 +46,28 @@ class MagnitStoreSearchContractTest {
     }
 
     @Test
+    void directNestedConstructionCannotBypassBoundingBoxGeometry() {
+        assertThatThrownBy(() -> new MagnitStoreSearchRequest.GeoFilter(
+                        "box",
+                        new MagnitGeoPoint(54.0, 37.0),
+                        new MagnitGeoPoint(55.0, 38.0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("latitude");
+    }
+
+    @Test
+    void directNestedConstructionCannotReplaceTheProvenStoreTypeContract() {
+        var geo = new MagnitStoreSearchRequest.GeoFilter(
+                "box",
+                new MagnitGeoPoint(55.0, 37.0),
+                new MagnitGeoPoint(54.0, 38.0));
+
+        assertThatThrownBy(() -> new MagnitStoreSearchRequest.Filters(geo, List.of("MM")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("storeTypeListV2");
+    }
+
+    @Test
     void geoPointRejectsNonFiniteAndOutOfRangeCoordinates() {
         for (var latitude : List.of(Double.NaN, Double.POSITIVE_INFINITY, -90.0001, 90.0001)) {
             assertThatThrownBy(() -> new MagnitGeoPoint(latitude, 37.6))

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchResponseParserTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchResponseParserTest.java
@@ -1,0 +1,113 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MagnitStoreSearchResponseParserTest {
+
+    @Test
+    void parsesOnlyShopCodeAndCoordinatesFromTheProvenResponseShape() {
+        var result = MagnitStoreSearchResponseParser.parse("""
+                {
+                  "items": {
+                    "items": [
+                      {
+                        "address": "must not be retained",
+                        "name": "must not be retained",
+                        "coordinates": {"latitude": 45.067057, "longitude": 38.973527},
+                        "externalId": {"owner": "magnit", "storeCode": "992301"},
+                        "storeTypeV2": "MM"
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        assertThat(result.conflictingStoreEvidence()).isFalse();
+        assertThat(result.candidates()).containsExactly(
+                new MagnitStoreCandidate("992301", new MagnitGeoPoint(45.067057, 38.973527)));
+        assertThat(result.toString())
+                .doesNotContain("must not be retained")
+                .doesNotContain("address")
+                .doesNotContain("name");
+    }
+
+    @Test
+    void acceptsNumericStoreCodeAndNumericStringsForCoordinates() {
+        var result = MagnitStoreSearchResponseParser.parse("""
+                {"items":{"items":[{
+                  "coordinates":{"latitude":"55.750","longitude":"37.620"},
+                  "externalId":{"storeCode":12345}
+                }]}}
+                """);
+
+        assertThat(result.candidates()).containsExactly(
+                new MagnitStoreCandidate("12345", new MagnitGeoPoint(55.750, 37.620)));
+    }
+
+    @Test
+    void ignoresMalformedEntriesAndUnrelatedJson() {
+        var result = MagnitStoreSearchResponseParser.parse("""
+                {
+                  "storeCode": "outside-proven-shape",
+                  "coordinates": {"latitude": 1, "longitude": 2},
+                  "items": {
+                    "items": [
+                      {"externalId":{"storeCode":"missing-coordinates"}},
+                      {"coordinates":{"latitude":55.7,"longitude":37.6}},
+                      {"coordinates":{"latitude":999,"longitude":37.6},"externalId":{"storeCode":"bad-lat"}},
+                      {"coordinates":{"latitude":55.7,"longitude":"unknown"},"externalId":{"storeCode":"bad-lon"}},
+                      {"coordinates":{"latitude":55.7,"longitude":37.6},"externalId":{"storeCode":"   "}},
+                      null,
+                      42
+                    ]
+                  }
+                }
+                """);
+
+        assertThat(result.candidates()).isEmpty();
+        assertThat(result.conflictingStoreEvidence()).isFalse();
+    }
+
+    @Test
+    void deduplicatesEquivalentRepeatedStoreEvidence() {
+        var result = MagnitStoreSearchResponseParser.parse("""
+                {"items":{"items":[
+                  {"coordinates":{"latitude":45.067057,"longitude":38.973527},"externalId":{"storeCode":"992301"}},
+                  {"coordinates":{"latitude":45.067057,"longitude":38.973527},"externalId":{"storeCode":"992301"}}
+                ]}}
+                """);
+
+        assertThat(result.candidates()).containsExactly(
+                new MagnitStoreCandidate("992301", new MagnitGeoPoint(45.067057, 38.973527)));
+        assertThat(result.conflictingStoreEvidence()).isFalse();
+    }
+
+    @Test
+    void failsClosedWhenOneStoreCodeHasConflictingCoordinates() {
+        var result = MagnitStoreSearchResponseParser.parse("""
+                {"items":{"items":[
+                  {"coordinates":{"latitude":45.067057,"longitude":38.973527},"externalId":{"storeCode":"992301"}},
+                  {"coordinates":{"latitude":45.067100,"longitude":38.973527},"externalId":{"storeCode":"992301"}}
+                ]}}
+                """);
+
+        assertThat(result.candidates()).isEmpty();
+        assertThat(result.conflictingStoreEvidence()).isTrue();
+    }
+
+    @Test
+    void malformedOrStructurallyUnexpectedJsonCreatesNoStoreEvidence() {
+        for (var payload : new String[] {
+            "not-json",
+            "{}",
+            "{\"items\":null}",
+            "{\"items\":{\"items\":{\"storeCode\":\"992301\"}}}"
+        }) {
+            var result = MagnitStoreSearchResponseParser.parse(payload);
+            assertThat(result.candidates()).as(payload).isEmpty();
+            assertThat(result.conflictingStoreEvidence()).as(payload).isFalse();
+        }
+    }
+}

--- a/docs/integrations/magnit-shopcode-resolution-2026-08-12.md
+++ b/docs/integrations/magnit-shopcode-resolution-2026-08-12.md
@@ -1,0 +1,148 @@
+# Magnit public `shopCode` resolution evidence — 2026-08-12
+
+Status: M1 technical evidence for issue #69; **not recurring production-access authorization**.
+
+## Objective
+
+Prove whether ordinary public Magnit surfaces can map a geographic store-search context to stable public `shopCode` values without private APIs, borrowed sessions, anti-bot workarounds, hidden credentials, precise-address fixtures or browser-only state.
+
+## Public first-party surface
+
+The ordinary public page `https://magnit.ru/shops` loads successfully without authentication and exposes store-search state. Clean browser observation showed first-party requests to:
+
+- `POST /webgate/v1/stores-facade/search`;
+- `POST /webgate/v1/stores-facade/search/detail`.
+
+The search response contains public store identity and coordinates. The exact proven candidate path is:
+
+- `items.items[].externalId.storeCode`;
+- `items.items[].coordinates.latitude`;
+- `items.items[].coordinates.longitude`.
+
+Addresses/names are not required by the resolution contract and are not retained by the production-domain parser.
+
+## Proven request contract
+
+The public page sends a geographic bounding-box search:
+
+```json
+{
+  "filters": {
+    "geo": {
+      "typeName": "box",
+      "leftTopPoint": {"latitude": 45.069, "longitude": 38.967},
+      "rightBottomPoint": {"latitude": 45.065, "longitude": 38.980}
+    },
+    "storeTypeListV2": [
+      "MM", "GM", "DG", "MO", "ME", "MC", "DARKSTORE", "MM_MINI", "ZARYAD"
+    ]
+  }
+}
+```
+
+Browser observation exposed optional public app headers, but direct reproduction proved they are unnecessary for this search contract.
+
+## Clean stateless reproduction
+
+A one-shot Node probe called the public search endpoint directly using only:
+
+- `Accept: application/json`;
+- `Content-Type: application/json`;
+- a descriptive User-Agent;
+- no Authorization;
+- no Magnit app/version headers;
+- no supplied cookies;
+- no cookie jar.
+
+### Known bbox
+
+The exact coarse bbox observed from the public `/shops` page was requested twice independently.
+
+Result:
+
+- HTTP 200 both times;
+- `Set-Cookie` absent both times;
+- one candidate each time;
+- identical candidate set;
+- public `shopCode=992301` both times;
+- candidate coordinates matched the observed public store context.
+
+This proves the store-search result is reproducible across clean stateless requests rather than depending on a borrowed browser session.
+
+### Broad-city ambiguity evidence
+
+Two coarse public city boxes were also queried:
+
+| Coarse box | HTTP | candidates | Example public codes |
+|---|---:|---:|---|
+| Moscow | 200 | 466 | `011830`, `019945`, `032005`, `043050`, `044800` |
+| Saint Petersburg | 200 | 652 | `012333`, `021945`, `022380`, `023463`, `023493` |
+
+The candidate sets were different.
+
+This is important product evidence: a location search commonly returns **many** stores. Therefore selecting the first result or inventing a nearest-store rule would be an unjustified semantic decision.
+
+## Text/address → coordinates investigation
+
+A safe text-geocoder contract was **not** proven.
+
+Clean public `/shops` sessions were tested with only public/coarse text, never a user's private address:
+
+- `Москва`;
+- `Москва, Красная площадь, 1`.
+
+Neither input produced a selectable address-autocomplete result or an attributable first-party address/geocoder request. Static Nuxt-bundle inspection also did not yield a safely reproducible text-address contract, and `GET /webgate/v1/address/search` without parameters returned a normal 404 rather than a useful validation schema.
+
+Decision: **do not invent or reverse-engineer an unproven locality/address → coordinates service.**
+
+## Accepted #69 technical boundary
+
+The implemented product-domain boundary accepts only the proven operation:
+
+`validated bbox → public Magnit store candidates → fail-closed resolution → provider-scoped fulfillment binding`
+
+Rules:
+
+- zero candidates → `NO_STORES`;
+- exactly one candidate → `RESOLVED`;
+- more than one candidate → `AMBIGUOUS`;
+- same `shopCode` with conflicting coordinates → `CONFLICTING_STORE_EVIDENCE`;
+- no implicit first/nearest/distance ranking;
+- explicit user/store choice may create a `MANUAL` binding.
+
+## Provider identity and privacy
+
+Existing Magnit provider identity is reused:
+
+- `sourceProviderId = "magnit-public-page"`;
+- `shopCode` becomes internal `LocationContext.fulfillmentContextId`;
+- `RESOLVED` and `MANUAL` reuse the existing `FulfillmentContextSelectionMode` boundary.
+
+`shopCode` is not added to `ProductLocation`, shopping-list items, basket items or product-facing reason text.
+
+The implementation does not retain public store address/name metadata. `MagnitStoreCandidate` contains only public `shopCode` and coordinates needed to interpret the candidate evidence.
+
+Coordinates are not added to `ProductLocation`; this slice therefore does not expand the user-location privacy surface.
+
+## Production-access boundary
+
+Issue #69 proves a reproducible technical location/store-context mechanism. It does **not** resolve issue #70.
+
+Until #70 is explicitly accepted:
+
+- no recurring Magnit polling is enabled;
+- no new production Spring/HTTP client is wired from comparison preview;
+- ordinary CI makes no live retailer calls;
+- live checks remain explicit guarded evidence only;
+- production comparison evidence remains fail-closed/no-op.
+
+## Acceptance path
+
+Before #69 is closed:
+
+1. deterministic request/parser/resolution/binding tests must pass;
+2. exact-head CI/security and independent review must pass;
+3. #86 must squash-merge and post-merge `main` CI must pass;
+4. a merged-main explicit guarded live check must repeat the known bbox twice and confirm stable public `992301` without auth/app headers/cookie jar.
+
+Only then may the project call Magnit location→provider-context technical resolution accepted. #70 remains independent.

--- a/docs/superpowers/plans/2026-08-12-magnit-shopcode-resolution.md
+++ b/docs/superpowers/plans/2026-08-12-magnit-shopcode-resolution.md
@@ -1,0 +1,114 @@
+# Magnit Public `shopCode` Resolution Implementation Plan
+
+Updated: 2026-08-12
+Issue: #69
+Design: `docs/superpowers/specs/2026-08-12-magnit-shopcode-resolution-design.md`
+Baseline: `main@25df1c018d30a9427231fd2f9f564fcb4b4ce1e4`
+Branch: `feat/magnit-shopcode-resolution`
+
+## Task 1 — RED: geographic/request contract
+
+Create tests before production code for:
+
+- valid `MagnitGeoPoint` and `MagnitGeoBoundingBox`;
+- invalid finite/range/order cases;
+- deterministic store-search request JSON;
+- exact `typeName=box`;
+- exact ordered store types `MM, GM, DG, MO, ME, MC, DARKSTORE, MM_MINI, ZARYAD`;
+- no address/user identifiers in request model.
+
+Run API verification and confirm RED is caused by missing new contract classes.
+
+## Task 2 — GREEN: geographic/request primitives
+
+Implement the smallest immutable provider-scoped types and Jackson request serialization data model. No HTTP/Spring client.
+
+Run focused tests and full API verification.
+
+## Task 3 — RED/GREEN: public response parsing
+
+Define parser tests for exact proven shape:
+
+`items.items[].externalId.storeCode + items.items[].coordinates.latitude/longitude`
+
+Cover:
+
+- one valid candidate;
+- missing/malformed code/coordinates ignored;
+- unrelated address/name metadata ignored;
+- equivalent duplicates deduplicate;
+- conflicting coordinates for one `shopCode` fail closed;
+- invalid coordinates cannot create evidence;
+- unknown fields ignored;
+- malformed JSON cannot create candidates.
+
+Implement parser with Jackson 3 tree model. No address fields are stored.
+
+## Task 4 — RED/GREEN: resolution semantics
+
+Test and implement deterministic order-independent resolution:
+
+- 0 candidates → `NO_STORES`;
+- 1 → `RESOLVED` carrying candidate;
+- >1 → `AMBIGUOUS` without implicit ranking;
+- conflicting parser evidence → `CONFLICTING_STORE_EVIDENCE`;
+- non-`RESOLVED` results cannot expose a chosen candidate.
+
+## Task 5 — RED/GREEN: provider-scoped fulfillment binding
+
+Test and implement a narrow Magnit binding factory:
+
+- reuse `sourceProviderId="magnit-public-page"`;
+- chosen `shopCode` becomes `LocationContext.fulfillmentContextId`;
+- caller locality is preserved;
+- automatic unique resolution → `RESOLVED` selection mode;
+- explicit manual candidate → `MANUAL` mode;
+- unresolved/ambiguous/conflicting results cannot auto-bind;
+- no mutation/extension of `ProductLocation`.
+
+## Task 6 — durable evidence/docs
+
+Record the finite #69 provenance:
+
+- public `/shops` surface;
+- stateless `POST /webgate/v1/stores-facade/search` contract;
+- exact known bbox twice → stable `992301` without auth/app headers/cookie jar;
+- Moscow/St Petersburg boxes → distinct large candidate sets, proving ambiguity is normal;
+- text/address → coordinates not proven and therefore not implemented;
+- #70 remains independent.
+
+Update `PROJECT_STATE`, `ROADMAP`, and `CHANGELOG` to actual implementation proof level only.
+
+## Task 7 — review / exact-head shipping
+
+Run all branch-protection CI/security workflows on the exact candidate head.
+
+Independent review must check:
+
+- no private/session-bound assumptions;
+- exact response identity path;
+- conflict handling;
+- coordinate validation;
+- no nearest/first selection;
+- no address retention/logging;
+- existing provider ID reuse;
+- no live network in ordinary CI or production runtime;
+- #70 remains unresolved.
+
+Fix P0/P1/P2 findings. Record non-blocking P3 follow-ups.
+
+Add docs-only shipping evidence, rerun final exact-head gate, mark PR ready, squash merge using expected head SHA, then verify post-merge `main` workflows.
+
+## Task 8 — merged-main guarded live acceptance
+
+Only after the deterministic slice is merged and post-merge CI is green, run an explicit guarded live probe against merged `main`:
+
+- same known public bbox twice;
+- minimal headers only;
+- no cookie jar;
+- HTTP 2xx;
+- stable same candidate set;
+- expected `shopCode=992301`;
+- sanitized output only.
+
+If this merged-main gate passes, issue #69 may be marked accepted/closed for **location-to-provider-context technical resolution**. This does not resolve #70 or enable recurring product acquisition.

--- a/docs/superpowers/plans/2026-08-13-magnit-shopcode-resolution-shipping.md
+++ b/docs/superpowers/plans/2026-08-13-magnit-shopcode-resolution-shipping.md
@@ -1,0 +1,62 @@
+# Magnit shopCode resolution shipping evidence
+
+Date: 2026-08-13
+PR: #86
+Issue: #69
+
+## Reviewed candidate
+
+- reviewed code SHA: `de2b97f0cab21487bc1d20c2ef0de94e8c33c14b`
+- scope: deterministic Magnit bbox request contract, sanitized store-candidate parser, fail-closed resolver and provider-scoped fulfillment binding
+- production HTTP activation: none
+- text/address geocoding: not implemented because no acceptable public contract was proven
+
+## Proof gate
+
+Exact reviewed SHA passed all nine PR workflow groups:
+
+- API CI — PASS
+- Contract CI — PASS
+- Web CI / responsive E2E — PASS
+- Retailer Bridge CI — PASS
+- Dependency Review — PASS
+- Container Security CI — PASS
+- CodeQL — PASS
+- Release Contract CI — PASS
+- Release Bundle CI — PASS
+
+The implementation additionally proved RED→GREEN checkpoints for geographic/request primitives, response parsing and resolution/binding semantics.
+
+## Change review
+
+Verdict: **Looks good**.
+
+- P0: none
+- P1: none
+- P2: none
+- P3: none blocking shipping
+- open review threads: none
+
+Review confirmed:
+
+- only the proven `items.items[].externalId.storeCode + coordinates` response shape participates;
+- address/name metadata is not retained by the domain model;
+- zero, many and conflicting candidates never create automatic bindings;
+- only exactly one candidate can create `RESOLVED`;
+- explicit selection creates `MANUAL` using the same provider identity;
+- `shopCode` remains internal `LocationContext.fulfillmentContextId`;
+- no provider-specific identifier enters shopping/basket/public comparison vocabulary;
+- direct request constructors cannot bypass bbox/store-type invariants;
+- no production/live Magnit traffic is introduced by this PR.
+
+## Shipping boundary
+
+#86 is ready to merge after the final docs-only exact-head gate.
+
+Merging #86 **does not yet close #69**. The issue acceptance contract requires a merged-main guarded live check that repeats the known public bbox twice and confirms stable `shopCode=992301` across a clean stateless boundary without auth/app headers or a cookie jar.
+
+#70 remains independent and unresolved; recurring production acquisition stays disabled.
+
+## Rollback
+
+The change is additive domain/contract code with no persistence migration and no production network activation. Rollback is a normal revert of the squash merge; existing explicit-store Magnit feasibility and production no-op evidence remain unaffected.

--- a/docs/superpowers/specs/2026-08-12-magnit-shopcode-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-12-magnit-shopcode-resolution-design.md
@@ -1,0 +1,201 @@
+# Magnit Public `shopCode` Resolution Design
+
+Updated: 2026-08-12
+Status: implementation direction
+Issue: #69
+Baseline: `main@25df1c018d30a9427231fd2f9f564fcb4b4ce1e4`
+
+## Context
+
+Magnit product-page feasibility already uses explicit public `shopCode` values. M1 needs a safe provider-scoped way to turn a location/store choice into that stable fulfillment-context identifier without leaking Magnit IDs into shopping/basket semantics and without inventing a private or session-bound mechanism.
+
+Finite public-surface research on `https://magnit.ru/shops` proved the following ordinary first-party mechanism:
+
+- public page requests `POST /webgate/v1/stores-facade/search`;
+- request body uses a geographic bounding box plus a fixed store-type list;
+- response items expose `coordinates { latitude, longitude }` and `externalId { owner, storeCode }`;
+- the exact browser-observed bbox was reproduced twice by plain Node `fetch` using only `Accept`, `Content-Type` and a User-Agent;
+- no auth headers, app headers, cookies or cookie jar were required;
+- the repeated known bbox returned the same store set containing `storeCode=992301`;
+- broad Moscow and Saint Petersburg boxes returned distinct non-empty store sets (466 and 652 candidates respectively).
+
+Text/locality/address → coordinates was **not** proven. Typing both `Москва` and the public landmark `Москва, Красная площадь, 1` in a clean public `/shops` session did not produce an address/geocoder request or selectable autocomplete result. Static/lazy-client exploration also did not yield a safely reproducible text-geocoder contract.
+
+Therefore this slice accepts the proven **bbox → store candidates** boundary and explicitly refuses to invent a hidden text geocoder.
+
+## Existing provider identity
+
+Existing Magnit evidence already uses:
+
+- retailer: `RetailerId.MAGNIT`;
+- source provider ID: `magnit-public-page`;
+- acquisition mode: `PUBLIC_WEB`;
+- fulfillment context IDs scoped to the selected public shop.
+
+The new code must reuse `magnit-public-page`; it must not introduce a second Magnit provider identity.
+
+## Goal
+
+Create deterministic production-domain primitives for:
+
+1. representing a validated Magnit geographic bbox;
+2. building the exact proven public store-search request body;
+3. parsing sanitized public store-search JSON into provider-scoped candidates;
+4. resolving only an unambiguous candidate set;
+5. converting an unambiguous or explicitly selected store into the existing `FulfillmentContextBinding` boundary.
+
+This slice deliberately stops before production live HTTP wiring. It proves the contract and selection semantics while #70 recurring production acquisition usage rights remains unresolved.
+
+## Non-goals
+
+- no text/address geocoder;
+- no new coordinates on `ProductLocation`;
+- no precise address persistence or logging;
+- no nearest-store ranking;
+- no first-candidate selection;
+- no distance/delivery-area heuristic;
+- no production Magnit HTTP client/Spring bean;
+- no comparison-preview live Magnit requests;
+- no scheduled/recurring polling;
+- no bypass of #70;
+- no provider IDs exposed through public shopping/basket/comparison vocabulary.
+
+## Public request contract
+
+The proven public endpoint accepts a POST body equivalent to:
+
+```json
+{
+  "filters": {
+    "geo": {
+      "typeName": "box",
+      "leftTopPoint": {"latitude": 45.069, "longitude": 38.967},
+      "rightBottomPoint": {"latitude": 45.065, "longitude": 38.980}
+    },
+    "storeTypeListV2": [
+      "MM", "GM", "DG", "MO", "ME", "MC", "DARKSTORE", "MM_MINI", "ZARYAD"
+    ]
+  }
+}
+```
+
+The store-type list and `typeName=box` are part of the deterministic provider contract. This class builds data only; it does not send a request.
+
+## Geographic model
+
+`MagnitGeoPoint`:
+
+- latitude finite and in `[-90, 90]`;
+- longitude finite and in `[-180, 180]`.
+
+`MagnitGeoBoundingBox`:
+
+- left-top latitude must be strictly greater than right-bottom latitude;
+- left-top longitude must be strictly less than right-bottom longitude;
+- degenerate or inverted boxes fail construction.
+
+Coordinates are provider-routing data for this specific operation. They are not added to `ProductLocation` and do not appear in default public comparison semantics.
+
+## Response contract
+
+Only exact proven response fields participate:
+
+- root `items.items` array;
+- each candidate item `externalId.storeCode` scalar string/number;
+- each candidate item `coordinates.latitude` and `coordinates.longitude` numeric/scalar-number values.
+
+Everything else, including address/name/city/metadata, is ignored by the parser.
+
+Malformed entries cannot create candidates.
+
+Candidate identity is `shopCode`. Equivalent duplicates (`same code + same canonical coordinates`) deduplicate. Reusing the same `shopCode` with conflicting coordinates causes the parse result to fail closed as `CONFLICTING_STORE_EVIDENCE` rather than arbitrarily choosing one record.
+
+## Resolution semantics
+
+`MagnitStoreResolution` is deterministic and order-independent:
+
+- zero valid candidates → `NO_STORES`;
+- exactly one unique valid candidate → `RESOLVED`;
+- more than one unique candidate → `AMBIGUOUS`;
+- conflicting duplicate identity evidence → `CONFLICTING_STORE_EVIDENCE`.
+
+Only `RESOLVED` carries a chosen store candidate.
+
+No distance-based ranking or implicit first element is permitted. Broad boxes returning hundreds of stores are expected to be `AMBIGUOUS` and require an explicit downstream/manual selection interaction.
+
+## Provider binding
+
+Provider-scoped binding uses the existing M1 location boundary:
+
+- `sourceProviderId = "magnit-public-page"`;
+- `fulfillmentContextId = shopCode`;
+- locality copied from the user's existing `ProductLocation`/caller context;
+- automatically unique candidate → `FulfillmentContextSelectionMode.RESOLVED`;
+- explicitly chosen validated shop code → `FulfillmentContextSelectionMode.MANUAL`.
+
+The binder never adds the shop code to `ProductLocation`, shopping-list data, basket items or product-facing comparison reason text.
+
+## Manual selection
+
+This slice provides a safe explicit binding factory for a manually chosen candidate/shop code. It does not build the UI yet.
+
+The product rule is:
+
+- auto-bind only `RESOLVED`;
+- `NO_STORES`, `AMBIGUOUS`, and `CONFLICTING_STORE_EVIDENCE` do not auto-bind;
+- a later/manual user selection may create a `MANUAL` provider binding.
+
+## Test contract
+
+Deterministic tests must prove:
+
+- valid bbox payload preserves exact proven store-type ordering and geometry;
+- invalid coordinates / degenerate boxes fail construction;
+- exact response item parses `externalId.storeCode` + coordinates;
+- address/name fields do not enter candidate state;
+- missing/malformed code or coordinates cannot create candidates;
+- equivalent duplicate entries deduplicate;
+- same code with conflicting coordinates fails closed;
+- parser ignores unrelated JSON fields;
+- zero → `NO_STORES`;
+- one → `RESOLVED`;
+- many → `AMBIGUOUS`, independent of response order;
+- automatic binding uses `magnit-public-page`, shopCode and `RESOLVED`;
+- manual binding uses the same provider ID/shopCode and `MANUAL`;
+- non-resolved results cannot produce automatic bindings;
+- precise-address content is not retained or exposed by these objects.
+
+## Live acceptance gate
+
+After deterministic implementation and normal CI pass, the guarded/live acceptance evidence may call only the proven public search endpoint and must remain explicit/manual.
+
+Before issue #69 is closed, merged-main live evidence should prove at minimum:
+
+1. the known public bbox twice;
+2. HTTP 2xx both times;
+3. no auth/app headers or cookie jar required;
+4. stable store set and expected public code `992301`;
+5. sanitized output only.
+
+Broad-city requests are useful ambiguity evidence but are not required for recurring acceptance runs.
+
+## Production/access boundary
+
+#69 proves location-context resolution mechanics, **not permission for recurring product acquisition**.
+
+#70 remains independent and unresolved. Therefore:
+
+- ordinary CI stays live-retailer-free;
+- production preview evidence remains no-op/fail-closed;
+- no scheduled Magnit polling is introduced;
+- the endpoint contract is not wired into automatic production traffic in this slice.
+
+## Exit criteria
+
+- deterministic request/response/resolution/binding tests pass;
+- no new Magnit provider identity is created;
+- no product-address geocoder is invented;
+- no provider IDs leak outside the existing internal provider/location boundary;
+- exact-head CI/security and independent review pass;
+- squash merge and post-merge `main` verification pass;
+- merged-main guarded live bbox proof passes before #69 is marked accepted/closed.


### PR DESCRIPTION
## Goal

Implement issue #69 as a deterministic provider-scoped Magnit location/store-resolution boundary based on the **proven public stateless bbox store-search contract**.

## Delivered

- validated `MagnitGeoPoint` / `MagnitGeoBoundingBox` primitives;
- exact public store-search request contract with fixed `typeName=box` and proven store-type ordering;
- sanitized parser for only `items.items[].externalId.storeCode + coordinates`;
- duplicate deduplication and explicit conflicting-identity evidence;
- deterministic fail-closed resolution:
  - 0 candidates → `NO_STORES`;
  - 1 → `RESOLVED`;
  - >1 → `AMBIGUOUS`;
  - conflicting duplicate identity → `CONFLICTING_STORE_EVIDENCE`;
- provider-scoped `FulfillmentContextBinding` using existing `sourceProviderId="magnit-public-page"` and internal `fulfillmentContextId=shopCode`;
- automatic binding only for `RESOLVED`; explicit choice uses `MANUAL`;
- direct-constructor hardening so callers cannot bypass bbox/store-type invariants;
- deterministic sanitized tests and durable public-surface evidence.

## Proven public mechanism

Finite research established ordinary first-party `POST /webgate/v1/stores-facade/search` with geographic bbox and response `storeCode + coordinates`.

The same known bbox was reproduced twice by clean stateless requests with no auth/app headers, supplied cookies or cookie jar and returned the same public `shopCode=992301`. Broad Moscow / Saint Petersburg boxes returned many distinct candidates, proving that nearest/first-candidate selection must not be invented.

Text/address → coordinates was **not** proven and is intentionally not implemented.

## Verification

Reviewed implementation SHA: `de2b97f0cab21487bc1d20c2ef0de94e8c33c14b`.

All 9 PR workflow groups passed on that exact SHA:
- API CI
- Contract CI
- Web CI / responsive E2E
- Retailer Bridge CI
- Dependency Review
- Container Security CI
- CodeQL
- Release Contract CI
- Release Bundle CI

Independent review verdict: **Looks good**; P0/P1/P2 none; open review threads none.

Final shipping marker: `docs/superpowers/plans/2026-08-13-magnit-shopcode-resolution-shipping.md`.

## Explicit non-goals / remaining gate

- no production Magnit HTTP client or Spring activation;
- no recurring polling;
- no hidden geocoder;
- no coordinates added to `ProductLocation`;
- no Magnit IDs leaked into shopping/basket/public comparison semantics;
- #70 production usage-rights remains unresolved.

**Merging #86 does not itself close #69.** The issue contract still requires one merged-main explicit guarded live proof that repeats the known bbox twice and confirms stable `992301` across a clean stateless boundary. That will be the immediate post-merge follow-up.