### PR TITLE
test(magnit): add merged-main shopCode live gate

### DIFF
--- a/.github/workflows/provider-live-probe-magnit-shopcode.yml
+++ b/.github/workflows/provider-live-probe-magnit-shopcode.yml
@@ -1,0 +1,132 @@
+name: Provider Live Probe - Magnit ShopCode
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: provider-live-probe-magnit-shopcode-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  magnit-shopcode:
+    name: Magnit ShopCode Location Gate
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 69 &&
+      github.actor == 'True-Ruslan' &&
+      github.event.comment.body == '/provider-probe magnit-shopcode'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out triggering main commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Magnit shopCode location gate
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=MagnitStoreSearchLiveProbeTest \
+            -Dzakup.live.magnit.shopcode=true \
+            test 2>&1 | tee "$RUNNER_TEMP/magnit-shopcode-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Magnit shopCode location gate' >> "$GITHUB_STEP_SUMMARY"
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/magnit-shopcode-live-probe.log" ]]; then
+            evidence="$(grep -F 'MAGNIT_SHOPCODE_LOCATION' "$RUNNER_TEMP/magnit-shopcode-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='MAGNIT_SHOPCODE_LOCATION no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            first_status="$(sed -n 's/.*first_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            first_candidates="$(sed -n 's/.*first_candidates=\([0-9]*\).*/\1/p' <<<"$evidence")"
+            first_has="$(sed -n 's/.*first_has_992301=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            second_status="$(sed -n 's/.*second_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            second_candidates="$(sed -n 's/.*second_candidates=\([0-9]*\).*/\1/p' <<<"$evidence")"
+            second_has="$(sed -n 's/.*second_has_992301=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            same_set="$(sed -n 's/.*same_candidate_set=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            conflicting="$(sed -n 's/.*conflicting_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            total_requests="$(sed -n 's/.*total_requests=\([0-9]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$first_status" =~ ^2[0-9][0-9]$ \
+               && "${first_candidates:-0}" -ge 1 \
+               && "$first_has" == 'true' \
+               && "$second_status" =~ ^2[0-9][0-9]$ \
+               && "${second_candidates:-0}" -ge 1 \
+               && "$second_has" == 'true' \
+               && "$same_set" == 'true' \
+               && "$conflicting" == 'false' \
+               && "$total_requests" == '2' ]]; then
+              state='success'
+              outcome='pass-stable-stateless-shopcode'
+            elif [[ ! "$first_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="first-${first_status:-unknown}"
+            elif [[ "$first_has" != 'true' ]]; then
+              outcome='first-992301-missing'
+            elif [[ ! "$second_status" =~ ^2[0-9][0-9]$ ]]; then
+              outcome="second-${second_status:-unknown}"
+            elif [[ "$second_has" != 'true' ]]; then
+              outcome='second-992301-missing'
+            elif [[ "$same_set" != 'true' ]]; then
+              outcome='candidate-set-drift'
+            elif [[ "$conflicting" != 'false' ]]; then
+              outcome='conflicting-store-evidence'
+            elif [[ "$total_requests" != '2' ]]; then
+              outcome='request-count-mismatch'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Magnit shopCode evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Magnit ShopCode / ${outcome}"
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${checked_out_sha}" \
+            -f state="$state" \
+            -f context="$context" \
+            -f description="$description" >/dev/null

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbe.java
@@ -1,0 +1,119 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import tools.jackson.databind.json.JsonMapper;
+
+final class MagnitStoreSearchLiveProbe {
+
+    private static final URI ENDPOINT = URI.create("https://magnit.ru/webgate/v1/stores-facade/search");
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
+    private static final String EXPECTED_SHOP_CODE = "992301";
+    private static final Map<String, String> REQUEST_HEADERS = Map.of(
+            "Accept", "application/json",
+            "Content-Type", "application/json");
+    private static final MagnitGeoBoundingBox KNOWN_PUBLIC_BOUNDING_BOX = new MagnitGeoBoundingBox(
+            new MagnitGeoPoint(45.069, 38.967),
+            new MagnitGeoPoint(45.065, 38.980));
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private final HttpClient httpClient;
+
+    private MagnitStoreSearchLiveProbe(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    static MagnitStoreSearchLiveProbe create() {
+        return new MagnitStoreSearchLiveProbe(HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    boolean hasCookieHandler() {
+        return httpClient.cookieHandler().isPresent();
+    }
+
+    Map<String, String> requestHeaders() {
+        return REQUEST_HEADERS;
+    }
+
+    LiveResult runKnownPublicBoundingBoxTwice() throws IOException, InterruptedException {
+        var requestBody = JSON.writeValueAsString(MagnitStoreSearchRequest.forBoundingBox(KNOWN_PUBLIC_BOUNDING_BOX));
+        var first = post(requestBody);
+        var second = post(requestBody);
+
+        var firstCodes = shopCodes(first.evidence());
+        var secondCodes = shopCodes(second.evidence());
+        return new LiveResult(
+                first.status(),
+                firstCodes.size(),
+                firstCodes.contains(EXPECTED_SHOP_CODE),
+                first.setCookiePresent(),
+                second.status(),
+                secondCodes.size(),
+                secondCodes.contains(EXPECTED_SHOP_CODE),
+                second.setCookiePresent(),
+                firstCodes.equals(secondCodes),
+                first.evidence().conflictingStoreEvidence() || second.evidence().conflictingStoreEvidence(),
+                2);
+    }
+
+    private Attempt post(String requestBody) throws IOException, InterruptedException {
+        var builder = HttpRequest.newBuilder(ENDPOINT)
+                .timeout(REQUEST_TIMEOUT)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8));
+        REQUEST_HEADERS.forEach(builder::header);
+        var response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        return new Attempt(
+                response.statusCode(),
+                response.headers().firstValue("Set-Cookie").isPresent(),
+                MagnitStoreSearchResponseParser.parse(response.body()));
+    }
+
+    private static Set<String> shopCodes(MagnitStoreSearchEvidence evidence) {
+        var codes = new TreeSet<String>();
+        evidence.candidates().forEach(candidate -> codes.add(candidate.shopCode()));
+        return Set.copyOf(codes);
+    }
+
+    private record Attempt(int status, boolean setCookiePresent, MagnitStoreSearchEvidence evidence) {}
+
+    record LiveResult(
+            int firstStatus,
+            int firstCandidates,
+            boolean firstHas992301,
+            boolean firstSetCookie,
+            int secondStatus,
+            int secondCandidates,
+            boolean secondHas992301,
+            boolean secondSetCookie,
+            boolean sameCandidateSet,
+            boolean conflictingEvidence,
+            int totalRequests) {
+
+        String toEvidenceLine() {
+            return "MAGNIT_SHOPCODE_LOCATION"
+                    + " first_status=" + firstStatus
+                    + " first_candidates=" + firstCandidates
+                    + " first_has_992301=" + firstHas992301
+                    + " first_set_cookie=" + firstSetCookie
+                    + " second_status=" + secondStatus
+                    + " second_candidates=" + secondCandidates
+                    + " second_has_992301=" + secondHas992301
+                    + " second_set_cookie=" + secondSetCookie
+                    + " same_candidate_set=" + sameCandidateSet
+                    + " conflicting_evidence=" + conflictingEvidence
+                    + " total_requests=" + totalRequests;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbe.java
@@ -35,12 +35,20 @@ final class MagnitStoreSearchLiveProbe {
     static MagnitStoreSearchLiveProbe create() {
         return new MagnitStoreSearchLiveProbe(HttpClient.newBuilder()
                 .connectTimeout(CONNECT_TIMEOUT)
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build());
     }
 
     boolean hasCookieHandler() {
         return httpClient.cookieHandler().isPresent();
+    }
+
+    boolean hasAuthenticator() {
+        return httpClient.authenticator().isPresent();
+    }
+
+    boolean followsRedirects() {
+        return httpClient.followRedirects() != HttpClient.Redirect.NEVER;
     }
 
     Map<String, String> requestHeaders() {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbeTest.java
@@ -1,0 +1,78 @@
+package io.github.trueruslan.zakupgotov.provider.magnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class MagnitStoreSearchLiveProbeTest {
+
+    @Test
+    void liveRequestBoundaryUsesNoSessionOrApplicationCredentials() {
+        var probe = MagnitStoreSearchLiveProbe.create();
+
+        assertThat(probe.hasCookieHandler()).isFalse();
+        assertThat(probe.requestHeaders().keySet())
+                .doesNotContainAnyElementsOf(Set.of(
+                        "Cookie",
+                        "Authorization",
+                        "X-Api-Key",
+                        "X-Auth-Token",
+                        "x-client-name",
+                        "x-device-platform",
+                        "x-new-magnit"));
+        assertThat(probe.requestHeaders()).containsOnlyKeys("Accept", "Content-Type");
+    }
+
+    @Test
+    void sanitizedEvidenceContainsOnlyStatusesCountsAndBooleans() {
+        var result = new MagnitStoreSearchLiveProbe.LiveResult(
+                200,
+                1,
+                true,
+                false,
+                200,
+                1,
+                true,
+                false,
+                true,
+                false,
+                2);
+
+        assertThat(result.toEvidenceLine())
+                .isEqualTo("MAGNIT_SHOPCODE_LOCATION"
+                        + " first_status=200"
+                        + " first_candidates=1"
+                        + " first_has_992301=true"
+                        + " first_set_cookie=false"
+                        + " second_status=200"
+                        + " second_candidates=1"
+                        + " second_has_992301=true"
+                        + " second_set_cookie=false"
+                        + " same_candidate_set=true"
+                        + " conflicting_evidence=false"
+                        + " total_requests=2")
+                .doesNotContain("address")
+                .doesNotContain("latitude")
+                .doesNotContain("longitude")
+                .doesNotContain("cookie_value")
+                .doesNotContain("token");
+    }
+
+    @Test
+    void mergedMainLiveGateRunsOnlyWhenExplicitlyEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("zakup.live.magnit.shopcode"));
+
+        var result = MagnitStoreSearchLiveProbe.create().runKnownPublicBoundingBoxTwice();
+        System.out.println(result.toEvidenceLine());
+
+        assertThat(result.totalRequests()).isEqualTo(2);
+        assertThat(result.firstStatus()).isBetween(200, 299);
+        assertThat(result.secondStatus()).isBetween(200, 299);
+        assertThat(result.firstHas992301()).isTrue();
+        assertThat(result.secondHas992301()).isTrue();
+        assertThat(result.sameCandidateSet()).isTrue();
+        assertThat(result.conflictingEvidence()).isFalse();
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/magnit/MagnitStoreSearchLiveProbeTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.Test;
 class MagnitStoreSearchLiveProbeTest {
 
     @Test
-    void liveRequestBoundaryUsesNoSessionOrApplicationCredentials() {
+    void liveRequestBoundaryUsesNoSessionRedirectOrApplicationCredentials() {
         var probe = MagnitStoreSearchLiveProbe.create();
 
         assertThat(probe.hasCookieHandler()).isFalse();
+        assertThat(probe.hasAuthenticator()).isFalse();
+        assertThat(probe.followsRedirects()).isFalse();
         assertThat(probe.requestHeaders().keySet())
                 .doesNotContainAnyElementsOf(Set.of(
                         "Cookie",

--- a/docs/superpowers/plans/2026-08-13-magnit-shopcode-live-gate-shipping.md
+++ b/docs/superpowers/plans/2026-08-13-magnit-shopcode-live-gate-shipping.md
@@ -1,0 +1,72 @@
+# Magnit shopCode merged-main live gate shipping evidence
+
+Date: 2026-08-13
+PR: #87
+Issue: #69
+
+## Reviewed candidate
+
+- reviewed implementation SHA: `b434fb1ff7006ebf036605275ab5fdf6115cccf8`
+- scope: test-only live probe plus an explicit issue-comment workflow
+- production runtime HTTP activation: none
+- schedules: none
+
+## TDD proof
+
+1. RED: the first contract failed only because `MagnitStoreSearchLiveProbe` did not exist.
+2. GREEN: the test-only probe compiled and the complete API verification passed with live networking skipped by default.
+3. Hardening RED: no-auth/no-redirect tests failed only because `hasAuthenticator()` and `followsRedirects()` did not exist.
+4. Hardening GREEN: the client now uses `Redirect.NEVER`, has no `Authenticator` and no `CookieHandler`; full API verification passed.
+
+## Exact-head CI
+
+All nine PR workflow groups passed on the reviewed implementation SHA:
+
+- API CI — PASS
+- Contract CI — PASS
+- Web CI / responsive E2E — PASS
+- Retailer Bridge CI — PASS
+- Dependency Review — PASS
+- Container Security CI — PASS
+- CodeQL Java + JavaScript/TypeScript — PASS
+- Release Contract CI — PASS
+- Release Bundle CI — PASS
+
+## Change review
+
+Verdict: **Looks good**.
+
+- P0: none
+- P1: none
+- P2: none
+- blocking P3: none
+- open review threads: none
+
+Review confirmed:
+
+- the live probe is under `src/test` and cannot activate production traffic;
+- ordinary CI never performs the network requests because the live test requires `zakup.live.magnit.shopcode=true`;
+- the workflow can run only for issue #69, actor `True-Ruslan`, exact command `/provider-probe magnit-shopcode`;
+- the request uses the accepted production `MagnitStoreSearchRequest` contract;
+- response interpretation uses the accepted production `MagnitStoreSearchResponseParser`;
+- the client supplies no cookie jar, authenticator or Magnit app/auth headers and does not follow redirects;
+- only statuses, candidate counts, booleans and request count are emitted as evidence;
+- raw response bodies, addresses, coordinates, cookie values and tokens are never written to evidence;
+- exactly two requests are required;
+- both attempts must be 2xx, contain public `shopCode=992301`, have identical candidate-code sets and contain no conflicting evidence.
+
+## Issue-state correction
+
+#69 was automatically closed when #86 merged even though its acceptance criteria require a merged-main live gate. It was reopened before shipping #87 and must remain open until the post-merge live workflow passes.
+
+## Shipping boundary
+
+#87 is ready to merge after the final docs-only exact-head gate.
+
+The merge itself is not acceptance of #69. After #87 is merged and `main` is green, the exact issue comment `/provider-probe magnit-shopcode` must trigger the default-branch workflow. Only a successful merged-main run satisfies the final `LOCATION_RESOLUTION` gate.
+
+#70 remains independent and unresolved. No recurring production acquisition is enabled by this change.
+
+## Rollback
+
+The PR is test/workflow-only. Rollback is a normal revert of the squash merge; production runtime behavior and existing explicit Magnit store contexts are unchanged.


### PR DESCRIPTION
## Goal

Finish issue #69 acceptance with an explicit guarded **merged-main** live gate for the accepted Magnit `bbox → shopCode` resolver.

## Delivered

- test-only `MagnitStoreSearchLiveProbe`;
- exactly two POST requests for the previously proven fixed public bbox;
- request body is serialized from production `MagnitStoreSearchRequest`;
- response is interpreted only through production `MagnitStoreSearchResponseParser`;
- known public `shopCode=992301` must appear in both attempts;
- candidate-code sets must be identical across the two clean requests;
- conflicting store evidence fails the gate;
- live client has no `CookieHandler`, no `Authenticator`, follows no redirects and sends no Magnit app/auth headers;
- evidence output contains only statuses, candidate counts, booleans and request count;
- no raw response body, address, coordinates, cookie values or tokens are logged;
- new issue-comment workflow runs only for issue #69, actor `True-Ruslan`, exact command `/provider-probe magnit-shopcode`;
- no schedule and no production runtime activation.

## TDD evidence

1. RED: missing `MagnitStoreSearchLiveProbe` produced only expected `cannot find symbol` failures.
2. GREEN: probe + workflow contract passed full API verification with the network test skipped by default.
3. Hardening RED: explicit no-auth/no-redirect assertions failed only on missing `hasAuthenticator()` / `followsRedirects()`.
4. Hardening GREEN: `HttpClient.Redirect.NEVER`, no authenticator/cookie handler, full API verification PASS.

## Important issue-state correction

#69 was automatically closed when #86 merged, even though its own acceptance contract says not to claim `LOCATION_RESOLUTION` before a merged-main live gate. It has been reopened and will remain open until the post-merge live command succeeds.

## Acceptance after merge

This PR still does **not** itself close #69. After merge and green `main`, the exact command below will be posted on #69:

`/provider-probe magnit-shopcode`

Only a successful default-branch workflow proving:
- both responses are 2xx;
- `992301` exists in both parsed candidate sets;
- candidate sets are identical;
- no conflicting evidence;
- exactly two requests;

will satisfy the final merged-main acceptance gate.

#70 remains independent and unresolved.