### PR TITLE
docs(m1): accept Magnit shopCode location resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,108 +1,100 @@
 # Changelog
 
-All notable project changes are recorded here. Zakup Gotov is pre-release; entries focus on user-visible behavior, architecture, security, integration evidence and release engineering rather than routine refactors.
+All notable project changes are recorded here. Zakup Gotov is pre-release; entries focus on user-visible behavior, architecture, security, retailer evidence and release engineering rather than routine refactors.
 
 ## [Unreleased]
 
 ### Added
 
+#### Product and shopping core
+
+- Canonical eight-retailer registry with independent technical-connectivity and production-access states.
+- Canonical shopping quantities and shopping-list aggregate with stable UUID identity and deterministic mutation semantics.
+- Provider/path orchestration preserving retailer, source-provider, acquisition-mode and fulfillment provenance.
+- Provider-neutral `ProductLocation`, sensitive-address redaction and typed provider-scoped fulfillment bindings.
+- Immutable offer snapshots with explicit observation/provider-freshness evidence and first-class `UNKNOWN` availability.
+- Deterministic exact-before-normalized product matching with explicit matched/ambiguous/unmatched states and no fuzzy/AI baseline.
+- Whole-package single-store basket calculation with explicit package evidence, deterministic decimal arithmetic and `COMPLETE / UNCERTAIN / INCOMPLETE` aggregate states.
+- Product-facing retailer comparison/readiness model that always preserves all canonical retailers and keeps provider/acquisition identifiers internal.
+- Stateless `POST /api/v1/comparison-previews` manual-list comparison API, synchronized OpenAPI/generated TypeScript client and responsive web journey.
+- Desktop/mobile Playwright critical-journey coverage for ready, uncertain, incomplete, unavailable, unmatched, ambiguous, package-unknown and unit-mismatch paths.
+
+#### Structured package evidence
+
+- Optional canonical package quantity on `ObservedOffer`, preserved through immutable `OfferSnapshot` and projected into `PackageQuantitySet` from snapshot evidence.
+- Runtime invariant rejecting a parallel package-evidence set when it disagrees with snapshots.
+- Regression coverage proving presentation names such as `970мл` or `1,5л` do not create package evidence.
+- Pure Magnit exact-characteristic semantics for `Вес, кг` / `Объем, л`, including explicit `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` states.
+- Magnit 20-product × 2-shop fixed-corpus package instrumentation that separates transport/identity failure from missing metadata.
+- SKU-bound Magnit JSON-LD package extraction from the same PUBLIC_WEB response using exact `Product.sku`, proven scalar `weight` and exact `additionalProperty[name="Объем, л"]` semantics.
+- Finite JSON-LD corpus evidence: 40/40 HTTP 2xx and usable observations, 20/20 stable identity, 36/40 `FOUND`, 0 `MISSING`, 4 explicit multi-dimensional ambiguities, 0 conflicts and 0 invalid values.
+- Diagnostic evidence identifying the four ambiguity observations as milk SKU `1000013732` and kefir SKU `1000330180` in both shop contexts; structured egg mass remains mass rather than count.
+
+#### Magnit location/store context
+
+- Deterministic public Magnit geographic primitives and exact `box` request contract for `POST /webgate/v1/stores-facade/search`.
+- Sanitized response parser accepting only `items.items[].externalId.storeCode + coordinates` and rejecting conflicting store identity evidence.
+- Fail-closed store resolution semantics: zero → `NO_STORES`, exactly one → `RESOLVED`, many → `AMBIGUOUS`, conflicting duplicate identity → `CONFLICTING_STORE_EVIDENCE`.
+- Provider-scoped Magnit fulfillment bindings reusing `sourceProviderId="magnit-public-page"`; `shopCode` remains internal `LocationContext.fulfillmentContextId`.
+- Explicit manual store selection using the same provider identity without introducing a first/nearest-store heuristic.
+- Test-only merged-main live gate for issue #69, runnable only by repository owner through exact issue command `/provider-probe magnit-shopcode` and never on a schedule.
+- Direct-stateless live client contract with no cookie jar, no authenticator, `Redirect.NEVER`, no Magnit application/auth headers and exactly two requests.
+- Merged-main LOCATION_RESOLUTION proof on SHA `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1`, workflow run `31642543544`:
+  - both responses HTTP 200;
+  - one candidate each;
+  - public `shopCode=992301` present both times;
+  - no response `Set-Cookie` in either attempt;
+  - identical candidate-code sets;
+  - no conflicting evidence;
+  - exactly two requests;
+  - focused tests 3/3 PASS and Maven `BUILD SUCCESS`.
+
+#### Retailer connectivity and engineering
+
 - Universal Retailer Connectivity design and evidence-driven acquisition-mode fallback policy.
 - Chromium MV3 retailer bridge with minimal permissions, sanitized local storage, deterministic fixtures and persistent-Chromium E2E.
 - Accepted first-party browser paths for Perekrestok v2 and Pyaterochka v1.
-- Magnit public-page Phase A/B probes and evidence establishing `AVAILABLE_PUBLIC_WEB` technical feasibility for explicit `shopCode` contexts.
-- M0 → M1 GO decision plus explicit Magnit location-resolution (#69) and production-usage-rights (#70) follow-ups.
-- M1 canonical retailer registry with separate technical coverage and production-access status.
-- M1 canonical quantities and shopping-list aggregate with stable UUID identity/order and explicit mutation semantics.
-- Provenance-complete `ObservedOffer`, deterministic provider-path orchestration and explicit expected path-failure handling.
-- Provider-neutral product location, redacted sensitive addresses and typed fulfillment-context bindings.
-- Immutable offer snapshots and freshness evidence separating observation time from optional provider-side update time.
-- Required observed `productName` evidence preserved through snapshots.
-- Deterministic exact-before-normalized product matching with explicit matched/ambiguous/unmatched states, retailer/context scoping and no fuzzy/AI baseline.
-- Explicit basket-layer package-quantity evidence keyed by `OfferSnapshotId`; absent evidence remains unknown instead of being guessed.
-- Whole-package selection using canonical quantities and exact decimal arithmetic, including ceiling package count, provided quantity and line total.
-- Single-store basket quote model with explicit per-item outcomes and `COMPLETE`, `UNCERTAIN`, `INCOMPLETE` aggregate states.
-- Basket architecture rule preventing production provider/shopping/matching/retailer modules from depending back on basket.
-- Durable basket design/plan in `docs/superpowers/specs/2026-08-12-m1-single-store-basket-design.md` and `docs/superpowers/plans/2026-08-12-m1-single-store-basket.md`.
-- Product-facing retailer comparison/readiness model that always preserves the eight canonical retailer entries and separates technical coverage, production access, runtime comparison state and product-safe failure reasons.
-- Conservative comparison freshness summary using the oldest selected observation and provider timestamps only when every selected line has trusted provider-side timestamp evidence.
-- `GET /api/v1/retailers` REST/OpenAPI contract plus synchronized generated TypeScript client path/types.
-- M1 web retailer-status surface with product-safe Russian labels, responsive semantic retailer cards and explicit service-unavailable behavior when the API cannot be reached.
-- Comparison architecture rule preventing retailer/provider/shopping/matching/basket/location production packages from depending back on the product read model.
-- Explicit web freshness evidence copy distinguishing observation-only evidence from a trusted provider-side update timestamp without inventing a stale/fresh verdict.
-- Stateless `POST /api/v1/comparison-previews` product boundary for locality-only manual shopping-list comparison.
-- Product-safe comparison preview response containing every canonical retailer and item-level resolution details without SKU, source-provider, acquisition-mode, source-reference or fulfillment-context identifiers.
-- Strict production `NoopComparisonRuntimeEvidenceSource` so the new preview journey fails closed and never falls back to fixture prices or hidden live retailer calls.
-- Deterministic test-only runtime evidence and browser mock API covering `READY`, `UNCERTAIN`, `INCOMPLETE`, `UNAVAILABLE`, unmatched, ambiguous, package-unknown and unit-mismatch cases.
-- Responsive M1 comparison form/results UI with repeatable shopping rows, typed quantities, accessible error states and a bounded server-side comparison timeout.
-- Desktop/mobile Playwright critical-journey coverage that submits a real product request shape, keeps all eight retailer results visible and verifies that internal provider identifiers do not leak.
-- Preview architecture guard preventing upstream shopping/location/provider/matching/basket/comparison/retailer production packages from depending back on `preview`, and preventing production preview code from depending on fixture/test-support namespaces.
-- Optional source-validated canonical package quantity on `ObservedOffer`, preserved unchanged through immutable `OfferSnapshot` creation.
-- Snapshot-driven `PackageQuantitySet.fromSnapshots(...)` projection that creates basket bindings only for explicit structured package evidence.
-- Runtime package-evidence derivation from snapshots so comparison fixtures and future provider paths carry one provenance-preserving source of package truth.
-- Regression coverage proving presentation names such as `Молоко 3,2%, 970мл` and `Вода 1,5л` do not create package evidence.
-- Pure Magnit source-specific `MagnitPackageQuantityExtractor` for exact visible `Характеристики` fields `Вес, кг` and `Объем, л`, with canonical kg→g and l→ml conversion.
-- Explicit Magnit package-extraction states `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` so source ambiguity never becomes a guessed basket quantity.
-- Magnit provider/snapshot regression proving a `FOUND` characteristic can populate #81 structured package evidence while multi-dimensional characteristics remain package-unknown.
-- Evidence note documenting official Magnit weight-only, volume-only, multi-dimensional and count-selector examples plus unchanged #69/#70 production gates.
-- Magnit fixed-corpus package-evidence instrumentation that classifies package extraction across the existing 20-product × 2-shop explicit/manual research corpus.
-- Structural `PackageEvidenceSummary` with `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES` and `INVALID_VALUE` counters whose sum must equal the eligible package-evidence page count.
-- Aggregate Magnit evidence-line counters for eligible package pages and each package-extraction status without logging HTML, page fragments or arbitrary provider data.
-- SKU-bound Magnit JSON-LD package extractor over the same raw PUBLIC_WEB response: exact JSON-LD `Product.sku`, scalar `Product.weight` as proven kilograms and exact `additionalProperty[name="Объем, л"]` as proven liters, without browser execution or another retailer request.
-- Deterministic JSON-LD regressions for foreign-SKU isolation, duplicate deduplication, conflicts, invalid values, multi-dimensional ambiguity, malformed JSON, script media-type boundaries and rejection of title/name/description/URL/count/generic-size heuristics.
-- Finite same-corpus JSON-LD evidence: 36/40 `FOUND`, 0 `MISSING`, 4 explicit `AMBIGUOUS_DIMENSIONS`, 0 conflicts, 0 invalid values, with 40/40 HTTP 2xx and usable observations and 20/20 stable product identity.
-- Sanitized one-shop diagnostic proving the four two-shop ambiguity observations are exactly milk SKU `1000013732` and kefir SKU `1000330180`; the other fixed requirements produce structured weight/volume evidence.
+- Magnit public-page Phase A/B evidence establishing `AVAILABLE_PUBLIC_WEB` technical feasibility.
+- M0 → M1 GO decision and explicit production-access/right-to-operate follow-up #70.
+- Architecture guards protecting basket/comparison/preview dependency direction and preventing production code from depending on fixtures/test support.
 
 ### Changed
 
 - Project phase advanced from M0 Product & Integration Discovery to **M1 Shopping Core** after satisfying technical exit criteria.
-- Retailer onboarding remains transport-neutral and universal; failed direct access changes the investigated acquisition mode rather than retailer scope.
-- Kuper remains provider/aggregator provenance rather than retailer identity.
-- Shopping text remains user wording; semantic normalization is isolated in matching.
-- `ObservedOffer` remains the provider trust boundary; `OfferSnapshot` remains the immutable comparison record.
+- Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
+- `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.
 - Matching never breaks semantic ambiguity using price, availability, freshness, acquisition mode or SKU ordering.
-- Package size/quantity is modeled as explicit structured evidence and is **not** inferred from `productName`, title, URL or other presentation text, nor assumed to be one unit per SKU.
-- Existing provider integrations remain source-compatible and package-unknown unless they explicitly supply a proven structured package quantity.
-- Runtime comparison package bindings now derive from immutable snapshot evidence instead of being independently injected downstream.
-- Deterministic comparison fixtures attach package quantity at the provider observation boundary before snapshotting, mirroring the production evidence flow without live retailer access.
-- Magnit structured package semantics accept only proven source fields; simultaneous dimensions or conflicting/invalid values remain unknown rather than using category/title/density heuristics.
-- Magnit `Количество в упаковке` remains deferred pending separate source and multi-dimensional domain evidence; structured egg mass is not treated as count.
-- Magnit fixed-corpus package metrics classify only HTTP 2xx observations with expected-SKU identity evidence, so transport failures and wrong-product pages cannot dilute metadata quality as false `MISSING` cases.
-- The guarded Magnit live corpus remains exactly 20 fixed products × 2 explicit shop contexts behind an explicit opt-in; finite research evidence does not authorize recurring production polling.
-- The first visible-text corpus result (`0 FOUND / 40 MISSING`) is now correctly treated as a visible-rendering blind spot: the same raw HTTP responses expose SKU-bound JSON-LD package metadata.
-- Magnit fixed-corpus package projection now consumes the SKU-bound JSON-LD extractor while preserving the existing price/promo/availability request and identity path.
-- Package arithmetic continues to require canonical unit equality, so structured mass/volume evidence cannot satisfy a `PIECE` requirement.
-- `UNKNOWN` availability propagates into `AVAILABILITY_UNKNOWN` line state and an `UNCERTAIN` basket rather than a confirmed complete basket.
-- Incomplete single-store baskets expose no aggregate total, preventing partial-price comparisons from masquerading as complete basket prices.
-- Technical retailer connectivity no longer leaks directly into the product/API contract: public readiness uses stable coverage/access/comparison states and finite product-safe reason codes instead of provider IDs, acquisition modes or source references.
-- The home page now makes the stateless comparison preview the primary M1 action instead of the previous readiness-only surface.
-- The critical browser journey is driven through the generated OpenAPI client and the same product-safe comparison vocabulary as the core/read model.
-- Production comparison evidence remains deliberately no-op/fail-closed; deterministic source extraction and corpus instrumentation do not activate recurring retailer polling.
-- Active Magnit engineering focus moves from package-source discovery to shipping #85, then location → public `shopCode` (#69), while production usage rights (#70) remain separately unresolved.
+- Package quantity is modeled only as explicit structured evidence; product names, URLs, slugs, category and other presentation text are non-authoritative.
+- Existing integrations remain package-unknown unless they provide a proven structured quantity.
+- Magnit visible-text corpus result `0 FOUND / 40 MISSING` is treated as a rendering blind spot because the same raw responses contain SKU-bound JSON-LD package metadata.
+- Magnit corpus projection now consumes the JSON-LD extractor without changing price/promo/availability request or identity semantics.
+- Package arithmetic requires canonical unit equality; mass/volume evidence cannot satisfy a `PIECE` requirement.
+- `UNKNOWN` availability propagates into an uncertain basket instead of confirmed availability.
+- Incomplete baskets expose no aggregate total and cannot masquerade as complete winners.
+- The home page now centers the stateless comparison journey rather than readiness-only status.
+- Production comparison evidence remains deliberately no-op/fail-closed; deterministic extraction and finite live research do not activate recurring retailer polling.
+- Magnit technical location resolution for the proven bbox/store-selection boundary is now **accepted (#69)** after deterministic #86, test/workflow #87 and merged-main live reproduction.
+- Automatic arbitrary text/address → coordinates remains intentionally unimplemented because no acceptable public contract was proven.
+- Active Magnit M1 focus moves to **#70 production usage/right-to-operate**. Technical feasibility and a public endpoint do not silently authorize recurring acquisition.
 
 ### Fixed
 
 - Provider offer validation rejects provenance/context mismatches before comparison logic.
 - Precise addresses are excluded from default string representations and provider routing.
 - Snapshot freshness rejects provider timestamps after observation time.
-- Semantic matching rejects cross-retailer/context candidate mixing.
-- Impossible matching result combinations fail closed at construction.
-- Package-quantity bindings validate null elements before immutable-copy construction, preserving deterministic diagnostic failures.
-- Duplicate package evidence for one snapshot fails closed.
-- Package selection rejects incompatible canonical units.
-- Mixed currencies across selected basket lines fail closed.
-- Incomplete basket states cannot carry a basket total by construction.
-- Product comparison evidence rejects cross-retailer or structurally impossible provider/basket combinations.
-- Public comparison views reject impossible status/coverage/access/total/freshness combinations instead of relying only on assembler correctness.
-- Comparison reason codes are constrained to the semantics of their status and coverage/access gate: uncertain availability, item-level incomplete causes, and one matching unavailable cause.
-- `RetailerFreshness` rejects basis/provider-timestamp contradictions and provider update timestamps after the observation time.
-- Incomplete/unavailable product comparison states cannot expose a misleading aggregate total or freshness summary.
-- Responsive Playwright coverage distinguishes product service-unavailable alerts from framework route announcements while preserving accessible alert semantics.
-- Critical-journey Playwright item-gap assertions are scoped to the relevant retailer card with exact text matching, avoiding collisions between item labels and explanatory retailer reason copy.
-- Runtime evidence rejects an explicit package-quantity set when it differs from the structured quantities preserved by its snapshots, preventing two package-evidence sources from silently diverging.
-- Magnit package extraction ignores title/slug/description/script/style numbers and fails closed on weight+volume or conflicting supported characteristics.
-- Magnit fixed-corpus package reporting excludes non-2xx and wrong-identity observations instead of misclassifying transport/identity failures as missing package metadata.
-- Magnit JSON-LD extraction ignores foreign Product nodes and unproven schema/presentation fields, preserving exact-SKU provenance through package evidence.
+- Semantic matching rejects cross-retailer/context candidate mixing and impossible result combinations.
+- Package bindings reject duplicate/invalid evidence and incompatible canonical units.
+- Mixed currencies fail closed.
+- Incomplete comparison states cannot expose misleading totals or freshness summaries.
+- Public comparison/readiness objects reject impossible coverage/access/status combinations.
+- Comparison preview rejects unknown JSON request fields instead of silently ignoring client-controlled data.
+- Browser E2E item-gap assertions are retailer-scoped to avoid copy collisions.
+- Magnit package extraction ignores foreign SKU nodes and unproven fields; conflicting/multi-dimensional values never become guessed quantities.
+- Magnit corpus metrics exclude non-2xx and wrong-identity pages rather than counting them as missing metadata.
+- Magnit store-search request constructors enforce the proven bbox/store-type invariants even when nested records are instantiated directly.
+- Magnit store response parsing deduplicates equivalent candidates and exposes conflicting identity evidence instead of choosing an arbitrary record.
+- Issue #69 was reopened after GitHub auto-closed it on #86 merge; it remained open until its own merged-main live acceptance contract was satisfied.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,189 +1,193 @@
 # Project State
 
-Updated: 2026-08-12
+Updated: 2026-08-13
 
 ## Project
 
-**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is to turn a recipe, meal plan, or grocery list into a location-aware comparison of complete baskets using current retailer price and availability observations.
+**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is to turn recipes, meal plans or a manual grocery list into a location-aware comparison of complete retailer baskets while preserving price/availability evidence, package semantics, provenance, freshness and uncertainty.
 
 Repository: `True-Ruslan/zakup-gotov`  
 Visibility: Public  
 Current phase: **M1 — Shopping Core**  
 M0 status: **technical discovery COMPLETE**  
 M0→M1 decision: **GO** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md)  
-Current focus: **ship #85 SKU-bound Magnit JSON-LD package evidence; then continue #69 location → `shopCode` without bypassing #70 production-access gating**
+Current focus: **resolve #70 Magnit production usage/right-to-operate policy, then perform final M1 acceptance and move to M2 Recipes**
 
-## Product connectivity invariant
+## Permanent connectivity rule
 
-Universal Retailer Connectivity remains permanent:
+Universal Retailer Connectivity remains mandatory:
 
-> Every retailer/banner in the target registry remains mandatory coverage work until at least one reproducible accepted acquisition path exists. A failed transport changes the acquisition mode under investigation; it does not remove the retailer from product scope.
+> Every retailer/banner in the target registry remains coverage work until at least one reproducible accepted acquisition path exists. A failed transport changes the acquisition mode under investigation; it does not remove the retailer from product scope.
 
-Accepted acquisition-mode families are supported/direct API, aggregator-backed observations, stable public web/API surfaces and user-assisted first-party browser bridge.
+Technical feasibility and production-access readiness are separate states.
 
-## M0 exit status
+## M0 exit status — COMPLETE
 
 | Gate | Status | Evidence |
 |---|---|---|
-| Pyaterochka accepted path | **PASS** | `AVAILABLE_BROWSER_BRIDGE`, adapter v1 |
-| Perekrestok accepted path | **PASS** | `AVAILABLE_BROWSER_BRIDGE`, adapter v2 |
-| Independent non-X5 path | **PASS** | Magnit `AVAILABLE_PUBLIC_WEB` for explicit public `shopCode` contexts |
-| Two acquisition modes | **PASS** | Browser bridge + ordinary public web |
-| Deterministic verification | **PASS** | sanitized fixtures/E2E + Magnit Phase B regressions |
+| Pyaterochka path | **PASS** | `AVAILABLE_BROWSER_BRIDGE`, adapter v1 |
+| Perekrestok path | **PASS** | `AVAILABLE_BROWSER_BRIDGE`, adapter v2 |
+| Independent non-X5 path | **PASS** | Magnit `AVAILABLE_PUBLIC_WEB` |
+| Two acquisition modes | **PASS** | Browser bridge + public web |
+| Deterministic verification | **PASS** | sanitized fixtures/E2E + finite live probes |
 | Retailer-neutral boundary | **PASS** | provider harness + canonical retailer registry |
 
-M0 completion is **technical feasibility**, not blanket production-data-access approval.
+M0 completion means technical feasibility, not blanket permission for recurring production acquisition.
 
 ## M1 delivered foundations
 
 1. **Retailer registry / coverage state — COMPLETE (#72)**  
-   Canonical retailer/banner identities, explicit technical coverage state, independent production-access status and registry completeness.
+   Canonical retailer identities with separate technical coverage and production-access status.
 
 2. **Shopping list / canonical quantities — COMPLETE (#73)**  
-   Stable UUID identity, explicit mutation semantics, positive quantities and canonical `kg → g`, `l → ml` conversion.
+   Stable UUID identity, explicit mutation semantics and canonical `kg → g`, `l → ml` conversion.
 
 3. **Provider/path orchestration — COMPLETE (#74)**  
-   Retailer/source-provider/acquisition-mode/fulfillment provenance, deterministic path priority and fail-closed validation.
+   Retailer/provider/acquisition-mode/fulfillment provenance with deterministic path priority and fail-closed validation.
 
 4. **Location / fulfillment context — COMPLETE (#75)**  
-   Provider-neutral location, sensitive-address redaction and typed provider-scoped fulfillment bindings.
+   Provider-neutral product location, sensitive-address redaction and provider-scoped fulfillment bindings.
 
 5. **Price / availability snapshots — COMPLETE (#76)**  
    Immutable snapshots, explicit freshness evidence and first-class `UNKNOWN` availability.
 
 6. **Deterministic product matching — COMPLETE (#77)**  
-   Exact-before-normalized matching, explicit matched/ambiguous/unmatched outcomes, retailer/context isolation and no fuzzy/AI baseline.
+   Exact-before-normalized matching with matched/ambiguous/unmatched outcomes and no fuzzy/AI baseline.
 
 7. **Single-store basket quote — COMPLETE (#78)**  
-   Explicit package evidence, whole-package arithmetic, per-item resolution states, `COMPLETE` / `UNCERTAIN` / `INCOMPLETE` basket states, no total for incomplete baskets and fail-closed mixed-currency behavior.
+   Whole-package arithmetic, explicit item states, `COMPLETE / UNCERTAIN / INCOMPLETE`, no total for incomplete baskets and fail-closed currency handling.
 
 8. **Failure / coverage / freshness product boundary — COMPLETE (#79)**  
-   All eight canonical retailers remain visible; technical coverage, production access, comparison status, product-safe reasons and freshness are separated. Provider IDs, acquisition modes, source references and precise addresses remain internal.
+   All eight canonical retailers remain visible; product-safe reasons are separated from internal provider/acquisition details.
 
 9. **Stateless critical comparison journey — COMPLETE / ACCEPTED (#80)**  
-   `POST /api/v1/comparison-previews`, locality-only public context, manual-list input, full deterministic comparison orchestration, generated client, responsive UI and desktop/mobile Playwright are merged. Production comparison evidence remains strict no-op/fail-closed.
+   `POST /api/v1/comparison-previews`, generated client, responsive web UI and desktop/mobile Playwright. Production evidence remains strict no-op/fail-closed.
 
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**  
-    Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`. `ObservedOffer` can carry optional canonical package quantity, snapshots preserve it, basket/runtime bindings derive from snapshots, and presentation text is explicitly non-authoritative. Full PR gate and post-merge `main` gate passed.
+    `ObservedOffer → OfferSnapshot → PackageQuantitySet` preserves only explicit structured package evidence. Presentation names are non-authoritative. Merged as `d8a9e5f0f67defeeac410e0a006eab57dc2bb637`.
 
-11. **Magnit structured visible-characteristic semantics — COMPLETE / ACCEPTED (#82)**  
-    Merged as `3753a9296562354939e86876a8096c15b2957e35`.
-    - pure `MagnitPackageQuantityExtractor`, no HTTP/Spring activation;
-    - exact visible `Характеристики` fields `Вес, кг` and `Объем, л` only;
-    - canonical kg→g and l→ml conversion;
-    - duplicate equivalent values deduplicated;
-    - weight + volume → `AMBIGUOUS_DIMENSIONS`;
-    - conflicting same-dimension values → `CONFLICTING_VALUES`;
-    - malformed/zero/negative values → `INVALID_VALUE`;
-    - title/slug/description/script/style/out-of-section numbers cannot create package evidence;
-    - `Количество в упаковке` deferred from v1.
+11. **Magnit exact characteristic semantics — COMPLETE / ACCEPTED (#82)**  
+    Pure fail-closed semantics for exact `Вес, кг` and `Объем, л`; simultaneous dimensions/conflicts/invalid values never become guessed quantities. Count remains deferred. Merged as `3753a9296562354939e86876a8096c15b2957e35`.
 
-    This slice remains useful as the accepted semantic rule set, but later live evidence showed that the fixed Magnit server-side product corpus does not render those fields reliably as visible text.
+12. **Magnit fixed-corpus instrumentation — COMPLETE / ACCEPTED (#83)**  
+    Existing 20-product × 2-shop corpus reports package extraction only for HTTP-2xx, expected-SKU observations. The initial visible-text result `FOUND=0 / MISSING=40` was correctly reclassified as a visible-rendering blind spot rather than absence of source metadata. Merged as `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6`.
 
-12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**  
-    Merged as `bee69a7bf84f1c2b98f20f76fe244d4bf3ade4a6` and passed the full post-merge `main` gate.
-    - reuses the explicit/manual 20-product × 2-shop Magnit research corpus;
-    - package statistics include only HTTP 2xx responses with expected-SKU identity evidence;
-    - non-2xx/error pages and wrong-identity pages are excluded rather than mislabeled `MISSING`;
-    - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
-    - status counts must sum exactly to `packageEvidencePages`;
-    - aggregate evidence contains counters rather than committed HTML/provider-page dumps;
-    - guarded live execution remains explicit/manual and ordinary CI remains live-retailer-free.
+13. **Magnit SKU-bound JSON-LD package evidence — COMPLETE / ACCEPTED (#85)**  
+    The same raw PUBLIC_WEB response is parsed without another retailer request or browser execution. Only exact JSON-LD `Product.sku`, proven scalar `weight` and exact `additionalProperty.name="Объем, л"` participate.
 
-    First accepted visible-text measurement: 40/40 eligible pages, `FOUND=0`, `MISSING=40`, no ambiguity/conflict/invalid status. This was subsequently reinterpreted correctly as a **visible-text extraction blind spot**, not absence of structured package metadata in the raw response.
-
-13. **Magnit SKU-bound JSON-LD package evidence — IMPLEMENTED / LIVE EVIDENCE PROVEN / SHIPPING (#85)**  
-    Current feature slice parses the **same raw PUBLIC_WEB response** without another retailer request or browser execution.
-    - only `<script type="application/ld+json">` bodies are parsed;
-    - only JSON-LD `Product` nodes with exact expected `sku` participate;
-    - scalar `Product.weight` is accepted as kilograms based on proven Magnit examples;
-    - exact `additionalProperty.name="Объем, л"` scalar values are accepted as liters;
-    - generic `volume`, `size`, title/name/description/URL/category and count-looking presentation data are ignored;
-    - malformed JSON-LD is not repaired heuristically;
-    - duplicate equivalent structured values deduplicate;
-    - recognized invalid values → `INVALID_VALUE`;
-    - conflicting same-dimension values → `CONFLICTING_VALUES`;
-    - simultaneous weight + volume → `AMBIGUOUS_DIMENSIONS`;
-    - output remains canonical `Quantity` evidence compatible with #81 snapshots/basket path.
-
-    Same fixed-corpus replay, still exactly 40 requests across shop contexts `139147` and `773577`:
-    - HTTP 2xx: 20/20 + 20/20;
-    - usable: 20/20 + 20/20;
-    - stable identity: 20/20;
-    - package pages: 40;
+    Accepted fixed-corpus replay:
+    - HTTP 2xx: 40/40;
+    - usable observations: 40/40;
+    - stable product identity: 20/20;
     - `FOUND=36`;
     - `MISSING=0`;
     - `AMBIGUOUS_DIMENSIONS=4`;
-    - `CONFLICTING_VALUES=0`;
-    - `INVALID_VALUE=0`;
-    - failed requirements: 0.
+    - conflicts: 0;
+    - invalid: 0.
 
-    A separate finite one-shop diagnostic identified the four cross-shop ambiguity observations as exactly two products in both contexts: milk SKU `1000013732` and kefir SKU `1000330180`. All other fixed requirements returned `FOUND`. Eggs yield structured mass evidence (`700 g`), **not count evidence**; basket arithmetic requires canonical unit compatibility and therefore cannot use that mass for a `PIECE` requirement.
+    The four ambiguity observations are milk SKU `1000013732` and kefir SKU `1000330180` in both shop contexts. Egg evidence is structured mass, not package count; mass cannot satisfy a `PIECE` requirement.
 
-    Design: [`superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`](superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md)  
-    Plan: [`superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md`](superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md)  
-    Evidence: [`integrations/magnit-jsonld-package-evidence-2026-08-12.md`](integrations/magnit-jsonld-package-evidence-2026-08-12.md)
+14. **Magnit deterministic bbox → `shopCode` boundary — COMPLETE / ACCEPTED (#86)**  
+    Merged as `c3d10c672b6b67e8f03cc17823041bc88cc9bdee` and passed the complete post-merge `main` gate.
 
-## Important M1 limitations
+    Proven first-party contract:
+    - `POST /webgate/v1/stores-facade/search`;
+    - geographic `box` request;
+    - response candidate path `items.items[].externalId.storeCode + coordinates`;
+    - existing provider identity `magnit-public-page`;
+    - `shopCode` stays internal `LocationContext.fulfillmentContextId`.
+
+    Resolution semantics:
+    - 0 candidates → `NO_STORES`;
+    - exactly 1 → `RESOLVED`;
+    - >1 → `AMBIGUOUS`;
+    - one code with conflicting coordinates → `CONFLICTING_STORE_EVIDENCE`;
+    - explicit store selection → `MANUAL`;
+    - no implicit first/nearest-store rule.
+
+15. **Magnit merged-main LOCATION_RESOLUTION live acceptance — COMPLETE / ACCEPTED (#87 / #69)**  
+    PR #87 merged as `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1`. Its ordinary `main` push baseline completed successfully before the owner-only live command was issued.
+
+    Merged-main workflow run `31642543544` checked out that exact SHA and executed exactly two direct stateless requests with:
+    - no cookie jar;
+    - no authenticator;
+    - `Redirect.NEVER`;
+    - no Magnit app/auth headers;
+    - production request serializer and response parser;
+    - sanitized evidence only.
+
+    Accepted evidence:
+
+    ```text
+    MAGNIT_SHOPCODE_LOCATION first_status=200 first_candidates=1 first_has_992301=true first_set_cookie=false second_status=200 second_candidates=1 second_has_992301=true second_set_cookie=false same_candidate_set=true conflicting_evidence=false total_requests=2
+    ```
+
+    The focused live test reported 3 tests, 0 failures, 0 errors and Maven `BUILD SUCCESS`.
+
+    Therefore **Magnit technical `LOCATION_RESOLUTION` is accepted for the proven bbox/store-selection boundary**. This does not prove arbitrary text/address → coordinates and does not authorize recurring production polling.
+
+## Magnit current status
+
+Technical path: **`AVAILABLE_PUBLIC_WEB`**.
+
+Accepted technical capabilities now include:
+
+- explicit public `shopCode` product observations;
+- SKU/current-price/promo evidence on the finite corpus;
+- SKU-bound JSON-LD weight/volume package evidence;
+- fail-closed bbox → store candidate resolution;
+- merged-main stateless reproduction of stable public `shopCode` evidence.
+
+Remaining Magnit blocker:
+
+- **#70 — production usage/right-to-operate decision is UNRESOLVED.**
+
+No production Spring/HTTP client is activated from comparison preview, and recurring polling remains disabled until #70 is explicitly accepted.
+
+## Important remaining M1 limitations
 
 - Production comparison evidence remains deliberately **no-op/fail-closed**. The critical journey proves product/API/core integration, not live production retailer acquisition.
-- Perekrestok and Pyaterochka accepted browser paths still do not prove a dedicated structured package field. Do not parse product names or widen browser permissions merely to obtain package size.
-- Magnit JSON-LD package evidence is strong on the measured fixed corpus but is **not universal-catalog proof** and is not production activation.
-- Magnit multi-dimensional milk/kefir observations remain explicitly unknown under the current single-`Quantity` package model; no density/category heuristic is permitted.
-- `Количество в упаковке` remains unproven in the accepted JSON-LD path and is deferred. Structured mass for eggs is not equivalent to count.
-- Magnit location/address → public `shopCode` resolution remains unresolved (#69).
-- Magnit recurring production acquisition usage rights remain unresolved (#70); recurring polling remains disabled until authoritative acceptance.
-- Browser-bridge persistent-session/store-change lifecycle hardening remains open (#54).
-- Kuper supported aggregator access remains open (#36).
-- Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer paths still require onboarding/hardening.
+- Magnit JSON-LD evidence is strong on the fixed corpus but is not universal-catalog proof.
+- Multi-dimensional milk/kefir package observations remain unknown under the current single-`Quantity` model; no density/category heuristic is permitted.
+- `Количество в упаковке` is still unproven; structured egg mass is not count evidence.
+- Text/locality/address → coordinates is not accepted; the proven Magnit resolution input is a validated bbox or explicit manual candidate selection.
+- **#70** recurring Magnit production acquisition rights remain unresolved.
+- **#54** browser-bridge persistent-session/store-change lifecycle hardening remains open.
+- **#36** Kuper supported aggregator access remains open.
+- Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and other mandatory retailer paths still require onboarding/hardening.
 - A successful real `v0.1.0-rc.3` GitHub Release proof remains outstanding.
-
-## Magnit status
-
-Technical path: **`AVAILABLE_PUBLIC_WEB` for explicit-store-context feasibility**.
-
-Package evidence now has two distinct evidence layers:
-
-1. accepted visible-characteristic semantics (#82), useful for deterministic source rules;
-2. SKU-bound JSON-LD extraction (#85), which matches the actual measured server-side public response far better.
-
-Measured #85 fixed-corpus distribution: **36/40 FOUND, 0/40 MISSING, 4/40 explicit multi-dimensional ambiguity** with no conflict/invalid cases.
-
-Constraints remain:
-- **#69** — automatic location/address → public `shopCode` resolution not proven;
-- **#70** — recurring production catalog acquisition usage rights `UNRESOLVED`.
 
 ## M1 invariants
 
-1. Core shopping/basket/comparison behavior is deterministic over supplied evidence.
-2. Every canonical retailer stays visible; unavailable retailers are never silently omitted.
-3. Technical connectivity and production-access readiness remain independent.
+1. Shopping/basket/comparison behavior is deterministic over supplied evidence.
+2. Every canonical retailer remains visible; unavailable retailers are never silently omitted.
+3. Technical connectivity and production-access readiness are independent.
 4. Precise addresses are sensitive and redacted by default.
-5. Retailer, source provider, acquisition mode and fulfillment context remain distinct internally and do not leak into public comparison semantics.
-6. `UNKNOWN` availability is never coerced to available/unavailable.
-7. Observation time is never misrepresented as provider freshness.
-8. Matching ambiguity never becomes a hidden winner and no fuzzy/AI tie-break is introduced implicitly.
-9. Package quantity is explicit structured evidence; missing evidence is never guessed from names, URLs, category or other presentation text.
-10. Package evidence attached to runtime basket calculation derives from immutable snapshot evidence.
-11. Source-specific extraction fails closed on conflicting or multi-dimensional fields unless a separate domain rule is explicitly proven.
-12. Corpus package metrics classify only transport-successful, identity-valid product pages.
-13. Structured package evidence must remain unit-compatible with the shopping requirement; mass, volume and count are not interchangeable.
-14. Incomplete baskets never expose a misleading complete-basket total.
-15. Production activation respects usage-rights state.
-16. Ordinary CI and browser acceptance make no live retailer requests.
-17. Production preview evidence fails closed rather than falling back to deterministic fixtures.
-18. Unknown public JSON request fields fail closed rather than being ignored.
-19. Universal retailer connectivity remains mandatory for every registry entry.
+5. Provider/acquisition/fulfillment identifiers remain internal and do not leak into public comparison semantics.
+6. `UNKNOWN` availability is never coerced.
+7. Observation time is not misrepresented as provider freshness.
+8. Matching ambiguity never becomes a hidden winner.
+9. Package quantity is explicit structured evidence and is never guessed from names/URLs/category/presentation text.
+10. Basket package bindings derive from immutable snapshot evidence.
+11. Source ambiguity/conflict remains fail-closed.
+12. Corpus quality metrics separate transport/identity failure from metadata absence.
+13. Mass, volume and count are not interchangeable.
+14. Incomplete baskets never expose misleading complete-basket totals.
+15. Production activation respects independent usage-rights status.
+16. Ordinary CI/browser acceptance makes no live retailer requests.
+17. Production preview evidence does not fall back to deterministic fixtures.
+18. Unknown JSON request fields fail closed.
+19. Universal retailer connectivity remains mandatory.
+20. A technically public endpoint is not treated as recurring-production authorization without an explicit #70-style policy decision.
 
 ## Immediate next work
 
-1. **Finish shipping #85** with exact-head CI/security and independent review; do not call it ACCEPTED until squash merge and post-merge `main` verification succeed.
-2. After #85 acceptance, prioritize **#69 Magnit location → public `shopCode`** as the highest-leverage implementable Magnit product blocker.
-3. Keep **#70 production usage-rights** as an independent mandatory decision; technical success must not silently authorize recurring acquisition.
-4. Keep multi-dimensional package-domain extension and `Количество в упаковке` evidence as separate work only when source/product evidence justifies it.
-5. Continue **#54** browser-bridge lifecycle hardening, **#36** Kuper supported-access investigation and mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding.
-6. Prove a successful real `v0.1.0-rc.3` release event.
-7. Move to **M2 Recipes** only after remaining M1 evidence/production constraints are explicitly accepted rather than hidden.
+1. **#70 — decide Magnit production usage/right-to-operate policy** from current authoritative first-party/legal/robots/terms evidence. Technical success must not silently authorize recurring acquisition.
+2. After #70, run a **final M1 acceptance pass** over shopping → location/fulfillment → evidence → snapshots → matching → basket → comparison, including failure/ambiguity/privacy/freshness invariants.
+3. Keep **#54** browser-bridge lifecycle hardening and **#36** Kuper supported-access investigation active in parallel.
+4. Continue mandatory Chizhik/Ozon Fresh/Samokat/Lenta/VkusVill onboarding without weakening retailer-neutral boundaries.
+5. Prove a successful real **`v0.1.0-rc.3` release event**.
+6. Once M1 constraints are explicitly accepted, begin **M2 Recipes** with `Recipe → normalized ingredients → ShoppingList` as the first vertical slice.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
-Updated: 2026-08-12
+Updated: 2026-08-13
 
-The roadmap is evidence-driven. Milestones may change when retailer integration feasibility or product usage contradicts current assumptions.
+The roadmap is evidence-driven. Milestones change when integration evidence, product behavior or production constraints contradict an earlier assumption.
 
 ## Product connectivity invariant
 
-Zakup Gotov targets **universal connectivity for the retailer registry**, not a permanently curated subset of easy integrations. Every retailer/banner added to the target registry remains mandatory coverage work until at least one reproducible acquisition path is available.
+Zakup Gotov targets **universal connectivity for the retailer registry**, not a permanently curated subset of easy integrations. Every retailer/banner remains mandatory coverage work until at least one reproducible acquisition path exists.
 
 Durable design: [`superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md`](superpowers/specs/2026-08-10-universal-retailer-connectivity-design.md).
 
@@ -14,128 +14,193 @@ Durable design: [`superpowers/specs/2026-08-10-universal-retailer-connectivity-d
 
 Decision: **GO to M1** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md).
 
-Exit evidence remains Perekrestok/Pyaterochka browser bridge, Magnit public web for explicit `shopCode`, two acquisition modes, deterministic sanitized verification and retailer-neutral architecture. M0 completion is technical feasibility, not production-access clearance; #54, #69 and #70 remain explicit constraints.
+Exit evidence remains Perekrestok/Pyaterochka browser bridge, Magnit public web, two acquisition modes, deterministic sanitized verification and retailer-neutral architecture. M0 is technical feasibility, not blanket production-access clearance.
 
 ## M1 — Shopping Core — CURRENT
 
 Goal: compare a manually entered grocery list across connected retailers while preserving explicit coverage, location/context, provenance, freshness, package evidence and uncertainty.
 
-### Entry rules
+### Permanent M1 rules
 
 - fixture/evidence-first core;
 - unavailable/blocked retailers remain visible;
 - exact addresses redacted by default;
-- retailer/source-provider/acquisition-mode/fulfillment context remain distinct;
-- `UNKNOWN` availability remains first-class;
+- retailer/provider/acquisition/fulfillment context remain distinct;
+- `UNKNOWN` availability is first-class;
 - observation time is not provider-update time;
-- package quantity is explicit structured evidence, never inferred from product names, slugs, category or presentation text;
-- source-specific extraction fails closed on ambiguity/conflict;
+- package quantity is structured evidence, never inferred from names/slugs/category/presentation text;
 - mass, volume and count are not interchangeable;
-- corpus quality metrics classify only transport-successful, identity-valid pages;
-- production activation respects usage-rights state;
-- ordinary M1 tests make no live retailer requests.
+- source ambiguity/conflict fails closed;
+- transport/identity failures are not counted as missing metadata;
+- ordinary CI makes no live retailer requests;
+- production activation is independently gated by right-to-operate/access policy.
 
-### Implementation sequence
+### Completed implementation sequence
 
-1. **Retailer registry + coverage-state model — COMPLETE (#72)**
-2. **Shopping-list aggregate + canonical quantities/units — COMPLETE (#73)**
-3. **Provider/path orchestration over deterministic fixtures — COMPLETE (#74)**
+1. **Retailer registry + coverage state — COMPLETE (#72)**
+2. **Shopping-list aggregate + canonical quantities — COMPLETE (#73)**
+3. **Provider/path orchestration — COMPLETE (#74)**
 4. **Location / fulfillment-context boundary — COMPLETE (#75)**
-5. **Price and availability snapshots — COMPLETE (#76)**
+5. **Price / availability snapshots — COMPLETE (#76)**
 6. **Deterministic product matching — COMPLETE (#77)**
-7. **Complete single-store basket comparison — COMPLETE (#78)**
-8. **Failure / coverage / freshness product + API + UX boundary — COMPLETE (#79)**
+7. **Single-store basket comparison — COMPLETE (#78)**
+8. **Failure / coverage / freshness product boundary — COMPLETE (#79)**
 9. **Critical product journey — COMPLETE / ACCEPTED (#80)**
-   - stateless manual-list comparison API and responsive web journey;
-   - all eight retailers remain visible with explicit comparison states;
-   - product-safe item gaps;
-   - production runtime evidence strict no-op/fail-closed;
-   - desktop/mobile deterministic Playwright without hidden live retailer access.
 10. **Structured package-evidence plumbing — COMPLETE / ACCEPTED (#81)**
-   - optional canonical `ObservedOffer.packageQuantity`;
-   - immutable snapshot preservation;
-   - snapshot-derived `PackageQuantitySet`;
-   - runtime rejects a parallel package set that disagrees with snapshots;
-   - title/presentation parsing explicitly prohibited and regression-tested.
-11. **Magnit visible exact-characteristic semantics — COMPLETE / ACCEPTED (#82)**
-   - pure exact-field semantics for `Вес, кг` / `Объем, л` inside visible `Характеристики`;
-   - canonical kg→g / l→ml;
-   - fail-closed ambiguity/conflict/invalid states;
-   - title/slug/description/script/style/out-of-section data cannot create evidence;
-   - count semantics deferred;
-   - no HTTP/Spring activation.
-12. **Magnit fixed-corpus package-evidence instrumentation — COMPLETE / ACCEPTED (#83)**
-   - existing explicit/manual 20-product × 2-shop corpus remains unchanged in request count and transport policy;
-   - package status metrics include only HTTP 2xx + expected-SKU observations;
-   - transport/error and wrong-identity pages are excluded rather than counted as `MISSING`;
-   - structural summary reports `FOUND`, `MISSING`, `AMBIGUOUS_DIMENSIONS`, `CONFLICTING_VALUES`, `INVALID_VALUE`;
-   - status counts equal `packageEvidencePages` exactly;
-   - ordinary CI remains live-retailer-free;
-   - first visible-text live measurement: `FOUND=0`, `MISSING=40`, with 40 eligible pages and no ambiguity/conflict/invalid values.
-13. **Magnit SKU-bound JSON-LD package evidence — IMPLEMENTED / LIVE EVIDENCE PROVEN / SHIPPING (#85)**
-   - same raw PUBLIC_WEB response, no extra retailer request and no browser execution;
-   - exact JSON-LD `Product` + exact expected `sku` identity;
-   - scalar `Product.weight` accepted as kilograms only because Magnit provenance was explicitly proven;
-   - exact `additionalProperty.name="Объем, л"` scalar value accepted as liters;
-   - generic fields and presentation text remain non-authoritative;
-   - duplicate equivalent values deduplicate;
-   - invalid/conflicting/multi-dimensional source evidence remains fail-closed;
-   - count remains deferred;
-   - corpus projection uses the JSON-LD extractor without changing price/promo/availability transport logic;
-   - deterministic extractor/corpus tests and full API verification are green;
-   - same finite 40-request replay produced `FOUND=36`, `MISSING=0`, `AMBIGUOUS_DIMENSIONS=4`, `CONFLICTING_VALUES=0`, `INVALID_VALUE=0`, failed requirements `0`;
-   - the four ambiguity observations are exactly milk SKU `1000013732` and kefir SKU `1000330180` in both shop contexts;
-   - all other fixed requirements are `FOUND` in the one-shop diagnostic;
-   - egg evidence is structured mass, not package count, and canonical unit mismatch prevents mass from satisfying `PIECE` requirements.
+11. **Magnit exact visible-characteristic semantics — COMPLETE / ACCEPTED (#82)**
+12. **Magnit fixed-corpus package instrumentation — COMPLETE / ACCEPTED (#83)**
+13. **Magnit SKU-bound JSON-LD package evidence — COMPLETE / ACCEPTED (#85)**
+14. **Magnit deterministic bbox → `shopCode` domain boundary — COMPLETE / ACCEPTED (#86)**
+15. **Magnit merged-main LOCATION_RESOLUTION live gate — COMPLETE / ACCEPTED (#87 / #69)**
 
-   Design: [`superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md`](superpowers/specs/2026-08-12-magnit-jsonld-package-evidence-design.md).  
-   Plan: [`superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md`](superpowers/plans/2026-08-12-magnit-jsonld-package-evidence.md).  
-   Evidence: [`integrations/magnit-jsonld-package-evidence-2026-08-12.md`](integrations/magnit-jsonld-package-evidence-2026-08-12.md).
+### Magnit evidence now accepted
 
-### Important remaining basket-data limitation
+#### Package evidence
 
-Magnit now has strong structured weight/volume coverage on the measured fixed corpus, but this is not universal-catalog proof. Products with both weight and volume remain unknown under the current single-`Quantity` model; count is deferred; other retailers still lack an accepted structured package field.
+The same raw PUBLIC_WEB response supplies exact-SKU JSON-LD package evidence without another retailer request or browser execution.
 
-Never replace this with product-name parsing or density/category guesses.
+Finite 20-product × 2-shop replay:
+
+- HTTP 2xx: 40/40;
+- usable: 40/40;
+- stable identity: 20/20;
+- `FOUND=36`;
+- `MISSING=0`;
+- `AMBIGUOUS_DIMENSIONS=4`;
+- conflicts: 0;
+- invalid: 0.
+
+Milk SKU `1000013732` and kefir SKU `1000330180` are deliberately ambiguous in both shop contexts because both weight and volume are present. Count remains unproven; structured egg mass is not count.
+
+#### Location/store context
+
+Accepted first-party surface:
+
+`POST /webgate/v1/stores-facade/search`
+
+Accepted product semantics:
+
+- validated bbox → public candidate set;
+- 0 candidates → `NO_STORES`;
+- 1 → `RESOLVED`;
+- >1 → `AMBIGUOUS`;
+- conflicting duplicate store identity → `CONFLICTING_STORE_EVIDENCE`;
+- explicit choice → `MANUAL`;
+- never pick first/nearest without a separately proven rule.
+
+PR #86 merged the deterministic domain boundary. PR #87 merged the guarded default-branch acceptance workflow.
+
+Merged-main run `31642543544` on SHA `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1` produced:
+
+```text
+MAGNIT_SHOPCODE_LOCATION first_status=200 first_candidates=1 first_has_992301=true first_set_cookie=false second_status=200 second_candidates=1 second_has_992301=true second_set_cookie=false same_candidate_set=true conflicting_evidence=false total_requests=2
+```
+
+Therefore issue #69's technical `LOCATION_RESOLUTION` requirement is satisfied for the proven bbox/store-selection boundary.
+
+Text/locality/address → coordinates remains intentionally unproven; no hidden geocoder is introduced.
+
+### Remaining M1 exit work
+
+#### 1. Magnit production usage/right-to-operate — **NEXT (#70)**
+
+Technical feasibility is no longer the blocker. The next mandatory decision is whether and under what constraints the public Magnit surfaces may be used for recurring production acquisition.
+
+The #70 decision must define one explicit operational state such as:
+
+- production enabled under documented constraints;
+- guarded/low-frequency/manual-only;
+- disabled pending explicit authorization;
+- another evidence-backed fail-closed mode.
+
+Until #70 is accepted:
+
+- no recurring Magnit polling;
+- no comparison-preview live Magnit HTTP client;
+- ordinary CI remains live-free;
+- production runtime evidence remains no-op/fail-closed.
+
+#### 2. Final M1 acceptance pass
+
+After #70, verify the complete vertical path:
+
+`ShoppingList → ProductLocation/FulfillmentContext → ProviderEvidence → OfferSnapshot → Matching → BasketQuote → RetailerComparison`
+
+Acceptance must cover:
+
+- complete/uncertain/incomplete/unavailable outcomes;
+- package unknown and unit mismatch;
+- ambiguous matching and ambiguous store selection;
+- freshness/provenance boundaries;
+- privacy and identifier non-leakage;
+- incomplete basket cannot become a winner;
+- no hidden fixture/live fallback.
+
+#### 3. Parallel connectivity/hardening
+
+Continue without blocking M2 unnecessarily:
+
+- **#54** browser-bridge persistent-session/store-change/SPA lifecycle;
+- **#36** Kuper supported aggregator investigation;
+- Chizhik, Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
+- retailer-specific structured package semantics only when source evidence proves them.
+
+#### 4. Release proof
+
+Publish and verify a successful real **`v0.1.0-rc.3`** GitHub Release event with final image promotion, SBOM/attestation and digest smoke evidence.
 
 ### M1 exit criteria
 
-- critical journey covered by automated integration/browser E2E;
-- incomplete/ambiguous/uncertain outcomes transparent;
-- deterministic explainable one-store quote totals;
-- unavailable retailer coverage explicit;
-- no hidden live retailer dependency in ordinary tests/product journey;
-- product location/privacy boundary preserved;
-- provenance/context/freshness survive internally without leaking implementation IDs;
-- package evidence remains structured source evidence through provider → snapshot → basket;
-- source-specific ambiguity/conflict never becomes a guessed quantity;
-- package dimensions remain unit-compatible and count is never inferred from mass/volume;
-- evidence-quality measurements separate transport/identity failure from missing metadata;
-- incomplete baskets cannot masquerade as complete winners;
-- production activation remains separately gated by access, location/context and source semantics.
+M1 exits only when:
 
-### Next M1 engineering focus
-
-1. **Ship #85** after exact-head CI/security and independent review; require post-merge `main` verification before calling it ACCEPTED.
-2. Then prioritize **Magnit location → `shopCode` (#69)** as the highest-leverage implementable blocker for converting explicit-store feasibility into location-aware product use.
-3. Keep **production usage-rights decision (#70)** independent and mandatory before recurring acquisition; technical feasibility is not authorization.
-4. Keep multi-dimensional package-domain extension and `Количество в упаковке` as separate evidence-driven work, not blockers for shipping current mass/volume support.
-5. **Browser bridge lifecycle hardening (#54)** for persistent sessions/store changes/SPA navigation.
-6. **Kuper supported aggregator investigation (#36)**.
-7. Continue Chizhik, Ozon Fresh, Samokat, Lenta, VkusVill and additional mandatory retailer onboarding.
-8. Prove a successful real `v0.1.0-rc.3` release event.
+- critical journey has automated API/integration/browser coverage;
+- incomplete/ambiguous/uncertain states are transparent;
+- one-store quote totals are deterministic and explainable;
+- all canonical retailers remain explicit in coverage;
+- package evidence remains source-structured through provider → snapshot → basket;
+- source ambiguity never becomes guessed quantity;
+- location/provider IDs remain provider-scoped;
+- incomplete baskets cannot masquerade as winners;
+- ordinary tests/product journey have no hidden live retailer dependency;
+- production activation states are explicit rather than implied by technical feasibility;
+- the remaining M1 production/access constraints have an accepted outcome.
 
 ## M2 — Recipes
 
 Goal: make recipes a first-class source of shopping requirements.
 
-Scope: built-in/user recipes, servings, normalized ingredient quantities, instructions, recipe → shopping-requirement conversion, editing/duplication and import experiments after the core model is stable.
+### First vertical slice
 
-Do not start M2 merely because fixture-driven M1 UI is complete. M1 evidence and production constraints must remain explicit and accepted rather than hidden.
+Start with:
+
+`Recipe → ingredients → canonical quantities → ShoppingList`
+
+Scope:
+
+- recipe identity/title;
+- servings;
+- ingredient name + explicit quantity/unit;
+- deterministic serving scaling;
+- canonical unit normalization using existing shopping quantity rules;
+- safe merging of compatible repeated ingredients;
+- provenance from shopping requirement back to recipe/ingredient;
+- recipe → ShoppingList conversion;
+- API/OpenAPI/generated-client boundary;
+- minimal responsive flow: create recipe → adjust servings → generate list → compare.
+
+Non-goals for the first slice:
+
+- AI recipe parsing;
+- arbitrary web import;
+- nutritional optimization;
+- fuzzy ingredient equivalence;
+- pantry prediction.
+
+Those can follow once the deterministic recipe model is accepted.
 
 ## M3 — Weekly Planning
 
-Goal: generate one coherent shopping-requirement set from several meals.
+Goal: combine several meals into one coherent shopping-requirement set.
 
 Scope: weekly planner, safe duplicate merging/unit conversion, pantry/exclusion controls and shopping-list review before comparison.
 
@@ -143,16 +208,16 @@ Scope: weekly planner, safe duplicate merging/unit conversion, pantry/exclusion 
 
 Goal: optimize real checkout cost rather than naive SKU sums.
 
-Scope: richer package-size/substitute optimization, fees, minimum orders, single-store convenience, future multi-store lowest-total-cost mode and confidence/freshness penalties.
+Scope: richer package/substitute optimization, fees, minimum orders, single-store convenience, future multi-store lowest-total-cost mode and confidence/freshness penalties.
 
 ## M5 — Productization
 
-Goal: reliable repeat-use product with privacy-aware accounts/preferences, analytics abstraction, feature flags, provider health monitoring and production provider activation only after access constraints are resolved.
+Goal: reliable repeat use with privacy-aware accounts/preferences, analytics abstraction, feature flags, provider health monitoring and production provider activation only after access constraints are resolved.
 
 ## M6 — Native Mobile
 
-Goal: native Android/iOS clients via Expo/React Native/TypeScript using generated API clients and shared product vocabulary/design tokens.
+Goal: Android/iOS clients using the shared API vocabulary and generated client contracts after the web/core product is stable.
 
 ## Guiding rule
 
-Do not add infrastructure or data semantics because they are convenient. Add them only when evidence makes the behavior correct, explainable and worth the operational cost.
+Do not add infrastructure or semantics because they are convenient. Add them only when evidence makes the behavior correct, explainable and worth the operational cost.

--- a/docs/integrations/magnit-shopcode-resolution-2026-08-12.md
+++ b/docs/integrations/magnit-shopcode-resolution-2026-08-12.md
@@ -1,6 +1,6 @@
-# Magnit public `shopCode` resolution evidence — 2026-08-12
+# Magnit public `shopCode` resolution evidence — 2026-08-12/13
 
-Status: M1 technical evidence for issue #69; **not recurring production-access authorization**.
+Status: **M1 technical LOCATION_RESOLUTION accepted for issue #69**. This is **not recurring production-access authorization**; issue #70 remains independent.
 
 ## Objective
 
@@ -8,12 +8,12 @@ Prove whether ordinary public Magnit surfaces can map a geographic store-search 
 
 ## Public first-party surface
 
-The ordinary public page `https://magnit.ru/shops` loads successfully without authentication and exposes store-search state. Clean browser observation showed first-party requests to:
+The ordinary public page `https://magnit.ru/shops` loads without authentication and exposes store-search state. Clean browser observation identified first-party requests to:
 
 - `POST /webgate/v1/stores-facade/search`;
 - `POST /webgate/v1/stores-facade/search/detail`.
 
-The search response contains public store identity and coordinates. The exact proven candidate path is:
+The accepted search-response candidate path is intentionally narrow:
 
 - `items.items[].externalId.storeCode`;
 - `items.items[].coordinates.latitude`;
@@ -40,64 +40,47 @@ The public page sends a geographic bounding-box search:
 }
 ```
 
-Browser observation exposed optional public app headers, but direct reproduction proved they are unnecessary for this search contract.
+Direct reproduction proved Magnit application/version headers are not required for this store-search contract.
 
-## Clean stateless reproduction
+## Clean stateless research reproduction
 
-A one-shot Node probe called the public search endpoint directly using only:
+The first finite research probe called the endpoint directly with ordinary JSON request headers and no Authorization, Magnit app/version headers, supplied cookies or cookie jar.
 
-- `Accept: application/json`;
-- `Content-Type: application/json`;
-- a descriptive User-Agent;
-- no Authorization;
-- no Magnit app/version headers;
-- no supplied cookies;
-- no cookie jar.
-
-### Known bbox
-
-The exact coarse bbox observed from the public `/shops` page was requested twice independently.
-
-Result:
+For the known coarse bbox, two independent requests produced:
 
 - HTTP 200 both times;
-- `Set-Cookie` absent both times;
+- no response `Set-Cookie` header in the accepted run;
 - one candidate each time;
-- identical candidate set;
-- public `shopCode=992301` both times;
-- candidate coordinates matched the observed public store context.
+- identical candidate sets;
+- public `shopCode=992301` both times.
 
-This proves the store-search result is reproducible across clean stateless requests rather than depending on a borrowed browser session.
-
-### Broad-city ambiguity evidence
-
-Two coarse public city boxes were also queried:
+Broad public city boxes also proved that automatic selection must fail closed when many stores exist:
 
 | Coarse box | HTTP | candidates | Example public codes |
 |---|---:|---:|---|
 | Moscow | 200 | 466 | `011830`, `019945`, `032005`, `043050`, `044800` |
 | Saint Petersburg | 200 | 652 | `012333`, `021945`, `022380`, `023463`, `023493` |
 
-The candidate sets were different.
-
-This is important product evidence: a location search commonly returns **many** stores. Therefore selecting the first result or inventing a nearest-store rule would be an unjustified semantic decision.
+A first/nearest-store rule is therefore not inferred from provider ordering.
 
 ## Text/address → coordinates investigation
 
 A safe text-geocoder contract was **not** proven.
 
-Clean public `/shops` sessions were tested with only public/coarse text, never a user's private address:
+Clean public `/shops` sessions were tested only with public/coarse text, never a user's private address:
 
 - `Москва`;
 - `Москва, Красная площадь, 1`.
 
-Neither input produced a selectable address-autocomplete result or an attributable first-party address/geocoder request. Static Nuxt-bundle inspection also did not yield a safely reproducible text-address contract, and `GET /webgate/v1/address/search` without parameters returned a normal 404 rather than a useful validation schema.
+Neither produced a safely reproducible text-address contract. Static public bundle inspection and a parameterless `/webgate/v1/address/search` probe also did not establish an acceptable contract.
 
 Decision: **do not invent or reverse-engineer an unproven locality/address → coordinates service.**
 
-## Accepted #69 technical boundary
+## Accepted deterministic product boundary — #86
 
-The implemented product-domain boundary accepts only the proven operation:
+PR #86 introduced only deterministic domain/contract behavior and did not activate production network traffic.
+
+Accepted operation:
 
 `validated bbox → public Magnit store candidates → fail-closed resolution → provider-scoped fulfillment binding`
 
@@ -110,39 +93,82 @@ Rules:
 - no implicit first/nearest/distance ranking;
 - explicit user/store choice may create a `MANUAL` binding.
 
-## Provider identity and privacy
-
-Existing Magnit provider identity is reused:
+Provider identity remains:
 
 - `sourceProviderId = "magnit-public-page"`;
-- `shopCode` becomes internal `LocationContext.fulfillmentContextId`;
-- `RESOLVED` and `MANUAL` reuse the existing `FulfillmentContextSelectionMode` boundary.
+- `shopCode` is internal `LocationContext.fulfillmentContextId`;
+- `RESOLVED` and `MANUAL` reuse `FulfillmentContextSelectionMode`.
 
-`shopCode` is not added to `ProductLocation`, shopping-list items, basket items or product-facing reason text.
+`shopCode` does not enter `ProductLocation`, shopping-list items, basket items or product-facing comparison reasons. Store address/name metadata is not retained. Coordinates remain provider evidence rather than an expansion of the public `ProductLocation` model.
 
-The implementation does not retain public store address/name metadata. `MagnitStoreCandidate` contains only public `shopCode` and coordinates needed to interpret the candidate evidence.
+PR #86 squash-merged as `c3d10c672b6b67e8f03cc17823041bc88cc9bdee` and passed its full post-merge `main` gate.
 
-Coordinates are not added to `ProductLocation`; this slice therefore does not expand the user-location privacy surface.
+## Merged-main live acceptance gate — #87
 
-## Production-access boundary
+Issue #69 explicitly required a **merged-main** live proof before the project could claim `LOCATION_RESOLUTION`.
 
-Issue #69 proves a reproducible technical location/store-context mechanism. It does **not** resolve issue #70.
+PR #87 added a test-only, owner-triggered issue-comment workflow. The production application remains network-no-op for Magnit. Ordinary CI does not run the live test.
+
+The live client is deliberately stricter than the initial research probe:
+
+- fresh `HttpClient`;
+- no `CookieHandler`;
+- no `Authenticator`;
+- `Redirect.NEVER`;
+- no Magnit app/version/auth headers;
+- request body comes from production `MagnitStoreSearchRequest`;
+- response interpretation comes from production `MagnitStoreSearchResponseParser`;
+- exactly two requests;
+- evidence output contains only statuses, candidate counts, booleans and request count.
+
+PR #87 squash-merged as `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1`. Its merged-main push baseline completed successfully before the live command was issued.
+
+The exact owner-only command `/provider-probe magnit-shopcode` was then posted to issue #69.
+
+GitHub Actions run: `31642543544`  
+Workflow: `Provider Live Probe - Magnit ShopCode`  
+Checked-out SHA: `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1`
+
+Sanitized evidence:
+
+```text
+MAGNIT_SHOPCODE_LOCATION first_status=200 first_candidates=1 first_has_992301=true first_set_cookie=false second_status=200 second_candidates=1 second_has_992301=true second_set_cookie=false same_candidate_set=true conflicting_evidence=false total_requests=2
+```
+
+The focused live test also reported:
+
+- tests run: 3;
+- failures: 0;
+- errors: 0;
+- skipped: 0;
+- Maven build: SUCCESS.
+
+This satisfies the final issue #69 acceptance requirement: the same explicit public store context is reproducible across a clean, direct, merged-main stateless boundary.
+
+## Accepted claim
+
+The project may now claim **Magnit technical `LOCATION_RESOLUTION` for the proven bbox/store-selection boundary**.
+
+This means:
+
+- a validated coarse geographic bbox can obtain public store candidates through the proven first-party surface;
+- an unambiguous single candidate may produce `RESOLVED` provider context;
+- ambiguous/empty/conflicting evidence remains fail-closed;
+- a user may explicitly select a candidate to create `MANUAL` context;
+- no user address geocoder, borrowed session or hidden credentials are required by the accepted mechanism.
+
+It does **not** mean arbitrary text/locality automatically becomes coordinates, nor that recurring product traffic is authorized.
+
+## Production-access boundary — #70
+
+Issue #70 remains unresolved and independent.
 
 Until #70 is explicitly accepted:
 
 - no recurring Magnit polling is enabled;
-- no new production Spring/HTTP client is wired from comparison preview;
+- no production Spring/HTTP client is wired from comparison preview;
 - ordinary CI makes no live retailer calls;
 - live checks remain explicit guarded evidence only;
 - production comparison evidence remains fail-closed/no-op.
 
-## Acceptance path
-
-Before #69 is closed:
-
-1. deterministic request/parser/resolution/binding tests must pass;
-2. exact-head CI/security and independent review must pass;
-3. #86 must squash-merge and post-merge `main` CI must pass;
-4. a merged-main explicit guarded live check must repeat the known bbox twice and confirm stable public `992301` without auth/app headers/cookie jar.
-
-Only then may the project call Magnit location→provider-context technical resolution accepted. #70 remains independent.
+Technical feasibility, package evidence and location resolution do not themselves grant a right to operate recurring acquisition in production.


### PR DESCRIPTION
## Goal

Synchronize durable project state after issue #69's merged-main Magnit LOCATION_RESOLUTION acceptance gate passed.

## Evidence recorded

- deterministic #86 boundary accepted on `main`;
- #87 merged-main test/workflow accepted;
- ordinary push baseline for `6ff8372c9e9e61b4c48c43d0d0c159fb65ffe7a1` completed successfully before live execution;
- owner-triggered run `31642543544` checked out that exact main SHA;
- sanitized live evidence:
  `first_status=200 first_candidates=1 first_has_992301=true first_set_cookie=false second_status=200 second_candidates=1 second_has_992301=true second_set_cookie=false same_candidate_set=true conflicting_evidence=false total_requests=2`;
- focused live tests: 3/3 PASS, Maven BUILD SUCCESS.

## Docs changed

- `docs/integrations/magnit-shopcode-resolution-2026-08-12.md` — records final merged-main acceptance and #70 boundary;
- `docs/PROJECT_STATE.md` — advances #85/#86/#87/#69 to accepted and moves current focus to #70;
- `docs/ROADMAP.md` — places #70 and final M1 acceptance ahead of M2 Recipes;
- `CHANGELOG.md` — records structured package/location evidence and accepted #69 outcome.

## Boundary

This PR is documentation-only. It does not enable Magnit production traffic, recurring polling or a hidden geocoder. #70 remains unresolved and is the next Magnit production decision.