### PR TITLE
feat(m2): add deterministic recipe domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 
 ### Added
 
+#### Recipes
+
+- Separate immutable `recipe` domain for M2.1 with UUID-backed recipe/ingredient identity, normalized titles, positive integer servings and ordered explicit ingredients.
+- Deterministic `Recipe → ShoppingList` conversion reusing accepted `ShoppingRequirement` and `Quantity` semantics instead of duplicating quantity/unit normalization.
+- Serving scaling that sums compatible canonical quantities before applying the serving ratio; terminating division remains exact and non-terminating ratios use deterministic `MathContext.DECIMAL128` without `double`/`float`.
+- Exact-safe ingredient grouping by normalized requirement + canonical unit only; case differences, synonyms, fuzzy equivalence and physical-dimension mismatches remain separate requirements.
+- Deterministic list-scoped `ShoppingItemId` derivation from `ShoppingListId + requirement + canonical unit`, independent of amount and requested servings.
+- Deep-immutable ordered provenance `ShoppingItemId → RecipeIngredientRef(RecipeId, RecipeIngredientId)` kept outside Shopping Core types.
+- Fail-closed generated-ID collision detection through a package-private deterministic-ID seam covered by regression tests.
+- M2.1 design and implementation plan documenting the domain/conversion boundary and explicit non-goals.
+
 #### Product and shopping core
 
 - Canonical eight-retailer registry with independent technical-connectivity and production-access states.
@@ -54,6 +65,9 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Project phase advanced from M0 Product & Integration Discovery to M1 Shopping Core and, after final acceptance, to **M2 Recipes**.
 - M1 Shopping Core is **COMPLETE / ACCEPTED** on the post-merge pre-acquisition-gate baseline `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 - The M1→M2 decision is **GO for deterministic product/core development**; it does not claim every retailer is production-ready.
+- M2.1 now has an implemented/tested shipping candidate for `Recipe → explicit ingredients → canonical quantities → ShoppingList`; REST/OpenAPI/client/UI/persistence remain separate follow-up work until the domain slice is accepted.
+- Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
+- Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`.
 - Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
 - `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.
@@ -68,10 +82,13 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Magnit remains technically `AVAILABLE_PUBLIC_WEB`, while production access is **`BLOCKED` by Zakup Gotov product policy (#70)** pending affirmative permission or licensed/supported terms.
 - Product-facing Magnit readiness is `CONNECTED + BLOCKED + UNAVAILABLE` with reason `PRODUCTION_ACCESS_BLOCKED`, without totals or freshness evidence.
 - Production-access policy is now enforced before acquisition rather than relying only on post-load filtering.
-- The next primary product slice is deterministic `Recipe → explicit ingredients → canonical quantities → ShoppingList`.
 
 ### Fixed
 
+- Recipe aggregate rejects missing fields, empty ingredient lists, null ingredients and duplicate ingredient IDs instead of producing a partially valid recipe.
+- Recipe conversion rejects missing inputs and invalid provenance identities.
+- Recipe generated-item identity collision across different merge keys fails closed rather than relying on overwrite/order behavior.
+- Recipe provenance maps and nested lineage lists are defensively copied and immutable.
 - Provider offer validation rejects provenance/context mismatches before comparison logic.
 - Precise addresses are excluded from default string representations and provider routing.
 - Snapshot freshness rejects provider timestamps after observation time.

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/Recipe.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/Recipe.java
@@ -1,0 +1,32 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public record Recipe(
+        RecipeId id,
+        RecipeTitle title,
+        RecipeServings baseServings,
+        List<RecipeIngredient> ingredients) {
+
+    public Recipe {
+        id = Objects.requireNonNull(id, "id must not be null");
+        title = Objects.requireNonNull(title, "title must not be null");
+        baseServings = Objects.requireNonNull(baseServings, "baseServings must not be null");
+        ingredients = Objects.requireNonNull(ingredients, "ingredients must not be null");
+        if (ingredients.isEmpty()) {
+            throw new IllegalArgumentException("ingredients must not be empty");
+        }
+
+        var ingredientIds = new HashSet<RecipeIngredientId>();
+        for (var ingredient : ingredients) {
+            Objects.requireNonNull(ingredient, "ingredient must not be null");
+            if (!ingredientIds.add(ingredient.id())) {
+                throw new IllegalArgumentException("duplicate recipe ingredient id: " + ingredient.id().value());
+            }
+        }
+
+        ingredients = List.copyOf(ingredients);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeId.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RecipeId(UUID value) {
+
+    public RecipeId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredient.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredient.java
@@ -1,0 +1,17 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.util.Objects;
+
+public record RecipeIngredient(
+        RecipeIngredientId id,
+        ShoppingRequirement requirement,
+        Quantity quantity) {
+
+    public RecipeIngredient {
+        id = Objects.requireNonNull(id, "id must not be null");
+        requirement = Objects.requireNonNull(requirement, "requirement must not be null");
+        quantity = Objects.requireNonNull(quantity, "quantity must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientId.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RecipeIngredientId(UUID value) {
+
+    public RecipeIngredientId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java
@@ -1,0 +1,5 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+public record RecipeIngredientRef(
+        RecipeId recipeId,
+        RecipeIngredientId ingredientId) {}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java
@@ -1,5 +1,13 @@
 package io.github.trueruslan.zakupgotov.recipe;
 
+import java.util.Objects;
+
 public record RecipeIngredientRef(
         RecipeId recipeId,
-        RecipeIngredientId ingredientId) {}
+        RecipeIngredientId ingredientId) {
+
+    public RecipeIngredientRef {
+        recipeId = Objects.requireNonNull(recipeId, "recipeId must not be null");
+        ingredientId = Objects.requireNonNull(ingredientId, "ingredientId must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeServings.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeServings.java
@@ -1,0 +1,10 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+public record RecipeServings(int value) {
+
+    public RecipeServings {
+        if (value <= 0) {
+            throw new IllegalArgumentException("value must be positive");
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIdDeriver.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIdDeriver.java
@@ -1,0 +1,15 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+
+@FunctionalInterface
+interface RecipeShoppingItemIdDeriver {
+
+    ShoppingItemId derive(
+            ShoppingListId shoppingListId,
+            ShoppingRequirement requirement,
+            QuantityUnit unit);
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java
@@ -1,0 +1,17 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record RecipeShoppingListConversion(
+        ShoppingList shoppingList,
+        Map<ShoppingItemId, List<RecipeIngredientRef>> provenance) {
+
+    public RecipeShoppingListConversion {
+        shoppingList = Objects.requireNonNull(shoppingList, "shoppingList must not be null");
+        provenance = Objects.requireNonNull(provenance, "provenance must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java
@@ -2,6 +2,8 @@ package io.github.trueruslan.zakupgotov.recipe;
 
 import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,5 +15,11 @@ public record RecipeShoppingListConversion(
     public RecipeShoppingListConversion {
         shoppingList = Objects.requireNonNull(shoppingList, "shoppingList must not be null");
         provenance = Objects.requireNonNull(provenance, "provenance must not be null");
+
+        var copy = new LinkedHashMap<ShoppingItemId, List<RecipeIngredientRef>>();
+        provenance.forEach((itemId, refs) -> copy.put(
+                Objects.requireNonNull(itemId, "provenance itemId must not be null"),
+                List.copyOf(Objects.requireNonNull(refs, "provenance refs must not be null"))));
+        provenance = Collections.unmodifiableMap(copy);
     }
 }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
@@ -1,0 +1,67 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RecipeShoppingListConverter {
+
+    public RecipeShoppingListConversion convert(
+            Recipe recipe,
+            RecipeServings targetServings,
+            ShoppingListId shoppingListId) {
+        Objects.requireNonNull(recipe, "recipe must not be null");
+        Objects.requireNonNull(targetServings, "targetServings must not be null");
+        Objects.requireNonNull(shoppingListId, "shoppingListId must not be null");
+
+        var groups = new LinkedHashMap<MergeKey, BigDecimal>();
+        for (var ingredient : recipe.ingredients()) {
+            var key = new MergeKey(ingredient.requirement(), ingredient.quantity().unit());
+            groups.merge(key, ingredient.quantity().amount(), BigDecimal::add);
+        }
+
+        var shoppingList = new ShoppingList(shoppingListId);
+        var index = 0;
+        for (var entry : groups.entrySet()) {
+            var key = entry.getKey();
+            var scaledAmount = scale(
+                    entry.getValue(),
+                    targetServings.value(),
+                    recipe.baseServings().value());
+            var quantity = new Quantity(scaledAmount, key.unit());
+            shoppingList.add(new ShoppingItem(
+                    temporaryItemId(shoppingListId, index++),
+                    key.requirement(),
+                    quantity));
+        }
+
+        return new RecipeShoppingListConversion(shoppingList, Map.of());
+    }
+
+    private static BigDecimal scale(BigDecimal summedBaseAmount, int targetServings, int baseServings) {
+        var numerator = summedBaseAmount.multiply(BigDecimal.valueOf(targetServings));
+        try {
+            return numerator.divide(BigDecimal.valueOf(baseServings));
+        } catch (ArithmeticException nonTerminatingDivision) {
+            return numerator.divide(BigDecimal.valueOf(baseServings), MathContext.DECIMAL128);
+        }
+    }
+
+    private static ShoppingItemId temporaryItemId(ShoppingListId shoppingListId, int index) {
+        var payload = shoppingListId.value() + ":" + index;
+        return new ShoppingItemId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private record MergeKey(ShoppingRequirement requirement, QuantityUnit unit) {}
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
@@ -17,6 +17,16 @@ import java.util.UUID;
 
 public final class RecipeShoppingListConverter {
 
+    private final RecipeShoppingItemIdDeriver itemIdDeriver;
+
+    public RecipeShoppingListConverter() {
+        this(RecipeShoppingListConverter::deriveDefaultItemId);
+    }
+
+    RecipeShoppingListConverter(RecipeShoppingItemIdDeriver itemIdDeriver) {
+        this.itemIdDeriver = Objects.requireNonNull(itemIdDeriver, "itemIdDeriver must not be null");
+    }
+
     public RecipeShoppingListConversion convert(
             Recipe recipe,
             RecipeServings targetServings,
@@ -34,6 +44,7 @@ public final class RecipeShoppingListConverter {
 
         var shoppingList = new ShoppingList(shoppingListId);
         var provenance = new LinkedHashMap<ShoppingItemId, java.util.List<RecipeIngredientRef>>();
+        var itemKeys = new LinkedHashMap<ShoppingItemId, MergeKey>();
         for (var entry : groups.entrySet()) {
             var key = entry.getKey();
             var accumulator = entry.getValue();
@@ -42,7 +53,13 @@ public final class RecipeShoppingListConverter {
                     targetServings.value(),
                     recipe.baseServings().value());
             var quantity = new Quantity(scaledAmount, key.unit());
-            var itemId = deriveItemId(shoppingListId, key);
+            var itemId = Objects.requireNonNull(
+                    itemIdDeriver.derive(shoppingListId, key.requirement(), key.unit()),
+                    "derived item id must not be null");
+            var previousKey = itemKeys.putIfAbsent(itemId, key);
+            if (previousKey != null && !previousKey.equals(key)) {
+                throw new IllegalStateException("generated shopping item id collision");
+            }
             shoppingList.add(new ShoppingItem(itemId, key.requirement(), quantity));
             provenance.put(itemId, accumulator.refs());
         }
@@ -59,12 +76,15 @@ public final class RecipeShoppingListConverter {
         }
     }
 
-    private static ShoppingItemId deriveItemId(ShoppingListId shoppingListId, MergeKey key) {
+    private static ShoppingItemId deriveDefaultItemId(
+            ShoppingListId shoppingListId,
+            ShoppingRequirement requirement,
+            QuantityUnit unit) {
         var payload = shoppingListId.value()
                 + "\n"
-                + key.requirement().text()
+                + requirement.text()
                 + "\n"
-                + key.unit().name();
+                + unit.name();
         return new ShoppingItemId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
     }
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
@@ -10,8 +10,8 @@ import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -25,28 +25,29 @@ public final class RecipeShoppingListConverter {
         Objects.requireNonNull(targetServings, "targetServings must not be null");
         Objects.requireNonNull(shoppingListId, "shoppingListId must not be null");
 
-        var groups = new LinkedHashMap<MergeKey, BigDecimal>();
+        var groups = new LinkedHashMap<MergeKey, GroupAccumulator>();
         for (var ingredient : recipe.ingredients()) {
             var key = new MergeKey(ingredient.requirement(), ingredient.quantity().unit());
-            groups.merge(key, ingredient.quantity().amount(), BigDecimal::add);
+            groups.computeIfAbsent(key, ignored -> new GroupAccumulator())
+                    .add(ingredient.quantity().amount(), new RecipeIngredientRef(recipe.id(), ingredient.id()));
         }
 
         var shoppingList = new ShoppingList(shoppingListId);
-        var index = 0;
+        var provenance = new LinkedHashMap<ShoppingItemId, java.util.List<RecipeIngredientRef>>();
         for (var entry : groups.entrySet()) {
             var key = entry.getKey();
+            var accumulator = entry.getValue();
             var scaledAmount = scale(
-                    entry.getValue(),
+                    accumulator.totalAmount(),
                     targetServings.value(),
                     recipe.baseServings().value());
             var quantity = new Quantity(scaledAmount, key.unit());
-            shoppingList.add(new ShoppingItem(
-                    temporaryItemId(shoppingListId, index++),
-                    key.requirement(),
-                    quantity));
+            var itemId = deriveItemId(shoppingListId, key);
+            shoppingList.add(new ShoppingItem(itemId, key.requirement(), quantity));
+            provenance.put(itemId, accumulator.refs());
         }
 
-        return new RecipeShoppingListConversion(shoppingList, Map.of());
+        return new RecipeShoppingListConversion(shoppingList, provenance);
     }
 
     private static BigDecimal scale(BigDecimal summedBaseAmount, int targetServings, int baseServings) {
@@ -58,10 +59,32 @@ public final class RecipeShoppingListConverter {
         }
     }
 
-    private static ShoppingItemId temporaryItemId(ShoppingListId shoppingListId, int index) {
-        var payload = shoppingListId.value() + ":" + index;
+    private static ShoppingItemId deriveItemId(ShoppingListId shoppingListId, MergeKey key) {
+        var payload = shoppingListId.value()
+                + "\n"
+                + key.requirement().text()
+                + "\n"
+                + key.unit().name();
         return new ShoppingItemId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
     }
 
     private record MergeKey(ShoppingRequirement requirement, QuantityUnit unit) {}
+
+    private static final class GroupAccumulator {
+        private BigDecimal totalAmount = BigDecimal.ZERO;
+        private final ArrayList<RecipeIngredientRef> refs = new ArrayList<>();
+
+        void add(BigDecimal amount, RecipeIngredientRef ref) {
+            totalAmount = totalAmount.add(amount);
+            refs.add(ref);
+        }
+
+        BigDecimal totalAmount() {
+            return totalAmount;
+        }
+
+        java.util.List<RecipeIngredientRef> refs() {
+            return refs;
+        }
+    }
 }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeTitle.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeTitle.java
@@ -1,0 +1,15 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+
+public record RecipeTitle(String value) {
+
+    public RecipeTitle {
+        value = Objects.requireNonNull(value, "value must not be null")
+                .strip()
+                .replaceAll("\\s+", " ");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("value must not be blank");
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeConversionValidationTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeConversionValidationTest.java
@@ -1,0 +1,59 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeConversionValidationTest {
+
+    private static final RecipeId RECIPE_ID = new RecipeId(UUID.fromString("5d3fa22c-014f-4b08-b5b3-4f759be8f920"));
+    private static final RecipeIngredientId INGREDIENT_ID = new RecipeIngredientId(UUID.fromString("81d23cd8-cd6f-4692-8a0f-a49e05c779cc"));
+    private static final ShoppingListId LIST_ID = new ShoppingListId(UUID.fromString("4ea3a925-1d2a-4246-a970-7a82ffc96402"));
+
+    @Test
+    void recipeIngredientRefRequiresBothIdentities() {
+        assertThatThrownBy(() -> new RecipeIngredientRef(null, INGREDIENT_ID))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("recipeId");
+        assertThatThrownBy(() -> new RecipeIngredientRef(RECIPE_ID, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ingredientId");
+    }
+
+    @Test
+    void converterRejectsMissingInputsAndMissingIdDeriver() {
+        var converter = new RecipeShoppingListConverter();
+        var recipe = recipe();
+
+        assertThatThrownBy(() -> converter.convert(null, new RecipeServings(1), LIST_ID))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("recipe");
+        assertThatThrownBy(() -> converter.convert(recipe, null, LIST_ID))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("targetServings");
+        assertThatThrownBy(() -> converter.convert(recipe, new RecipeServings(1), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("shoppingListId");
+        assertThatThrownBy(() -> new RecipeShoppingListConverter(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("itemIdDeriver");
+    }
+
+    private static Recipe recipe() {
+        return new Recipe(
+                RECIPE_ID,
+                new RecipeTitle("Test recipe"),
+                new RecipeServings(1),
+                List.of(new RecipeIngredient(
+                        INGREDIENT_ID,
+                        new ShoppingRequirement("Flour"),
+                        new Quantity(new BigDecimal("100"), QuantityUnit.GRAM))));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListCollisionTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListCollisionTest.java
@@ -1,0 +1,44 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeShoppingListCollisionTest {
+
+    @Test
+    void failsClosedWhenDifferentMergeKeysResolveToSameGeneratedItemId() {
+        var fixedId = new ShoppingItemId(UUID.fromString("26537fbd-8177-4b99-bb94-9315cf2a1065"));
+        RecipeShoppingItemIdDeriver collidingDeriver = (listId, requirement, unit) -> fixedId;
+        var converter = new RecipeShoppingListConverter(collidingDeriver);
+        var recipe = new Recipe(
+                new RecipeId(UUID.fromString("5d3fa22c-014f-4b08-b5b3-4f759be8f920")),
+                new RecipeTitle("Collision recipe"),
+                new RecipeServings(1),
+                List.of(
+                        ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Milk", "500", QuantityUnit.MILLILITER),
+                        ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Flour", "200", QuantityUnit.GRAM)));
+
+        assertThatThrownBy(() -> converter.convert(
+                        recipe,
+                        new RecipeServings(1),
+                        new ShoppingListId(UUID.fromString("4ea3a925-1d2a-4246-a970-7a82ffc96402"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("collision");
+    }
+
+    private static RecipeIngredient ingredient(String id, String requirement, String amount, QuantityUnit unit) {
+        return new RecipeIngredient(
+                new RecipeIngredientId(UUID.fromString(id)),
+                new ShoppingRequirement(requirement),
+                new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
@@ -1,6 +1,7 @@
 package io.github.trueruslan.zakupgotov.recipe;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.trueruslan.zakupgotov.shopping.Quantity;
 import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
@@ -104,6 +105,59 @@ class RecipeShoppingListConverterTest {
                 .isEqualTo(second.shoppingList().items().getFirst().quantity());
         assertThat(first.shoppingList().items().getFirst().quantity().amount())
                 .isEqualByComparingTo(new BigDecimal("33.33333333333333333333333333333333"));
+    }
+
+    @Test
+    void derivesItemIdentityFromListRequirementAndCanonicalUnitRatherThanPositionOrAmount() {
+        var flourKg = recipe(2, ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Flour", "0.5", QuantityUnit.KILOGRAM));
+        var flourG = recipe(4, ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Flour", "500", QuantityUnit.GRAM));
+        var milk = recipe(2, ingredient("e982cbf4-9a04-4dca-b16e-cbb0bad92023", "Milk", "500", QuantityUnit.MILLILITER));
+
+        var flourAtBase = converter.convert(flourKg, new RecipeServings(2), LIST_ID).shoppingList().items().getFirst().id();
+        var flourAtDifferentServings = converter.convert(flourKg, new RecipeServings(4), LIST_ID).shoppingList().items().getFirst().id();
+        var flourCanonicalRepresentation = converter.convert(flourG, new RecipeServings(4), LIST_ID).shoppingList().items().getFirst().id();
+        var milkId = converter.convert(milk, new RecipeServings(2), LIST_ID).shoppingList().items().getFirst().id();
+        var otherListId = converter.convert(
+                        flourKg,
+                        new RecipeServings(2),
+                        new ShoppingListId(UUID.fromString("b0d7c4a7-e9b2-446e-b01e-d12fd5d81f6a")))
+                .shoppingList().items().getFirst().id();
+
+        assertThat(flourAtDifferentServings).isEqualTo(flourAtBase);
+        assertThat(flourCanonicalRepresentation).isEqualTo(flourAtBase);
+        assertThat(milkId).isNotEqualTo(flourAtBase);
+        assertThat(otherListId).isNotEqualTo(flourAtBase);
+    }
+
+    @Test
+    void recordsCompleteOrderedProvenanceForMergedAndNonMergedIngredients() {
+        var milkFirst = ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Milk", "500", QuantityUnit.MILLILITER);
+        var flour = ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Flour", "200", QuantityUnit.GRAM);
+        var milkSecond = ingredient("e982cbf4-9a04-4dca-b16e-cbb0bad92023", "Milk", "0.5", QuantityUnit.LITER);
+        var recipe = recipe(1, milkFirst, flour, milkSecond);
+
+        var result = converter.convert(recipe, new RecipeServings(1), LIST_ID);
+        var milkItem = result.shoppingList().items().get(0);
+        var flourItem = result.shoppingList().items().get(1);
+
+        assertThat(result.provenance()).hasSize(2);
+        assertThat(result.provenance().get(milkItem.id())).containsExactly(
+                new RecipeIngredientRef(RECIPE_ID, milkFirst.id()),
+                new RecipeIngredientRef(RECIPE_ID, milkSecond.id()));
+        assertThat(result.provenance().get(flourItem.id())).containsExactly(
+                new RecipeIngredientRef(RECIPE_ID, flour.id()));
+    }
+
+    @Test
+    void exposesProvenanceAsDeeplyImmutableOutput() {
+        var ingredient = ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Flour", "200", QuantityUnit.GRAM);
+        var result = converter.convert(recipe(1, ingredient), new RecipeServings(1), LIST_ID);
+        var itemId = result.shoppingList().items().getFirst().id();
+
+        assertThatThrownBy(() -> result.provenance().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.provenance().get(itemId).add(new RecipeIngredientRef(RECIPE_ID, ingredient.id())))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     private static Recipe recipe(int servings, RecipeIngredient... ingredients) {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
@@ -1,0 +1,119 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeShoppingListConverterTest {
+
+    private static final RecipeId RECIPE_ID = new RecipeId(UUID.fromString("5d3fa22c-014f-4b08-b5b3-4f759be8f920"));
+    private static final ShoppingListId LIST_ID = new ShoppingListId(UUID.fromString("4ea3a925-1d2a-4246-a970-7a82ffc96402"));
+    private final RecipeShoppingListConverter converter = new RecipeShoppingListConverter();
+
+    @Test
+    void scalesOneIngredientIntoShoppingList() {
+        var recipe = recipe(4, ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Flour", "400", QuantityUnit.GRAM));
+
+        var result = converter.convert(recipe, new RecipeServings(2), LIST_ID);
+
+        assertThat(result.shoppingList().id()).isEqualTo(LIST_ID);
+        assertThat(result.shoppingList().items()).singleElement().satisfies(item -> {
+            assertThat(item.requirement()).isEqualTo(new ShoppingRequirement("Flour"));
+            assertThat(item.quantity()).isEqualTo(new Quantity(new BigDecimal("200"), QuantityUnit.GRAM));
+        });
+    }
+
+    @Test
+    void reusesShoppingQuantityCanonicalizationForMassAndVolume() {
+        var recipe = recipe(
+                2,
+                ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Flour", "0.5", QuantityUnit.KILOGRAM),
+                ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Milk", "0.5", QuantityUnit.LITER));
+
+        var result = converter.convert(recipe, new RecipeServings(4), LIST_ID);
+
+        assertThat(result.shoppingList().items())
+                .extracting(item -> item.quantity())
+                .containsExactly(
+                        new Quantity(new BigDecimal("1000"), QuantityUnit.GRAM),
+                        new Quantity(new BigDecimal("1000"), QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void mergesExactNormalizedRequirementWithSameCanonicalUnitBeforeScaling() {
+        var recipe = recipe(
+                4,
+                ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "  Milk  ", "500", QuantityUnit.MILLILITER),
+                ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Milk", "0.5", QuantityUnit.LITER));
+
+        var result = converter.convert(recipe, new RecipeServings(2), LIST_ID);
+
+        assertThat(result.shoppingList().items()).singleElement().satisfies(item -> {
+            assertThat(item.requirement()).isEqualTo(new ShoppingRequirement("Milk"));
+            assertThat(item.quantity()).isEqualTo(new Quantity(new BigDecimal("500"), QuantityUnit.MILLILITER));
+        });
+    }
+
+    @Test
+    void doesNotMergeCaseDifferencesSynonymsOrPhysicalDimensionMismatches() {
+        var recipe = recipe(
+                1,
+                ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Milk", "500", QuantityUnit.MILLILITER),
+                ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "milk", "500", QuantityUnit.MILLILITER),
+                ingredient("e982cbf4-9a04-4dca-b16e-cbb0bad92023", "tomatoes", "300", QuantityUnit.GRAM),
+                ingredient("d592f53c-c663-4d8b-8cab-00f8168d4b5a", "tomato", "300", QuantityUnit.GRAM),
+                ingredient("22531761-b7c8-4526-b431-e6f99500fcc4", "Eggs", "600", QuantityUnit.GRAM),
+                ingredient("f6a89b9f-5068-419a-b69c-d25d82bb86bc", "Eggs", "10", QuantityUnit.PIECE));
+
+        var result = converter.convert(recipe, new RecipeServings(1), LIST_ID);
+
+        assertThat(result.shoppingList().items()).hasSize(6);
+    }
+
+    @Test
+    void preservesFirstMergeGroupOccurrenceOrder() {
+        var recipe = recipe(
+                1,
+                ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Milk", "250", QuantityUnit.MILLILITER),
+                ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Flour", "200", QuantityUnit.GRAM),
+                ingredient("e982cbf4-9a04-4dca-b16e-cbb0bad92023", "Milk", "250", QuantityUnit.MILLILITER),
+                ingredient("d592f53c-c663-4d8b-8cab-00f8168d4b5a", "Eggs", "2", QuantityUnit.PIECE));
+
+        var result = converter.convert(recipe, new RecipeServings(1), LIST_ID);
+
+        assertThat(result.shoppingList().items())
+                .extracting(item -> item.requirement().text())
+                .containsExactly("Milk", "Flour", "Eggs");
+    }
+
+    @Test
+    void usesDeterministicDecimal128ForNonTerminatingScaleRatio() {
+        var recipe = recipe(3, ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Spice", "100", QuantityUnit.GRAM));
+
+        var first = converter.convert(recipe, new RecipeServings(1), LIST_ID);
+        var second = converter.convert(recipe, new RecipeServings(1), LIST_ID);
+
+        assertThat(first.shoppingList().items().getFirst().quantity())
+                .isEqualTo(second.shoppingList().items().getFirst().quantity());
+        assertThat(first.shoppingList().items().getFirst().quantity().amount())
+                .isEqualByComparingTo(new BigDecimal("33.33333333333333333333333333333333"));
+    }
+
+    private static Recipe recipe(int servings, RecipeIngredient... ingredients) {
+        return new Recipe(RECIPE_ID, new RecipeTitle("Test recipe"), new RecipeServings(servings), List.of(ingredients));
+    }
+
+    private static RecipeIngredient ingredient(String id, String requirement, String amount, QuantityUnit unit) {
+        return new RecipeIngredient(
+                new RecipeIngredientId(UUID.fromString(id)),
+                new ShoppingRequirement(requirement),
+                new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeTest.java
@@ -1,0 +1,104 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeTest {
+
+    private static final RecipeId RECIPE_ID = new RecipeId(UUID.fromString("5d3fa22c-014f-4b08-b5b3-4f759be8f920"));
+    private static final RecipeTitle TITLE = new RecipeTitle("Pasta Carbonara");
+    private static final RecipeServings SERVINGS = new RecipeServings(4);
+
+    @Test
+    void preservesIngredientOrderAndExposesImmutableSnapshot() {
+        var first = ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Pasta", "400", QuantityUnit.GRAM);
+        var second = ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Eggs", "4", QuantityUnit.PIECE);
+        var source = new ArrayList<>(List.of(first, second));
+
+        var recipe = new Recipe(RECIPE_ID, TITLE, SERVINGS, source);
+        source.clear();
+
+        assertThat(recipe.id()).isEqualTo(RECIPE_ID);
+        assertThat(recipe.title()).isEqualTo(TITLE);
+        assertThat(recipe.baseServings()).isEqualTo(SERVINGS);
+        assertThat(recipe.ingredients()).containsExactly(first, second);
+        assertThatThrownBy(() -> recipe.ingredients().add(first))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsEmptyIngredients() {
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, TITLE, SERVINGS, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ingredient");
+    }
+
+    @Test
+    void rejectsDuplicateIngredientIdentity() {
+        var id = "81d23cd8-cd6f-4692-8a0f-a49e05c779cc";
+        var first = ingredient(id, "Milk", "500", QuantityUnit.MILLILITER);
+        var duplicate = ingredient(id, "Milk", "0.5", QuantityUnit.LITER);
+
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, TITLE, SERVINGS, List.of(first, duplicate)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate");
+    }
+
+    @Test
+    void rejectsMissingAggregateFieldsAndNullIngredient() {
+        var ingredient = ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Pasta", "400", QuantityUnit.GRAM);
+
+        assertThatThrownBy(() -> new Recipe(null, TITLE, SERVINGS, List.of(ingredient)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("id");
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, null, SERVINGS, List.of(ingredient)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("title");
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, TITLE, null, List.of(ingredient)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("baseServings");
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, TITLE, SERVINGS, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ingredients");
+
+        var withNull = new ArrayList<RecipeIngredient>();
+        withNull.add(ingredient);
+        withNull.add(null);
+        assertThatThrownBy(() -> new Recipe(RECIPE_ID, TITLE, SERVINGS, withNull))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ingredient");
+    }
+
+    @Test
+    void recipeIngredientRejectsMissingFields() {
+        var id = new RecipeIngredientId(UUID.fromString("81d23cd8-cd6f-4692-8a0f-a49e05c779cc"));
+        var requirement = new ShoppingRequirement("Milk");
+        var quantity = new Quantity(new BigDecimal("500"), QuantityUnit.MILLILITER);
+
+        assertThatThrownBy(() -> new RecipeIngredient(null, requirement, quantity))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("id");
+        assertThatThrownBy(() -> new RecipeIngredient(id, null, quantity))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("requirement");
+        assertThatThrownBy(() -> new RecipeIngredient(id, requirement, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("quantity");
+    }
+
+    private static RecipeIngredient ingredient(String id, String requirement, String amount, QuantityUnit unit) {
+        return new RecipeIngredient(
+                new RecipeIngredientId(UUID.fromString(id)),
+                new ShoppingRequirement(requirement),
+                new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeValueObjectsTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeValueObjectsTest.java
@@ -1,0 +1,69 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeValueObjectsTest {
+
+    @Test
+    void preservesRecipeIdentity() {
+        var value = UUID.fromString("5d3fa22c-014f-4b08-b5b3-4f759be8f920");
+
+        assertThat(new RecipeId(value).value()).isEqualTo(value);
+    }
+
+    @Test
+    void rejectsMissingRecipeIdentity() {
+        assertThatThrownBy(() -> new RecipeId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("value");
+    }
+
+    @Test
+    void preservesIngredientIdentity() {
+        var value = UUID.fromString("81d23cd8-cd6f-4692-8a0f-a49e05c779cc");
+
+        assertThat(new RecipeIngredientId(value).value()).isEqualTo(value);
+    }
+
+    @Test
+    void rejectsMissingIngredientIdentity() {
+        assertThatThrownBy(() -> new RecipeIngredientId(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("value");
+    }
+
+    @Test
+    void normalizesRecipeTitleWhitespaceWithoutChangingCaseOrPunctuation() {
+        assertThat(new RecipeTitle("  Pasta   Carbonara!  ").value())
+                .isEqualTo("Pasta Carbonara!");
+    }
+
+    @Test
+    void rejectsBlankOrMissingRecipeTitle() {
+        assertThatThrownBy(() -> new RecipeTitle("   \t  "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("value");
+        assertThatThrownBy(() -> new RecipeTitle(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("value");
+    }
+
+    @Test
+    void acceptsPositiveIntegerServings() {
+        assertThat(new RecipeServings(3).value()).isEqualTo(3);
+    }
+
+    @Test
+    void rejectsNonPositiveServings() {
+        assertThatThrownBy(() -> new RecipeServings(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+        assertThatThrownBy(() -> new RecipeServings(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -12,7 +12,7 @@ Current phase: **M2 — Recipes**
 M0 status: **technical discovery COMPLETE**  
 M1 status: **Shopping Core COMPLETE / ACCEPTED**  
 M1→M2 decision: **GO** — [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md)  
-Current focus: **first deterministic Recipe → ShoppingList vertical slice**
+Current focus: **ship M2.1 deterministic Recipe → ShoppingList domain slice (#94 / #93), then design the application/API boundary**
 
 ## Permanent connectivity rule
 
@@ -39,7 +39,7 @@ M0 completion proves technical feasibility, not blanket permission for recurring
 
 Final acceptance: [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md).
 
-Accepted baseline after final hardening: `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
+Accepted final hardening baseline: `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 
 ### Accepted implementation sequence
 
@@ -132,30 +132,64 @@ No production Spring/HTTP Magnit acquisition is activated.
 
 ## M2 — Recipes — CURRENT
 
-First vertical slice:
+### M2.1 — Recipe domain and Recipe → ShoppingList — IMPLEMENTED / TESTED / SHIPPING (#94 / #93)
 
-`Recipe → explicit ingredients → canonical quantities → ShoppingList`
+Approved design: [`superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`](superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md).  
+Implementation plan: [`superpowers/plans/2026-08-13-m2-1-recipe-domain.md`](superpowers/plans/2026-08-13-m2-1-recipe-domain.md).
 
-Initial requirements:
+Current reviewed implementation head before shipping docs: `734ed53712b4327039eabfb358548828aa1a1dbe`.
 
-- stable recipe identity and title;
-- base servings;
-- stable ingredient identity within a recipe;
-- explicit ingredient name + quantity/unit;
-- deterministic serving scaling;
-- reuse existing `Quantity` canonicalization;
-- merge only deterministically equivalent requirements;
-- preserve provenance from generated shopping requirement back to recipe/ingredient;
-- recipe → ShoppingList conversion;
-- TDD domain acceptance before API/OpenAPI/client/UI expansion.
+Implemented behavior:
 
-Initial non-goals:
+- separate top-level `recipe` domain with `RecipeId`, `RecipeIngredientId`, normalized `RecipeTitle`, positive-integer `RecipeServings`, immutable ordered `RecipeIngredient` list and duplicate-ID rejection;
+- each ingredient reuses existing `ShoppingRequirement` and `Quantity`; Recipe introduces no duplicate unit/canonicalization model;
+- pure `RecipeShoppingListConverter` with no Spring, persistence, network, clock or retailer dependency;
+- serving scaling sums each compatible merge group before applying `targetServings / baseServings`;
+- terminating decimal division remains exact; non-terminating ratios use deterministic `MathContext.DECIMAL128`; no `double`/`float` path exists;
+- merge key is exact normalized `ShoppingRequirement` + canonical `QuantityUnit`;
+- case differences, synonyms and physical-dimension mismatches do not merge;
+- output group order follows first ingredient occurrence;
+- generated `ShoppingItemId` is deterministic and list-scoped from `ShoppingListId + requirement text + canonical unit`, independent of amount/target servings;
+- kg/g and l/ml representations converge through the existing `Quantity` canonicalization before identity/merge decisions;
+- provenance is returned separately as `ShoppingItemId → ordered List<RecipeIngredientRef(RecipeId, RecipeIngredientId)>` and is deep-immutable;
+- artificial generated-ID collisions across different merge keys fail closed;
+- Shopping Core production types remain recipe-agnostic and unchanged.
 
-- AI recipe parsing;
-- arbitrary recipe-web import;
-- fuzzy ingredient equivalence;
-- nutrition optimization;
-- pantry prediction.
+TDD/verification state:
+
+- value-object RED → GREEN complete;
+- immutable aggregate RED → GREEN complete;
+- scaling/merge RED → GREEN complete;
+- deterministic identity/provenance RED → GREEN complete;
+- collision fail-closed RED → GREEN complete;
+- conversion/lineage validation RED → GREEN complete;
+- full API `verify` PASS on `734ed537…`, including Spring Modulith architecture verification;
+- exact implementation head has 9/9 PR workflow groups `success`;
+- independent review verdict: **Looks good**, no P0/P1/P2; review threads empty.
+
+This status is **not yet ACCEPTED**. Acceptance requires the final shipping-doc head to pass the same exact-head gate, squash merge, and green post-merge `main` verification.
+
+### M2.1 non-goals preserved
+
+Not added in this slice:
+
+- REST/OpenAPI/generated-client contracts;
+- persistence/repository layer;
+- recipe web UI;
+- AI/NLP recipe parsing or arbitrary web import;
+- fuzzy/case-insensitive ingredient equivalence;
+- nutrition/calorie optimization;
+- pantry prediction;
+- fractional servings input;
+- multi-recipe aggregation.
+
+### Next product slice after M2.1 acceptance
+
+Design the application/API boundary:
+
+`Recipe request → Recipe domain → RecipeShoppingListConversion → comparison input`
+
+That follow-up owns REST/OpenAPI/generated-client semantics. A responsive create/edit/servings flow should only be layered on top after the application contract is accepted.
 
 ## Parallel mandatory work
 
@@ -191,6 +225,9 @@ These continue without blocking deterministic M2 domain work unless new evidence
 19. Unknown JSON request fields fail closed.
 20. Universal retailer connectivity remains mandatory.
 21. Public technical accessibility is never treated as production authorization by itself.
+22. Recipe semantics reuse Shopping Core quantity/requirement normalization instead of duplicating it.
+23. Recipe provenance remains outside Shopping Core types.
+24. Recipe exact-safe merging never introduces fuzzy/AI equivalence implicitly.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,59 +74,70 @@ This does not claim production retailer completeness. Retailer connectivity/acce
 
 Goal: make recipes a first-class deterministic source of shopping requirements without weakening accepted Shopping Core invariants.
 
-### M2.1 — Recipe domain and Recipe → ShoppingList — NEXT
+### M2.1 — Recipe domain and Recipe → ShoppingList — IMPLEMENTED / TESTED / SHIPPING (#94 / #93)
 
-First vertical slice:
+Approved design: [`superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`](superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md).  
+Implementation plan: [`superpowers/plans/2026-08-13-m2-1-recipe-domain.md`](superpowers/plans/2026-08-13-m2-1-recipe-domain.md).
 
-`Recipe → explicit ingredients → canonical quantities → ShoppingList`
+#### Delivered candidate behavior
 
-#### Domain scope
+- immutable `Recipe` aggregate with stable recipe/ingredient UUID identities;
+- normalized non-blank title and positive integer base/target servings;
+- ingredients reuse accepted `ShoppingRequirement` + `Quantity` semantics;
+- pure Recipe → ShoppingList converter without Spring/network/database/clock dependencies;
+- group amounts summed before serving scaling;
+- exact terminating decimal division and deterministic `MathContext.DECIMAL128` fallback for non-terminating ratios;
+- exact-safe merge only by normalized requirement + canonical unit;
+- no case folding, synonym matching, fuzzy matching, category inference or AI equivalence;
+- deterministic output order by first merge-group occurrence;
+- deterministic list-scoped `ShoppingItemId` independent of quantity/target servings;
+- deep-immutable ordered `RecipeId + RecipeIngredientId` provenance outside Shopping Core;
+- generated-ID collision across different merge keys fails closed;
+- Shopping Core production types remain recipe-agnostic.
 
-- stable `RecipeId`;
-- recipe title;
-- base servings;
-- stable ingredient identity inside a recipe;
-- ingredient display/requirement text;
-- explicit quantity + unit;
-- deterministic serving scaling;
-- reuse Shopping Core quantity canonicalization;
-- safe deterministic merging only when ingredient requirements are explicitly equivalent and units are compatible;
-- provenance from generated shopping requirement back to recipe + ingredient;
-- recipe → ShoppingList conversion.
+#### Verification candidate
 
-#### Required behavior
+Reviewed implementation head `734ed53712b4327039eabfb358548828aa1a1dbe` has:
 
-- scaling from base servings to requested servings uses deterministic decimal arithmetic;
-- incompatible units are never implicitly converted;
-- zero/negative servings and quantities fail at the domain boundary;
-- blank titles/ingredient text fail at construction;
-- recipe ingredient ordering is stable;
-- generated ShoppingList item identity/provenance is deterministic for the conversion request;
-- merging cannot use fuzzy matching, category inference or AI;
-- the converter depends on accepted shopping-domain primitives rather than duplicating quantity semantics.
+- all M2.1 RED→GREEN domain/converter gates complete;
+- full API `verify` PASS, including Spring Modulith architecture verification;
+- 9/9 PR workflow groups success;
+- independent review verdict **Looks good**, no P0/P1/P2.
 
-#### Delivery sequence
+M2.1 is not accepted until the final shipping-doc head passes the same gates, is squash-merged, and post-merge `main` is green.
 
-1. design/spec with exact identity, scaling, merge and provenance rules;
-2. TDD domain aggregate + ingredient model;
-3. TDD serving scaler and Recipe → ShoppingList converter;
-4. architecture guards;
-5. after domain acceptance: API/OpenAPI/generated-client boundary;
-6. responsive UI: create/edit recipe → choose servings → generate shopping list → comparison journey.
+#### Explicit non-goals preserved
 
-#### Initial non-goals
-
-- AI recipe parsing;
-- arbitrary recipe-web import;
-- fuzzy ingredient equivalence;
+- REST/OpenAPI/generated-client contract;
+- persistence;
+- recipe UI;
+- AI/NLP or arbitrary web import;
+- fuzzy/case-insensitive ingredient equivalence;
 - nutritional optimization;
 - pantry prediction;
-- image recognition;
-- recommendation/ranking of recipes.
+- fractional servings;
+- multi-recipe aggregation.
+
+### M2.2 — Recipe application/API boundary — NEXT AFTER M2.1 ACCEPTANCE
+
+Target path:
+
+`Recipe request → Recipe domain → RecipeShoppingListConversion → comparison input`
+
+Required design questions for the next slice:
+
+- stateless request/response contract versus persisted recipe identity lifecycle;
+- where caller-provided/generated `ShoppingListId` lives at application boundary;
+- how provenance is represented in public API without leaking internal implementation details;
+- OpenAPI/generated TypeScript client schema;
+- validation/error vocabulary consistent with existing fail-closed request handling;
+- whether comparison composition is one endpoint or an explicit two-step application flow.
+
+Do not add persistence or UI by default; decide them from product need after the application contract is designed.
 
 ### M2 exit direction
 
-After the first vertical slice is accepted, extend toward reusable recipe persistence/API UX and then recipe aggregation needed by M3 Weekly Planning. Do not introduce fuzzy/AI ingestion until deterministic recipe semantics are stable and tested.
+After M2.1 and the application/API boundary are accepted, extend toward reusable recipe persistence/API UX and then recipe aggregation needed by M3 Weekly Planning. Do not introduce fuzzy/AI ingestion until deterministic recipe semantics are stable and tested.
 
 ## Parallel connectivity / operational work
 

--- a/docs/superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md
+++ b/docs/superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md
@@ -1,0 +1,147 @@
+# M2.1 Recipe Domain Shipping Evidence
+
+Date: 2026-08-13  
+Issue: #93  
+PR: #94  
+Status: **SHIPPING — acceptance pending merge + post-merge main verification**
+
+## Approved design and plan
+
+- Design: `docs/superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-08-13-m2-1-recipe-domain.md`
+- Accepted code baseline before M2.1: `main=7fc38a8ef5c9866c015a3b63f913d7acee3675f7`
+
+## Scope shipped
+
+M2.1 introduces a separate top-level `recipe` domain and a pure deterministic converter into the accepted Shopping Core.
+
+Delivered semantics:
+
+- immutable Recipe aggregate with stable recipe/ingredient identity;
+- normalized non-blank title and positive integer servings;
+- existing `ShoppingRequirement` and `Quantity` reused as authoritative requirement/quantity boundaries;
+- canonical compatible amounts grouped and summed before serving scaling;
+- exact terminating decimal scaling, deterministic `MathContext.DECIMAL128` fallback for non-terminating ratios;
+- exact-safe merge only by normalized requirement + canonical unit;
+- deterministic list-scoped `ShoppingItemId` independent of amount/target servings;
+- ordered deep-immutable `RecipeId + RecipeIngredientId` provenance outside Shopping Core;
+- generated-ID collision across different merge keys fails closed;
+- no Shopping Core production type depends on Recipe;
+- no Spring/network/database/clock/persistence/REST/OpenAPI/web behavior added.
+
+## TDD evidence
+
+### Value objects
+
+- RED head: `4e8ae28356ca982572bc0dc2150e0fbe3671c9db`
+  - API test compilation failed only because the new Recipe value objects did not exist.
+- GREEN head: `15e47e142c784f6356b8237c885e0ddff94d4be8`
+  - full API verification PASS.
+
+### Immutable aggregate
+
+- RED head: `187f65051421ba75f920e720c1149a64fdedec43`
+  - expected missing `Recipe` / `RecipeIngredient` contract.
+- GREEN head: `360e32515a7e54a4c47e1bd96e88f35c173a55ec`
+  - full API verification PASS.
+
+### Scaling and exact-safe merge
+
+- RED head: `84a43731c1b9271d9fc387778ee1b62ca2a7d1da`
+  - expected missing Recipe → ShoppingList converter API.
+- GREEN head: `274bde76400b456cb4fff38de39cae4c9aaf09bd`
+  - full API verification PASS for scaling, canonicalization, merge/non-merge, first-occurrence order and DECIMAL128 non-terminating ratio behavior.
+
+### Deterministic identity and provenance
+
+- RED head: `5feb61e6b50840cf363ecd58cabbc8c374aa243e`
+  - behavioral suite rejected the temporary index-based identity and empty provenance.
+- GREEN head: `7e95b8907cc8593c72e81172bd118ae808aa9524`
+  - full API verification PASS for list-scoped key identity, ordered provenance and deep immutability.
+
+### Collision fail-closed
+
+- RED head: `fb28596377c4dda9c925218080467b7011db53d6`
+  - expected missing package-private ID-derivation seam.
+- GREEN head: `1f36680f051746533f78388b024cb43e01ba62f6`
+  - full API verification PASS with artificial cross-key collision rejection.
+
+### Conversion/lineage validation
+
+- RED head: `de7ead00e102845d81ad4a5412bab55ef3e97386`
+  - new validation contract exposed nullable `RecipeIngredientRef` identities.
+- GREEN/reviewed implementation head: `734ed53712b4327039eabfb358548828aa1a1dbe`
+  - full API verification PASS.
+
+## Architecture verification
+
+`ApplicationArchitectureTest` executes:
+
+`ApplicationModules.of(ZakupGotovApplication.class).verify()`
+
+It passes as part of full API verification on the reviewed implementation head. The resulting dependency direction is:
+
+`recipe → shopping`
+
+No Shopping Core production file was changed by M2.1 and no reverse Recipe dependency was introduced.
+
+## Independent review
+
+Reviewed implementation head: `734ed53712b4327039eabfb358548828aa1a1dbe`.
+
+Verdict: **Looks good**.
+
+- P0: none
+- P1: none
+- P2: none
+- review threads: none
+
+Review covered spec compliance, scaling/merge correctness, deterministic identity, provenance, collision behavior, Shopping Core compatibility, architecture direction, security/privacy surface and test coverage.
+
+## Exact-head repository gates
+
+### Reviewed implementation head
+
+`734ed53712b4327039eabfb358548828aa1a1dbe`
+
+Result: **9/9 workflow groups success**:
+
+- API CI
+- Contract CI
+- Web CI / Web E2E
+- CodeQL Java + JavaScript/TypeScript
+- Dependency Review
+- Container Security CI
+- Retailer Bridge CI
+- Release Contract CI
+- Release Bundle CI
+
+No queued/in-progress/failure workflow remained.
+
+### Code + canonical docs candidate
+
+`250d00f10b1c51fee0826356dfb95f8e7b853c50`
+
+Result before this shipping marker: **9/9 workflow groups success**. The final long-running jobs were explicitly verified as successful for Web/Web E2E, CodeQL Java/JavaScript-TypeScript and Release Bundle.
+
+## Non-goals preserved
+
+This PR does not add:
+
+- REST/OpenAPI/generated client;
+- persistence;
+- recipe web UI;
+- AI/NLP or arbitrary web import;
+- fuzzy/case-insensitive ingredient equivalence;
+- nutrition optimization;
+- pantry prediction;
+- fractional servings input;
+- multi-recipe aggregation.
+
+## Final gate
+
+This shipping marker changes documentation only. Its exact head must independently pass the same 9 workflow groups before PR #94 can be marked ready and squash-merged.
+
+After merge, M2.1 becomes **ACCEPTED** only when the resulting exact `main` SHA completes all normal push-triggered workflows successfully. Until then #93 remains open.
+
+Rollback is a single squash-revert of PR #94; there are no migrations, external side effects or runtime feature activation in this slice.

--- a/docs/superpowers/plans/2026-08-13-m2-1-recipe-domain.md
+++ b/docs/superpowers/plans/2026-08-13-m2-1-recipe-domain.md
@@ -1,0 +1,583 @@
+# M2.1 Recipe Domain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first M2 Recipes domain slice: an immutable Recipe aggregate that deterministically scales and converts explicit ingredients into the accepted Shopping Core while returning complete recipe/ingredient provenance.
+
+**Architecture:** Add a new top-level `recipe` module that depends one-way on the existing `shopping` module. Reuse `ShoppingRequirement`, `Quantity`, `QuantityUnit`, `ShoppingList`, `ShoppingListId`, `ShoppingItem`, and `ShoppingItemId`; do not modify Shopping Core types to understand recipes. A pure `RecipeShoppingListConverter` performs canonical-unit grouping, serving scaling, deterministic list-scoped item identity, and immutable provenance with no Spring/network/database/clock dependency.
+
+**Tech Stack:** Java 25, JUnit 5, AssertJ, Spring Modulith 2.1 architecture verification, existing Maven wrapper at `apps/api/mvnw`.
+
+## Global Constraints
+
+- Baseline design: `docs/superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`.
+- Issue: #93.
+- Recipe may depend on Shopping Core; Shopping Core must not depend on Recipe.
+- `Quantity` remains the only owner of kg→g and l→ml canonicalization.
+- `ShoppingRequirement` remains the ingredient requirement text normalization boundary.
+- Positive integer servings only in M2.1.
+- Use `BigDecimal` only; never `double` or `float`.
+- For non-terminating division, use `MathContext.DECIMAL128` deterministically.
+- Merge only exact normalized `ShoppingRequirement` + equal canonical `QuantityUnit`.
+- Case differences, synonyms, fuzzy equivalence, AI parsing, persistence, REST/OpenAPI and web UI are non-goals.
+- Provenance belongs to conversion output, not `ShoppingItem`.
+- Normal tests and production code make no retailer/network requests.
+
+---
+
+## File Structure
+
+### New production files
+
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeId.java` — UUID recipe identity.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientId.java` — UUID ingredient identity.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeTitle.java` — title whitespace normalization/validation.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeServings.java` — positive integer servings.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredient.java` — ingredient identity + existing shopping requirement + quantity.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/Recipe.java` — immutable ordered aggregate and duplicate-ID validation.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java` — self-contained `(RecipeId, RecipeIngredientId)` provenance value.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java` — generated list + immutable provenance map.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIdDeriver.java` — package-private deterministic-ID seam, with production name-based UUID implementation.
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java` — pure grouping/scaling/conversion service.
+
+### New tests
+
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeValueObjectsTest.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeTest.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java`
+
+### Existing verification used unchanged unless a real failure requires adjustment
+
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/ApplicationArchitectureTest.java` — `ApplicationModules.of(ZakupGotovApplication.class).verify()` must continue to pass after `recipe` becomes a top-level application module.
+
+---
+
+### Task 1: Recipe Value Objects and Immutable Aggregate
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeValueObjectsTest.java`
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeTest.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeId.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientId.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeTitle.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeServings.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredient.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/Recipe.java`
+
+**Interfaces:**
+- Consumes: existing `ShoppingRequirement` and `Quantity`.
+- Produces:
+  - `record RecipeId(UUID value)`
+  - `record RecipeIngredientId(UUID value)`
+  - `record RecipeTitle(String value)`
+  - `record RecipeServings(int value)`
+  - `record RecipeIngredient(RecipeIngredientId id, ShoppingRequirement requirement, Quantity quantity)`
+  - `Recipe(RecipeId id, RecipeTitle title, RecipeServings baseServings, List<RecipeIngredient> ingredients)` with accessors and immutable ingredient exposure.
+
+- [ ] **Step 1: Write failing value-object tests**
+
+```java
+@Test
+void normalizesRecipeTitleWhitespaceWithoutChangingCase() {
+    assertThat(new RecipeTitle("  Pasta   Carbonara  ").value())
+            .isEqualTo("Pasta Carbonara");
+}
+
+@Test
+void rejectsBlankTitleAndNonPositiveServings() {
+    assertThatThrownBy(() -> new RecipeTitle("   "))
+            .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new RecipeServings(0))
+            .isInstanceOf(IllegalArgumentException.class);
+}
+
+@Test
+void rejectsNullIds() {
+    assertThatThrownBy(() -> new RecipeId(null))
+            .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new RecipeIngredientId(null))
+            .isInstanceOf(NullPointerException.class);
+}
+```
+
+- [ ] **Step 2: Run RED for missing Recipe value objects**
+
+Run:
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeValueObjectsTest test
+```
+
+Expected: FAIL at test compilation because Recipe types do not exist.
+
+- [ ] **Step 3: Implement the minimal value objects**
+
+Use compact record constructors. `RecipeTitle` must exactly mirror the established whitespace rule:
+
+```java
+value = Objects.requireNonNull(value, "value must not be null")
+        .strip()
+        .replaceAll("\\s+", " ");
+if (value.isBlank()) {
+    throw new IllegalArgumentException("value must not be blank");
+}
+```
+
+`RecipeServings` rejects `value <= 0`.
+
+- [ ] **Step 4: Run value-object GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeValueObjectsTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing aggregate tests**
+
+Cover:
+
+```java
+@Test
+void preservesIngredientOrderAndExposesImmutableList() {
+    var recipe = new Recipe(recipeId, title, servings, List.of(first, second));
+    assertThat(recipe.ingredients()).containsExactly(first, second);
+    assertThatThrownBy(() -> recipe.ingredients().add(first))
+            .isInstanceOf(UnsupportedOperationException.class);
+}
+
+@Test
+void rejectsEmptyIngredientsAndDuplicateIngredientIds() {
+    assertThatThrownBy(() -> new Recipe(recipeId, title, servings, List.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new Recipe(recipeId, title, servings, List.of(first, duplicateIdIngredient)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("duplicate");
+}
+```
+
+Also reject null recipe fields and null ingredient elements.
+
+- [ ] **Step 6: Run aggregate RED**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeTest test
+```
+
+Expected: FAIL at compile or assertions until aggregate exists.
+
+- [ ] **Step 7: Implement immutable Recipe aggregate**
+
+Implementation requirements:
+
+```java
+this.ingredients = List.copyOf(ingredients);
+```
+
+Validate non-empty input and duplicate `RecipeIngredientId` before assignment. Do not add mutation methods or persistence annotations.
+
+- [ ] **Step 8: Run Task 1 GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeValueObjectsTest,RecipeTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe \
+        apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe
+git commit -m "feat(m2): add immutable recipe domain"
+```
+
+---
+
+### Task 2: Exact-Safe Grouping and Serving Scaling
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeIngredientRef.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIdDeriver.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java`
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java`
+
+**Interfaces:**
+- Consumes Task 1 `Recipe`, `RecipeServings`, `RecipeIngredient`, plus existing Shopping Core types.
+- Produces:
+  - `record RecipeIngredientRef(RecipeId recipeId, RecipeIngredientId ingredientId)`
+  - `record RecipeShoppingListConversion(ShoppingList shoppingList, Map<ShoppingItemId, List<RecipeIngredientRef>> provenance)` with defensive immutable provenance copying.
+  - `RecipeShoppingListConverter.convert(Recipe recipe, RecipeServings targetServings, ShoppingListId shoppingListId)`.
+
+- [ ] **Step 1: Write one-to-one and canonicalization RED tests**
+
+Start with one ingredient and no merge:
+
+```java
+@Test
+void scalesOneIngredientIntoShoppingList() {
+    var recipe = recipe(4, ingredient("Flour", "400", QuantityUnit.GRAM));
+
+    var result = converter.convert(recipe, new RecipeServings(2), listId);
+
+    assertThat(result.shoppingList().items()).singleElement().satisfies(item -> {
+        assertThat(item.requirement()).isEqualTo(new ShoppingRequirement("Flour"));
+        assertThat(item.quantity()).isEqualTo(new Quantity(new BigDecimal("200"), QuantityUnit.GRAM));
+    });
+}
+
+@Test
+void reusesShoppingQuantityCanonicalization() {
+    var recipe = recipe(2, ingredient("Milk", "0.5", QuantityUnit.LITER));
+    var result = converter.convert(recipe, new RecipeServings(4), listId);
+    assertThat(result.shoppingList().items().getFirst().quantity())
+            .isEqualTo(new Quantity(new BigDecimal("1000"), QuantityUnit.MILLILITER));
+}
+```
+
+- [ ] **Step 2: Run converter RED**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeShoppingListConverterTest test
+```
+
+Expected: FAIL because conversion types do not exist.
+
+- [ ] **Step 3: Implement minimal one-to-one conversion with deterministic decimal scaling**
+
+Inside the converter, operate on the already-canonical `Quantity.amount()` / `Quantity.unit()` values.
+
+Use helper semantics equivalent to:
+
+```java
+private BigDecimal scale(BigDecimal summedBaseAmount, int target, int base) {
+    var numerator = summedBaseAmount.multiply(BigDecimal.valueOf(target));
+    try {
+        return numerator.divide(BigDecimal.valueOf(base));
+    } catch (ArithmeticException nonTerminating) {
+        return numerator.divide(BigDecimal.valueOf(base), MathContext.DECIMAL128);
+    }
+}
+```
+
+Construct the output `Quantity` from that amount and canonical unit.
+
+- [ ] **Step 4: Run one-to-one GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeShoppingListConverterTest test
+```
+
+Expected: initial converter tests PASS.
+
+- [ ] **Step 5: Add RED tests for exact-safe merge and non-merge behavior**
+
+Required cases:
+
+```java
+// merge after ShoppingRequirement whitespace normalization
+ingredient("  Milk  ", "500", MILLILITER)
+ingredient("Milk", "0.5", LITER)
+// => one Milk item, canonical 1000 ml before serving scaling
+
+// do not merge case difference
+"Milk" vs "milk"
+
+// do not merge synonym-like text
+"tomatoes" vs "tomato"
+
+// do not merge physical dimension mismatch
+"Eggs" in GRAM vs "Eggs" in PIECE
+```
+
+Also assert output group order follows first occurrence.
+
+- [ ] **Step 6: Implement grouping before scaling**
+
+Use a `LinkedHashMap<MergeKey, GroupAccumulator>` so first occurrence determines output order.
+
+`MergeKey` must be:
+
+```java
+private record MergeKey(ShoppingRequirement requirement, QuantityUnit unit) {}
+```
+
+Because `Quantity` canonicalizes at construction, `ingredient.quantity().unit()` is already canonical. Sum each group's canonical amount first; scale once after grouping.
+
+- [ ] **Step 7: Add and satisfy deterministic non-terminating ratio test**
+
+```java
+@Test
+void usesDeterministicDecimal128ForNonTerminatingScaleRatio() {
+    var recipe = recipe(3, ingredient("Spice", "100", QuantityUnit.GRAM));
+    var first = converter.convert(recipe, new RecipeServings(1), listId);
+    var second = converter.convert(recipe, new RecipeServings(1), listId);
+
+    assertThat(first.shoppingList().items().getFirst().quantity())
+            .isEqualTo(second.shoppingList().items().getFirst().quantity());
+    assertThat(first.shoppingList().items().getFirst().quantity().amount())
+            .isEqualByComparingTo(new BigDecimal("33.33333333333333333333333333333333"));
+}
+```
+
+- [ ] **Step 8: Run Task 2 GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeShoppingListConverterTest test
+```
+
+Expected: PASS for scaling, canonicalization, merge/non-merge and stable order.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe \
+        apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
+git commit -m "feat(m2): convert recipes into shopping lists"
+```
+
+---
+
+### Task 3: Deterministic Item Identity and Complete Provenance
+
+**Files:**
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIdDeriver.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConversion.java`
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java`
+
+**Interfaces:**
+- Consumes: Task 2 merge groups.
+- Produces deterministic `ShoppingItemId` and immutable `Map<ShoppingItemId, List<RecipeIngredientRef>>`.
+
+- [ ] **Step 1: Write deterministic identity RED tests**
+
+Test these invariants independently:
+
+```java
+same recipe + same listId + same targetServings -> same item IDs
+same listId + changed targetServings -> same item IDs
+same logical requirement expressed kg vs g -> same item ID
+different listId -> different item ID
+different requirement or canonical unit -> different item ID
+```
+
+- [ ] **Step 2: Implement default deterministic ID derivation**
+
+The identity payload is exactly:
+
+```text
+<shoppingListUuid>\n<normalizedRequirementText>\n<CANONICAL_UNIT_NAME>
+```
+
+Use:
+
+```java
+UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8))
+```
+
+Return `new ShoppingItemId(uuid)`.
+
+`RecipeShoppingItemIdDeriver` should be a package-private functional interface so tests can inject a collision-producing implementation without exposing the seam outside the recipe package.
+
+- [ ] **Step 3: Run identity GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeShoppingListConverterTest test
+```
+
+Expected: PASS identity tests.
+
+- [ ] **Step 4: Write provenance RED tests**
+
+Required assertions:
+
+```java
+@Test
+void recordsSelfContainedProvenanceForMergedIngredients() {
+    var result = converter.convert(recipeWithTwoMergeableIngredients, target, listId);
+    var item = result.shoppingList().items().getFirst();
+
+    assertThat(result.provenance().get(item.id()))
+            .containsExactly(
+                    new RecipeIngredientRef(recipeId, firstIngredientId),
+                    new RecipeIngredientRef(recipeId, secondIngredientId));
+}
+```
+
+Also prove:
+- every output item has exactly one map entry;
+- every contributing ingredient appears exactly once;
+- provenance order follows source ingredient order;
+- map and nested lists reject mutation.
+
+- [ ] **Step 5: Implement defensive provenance copying**
+
+Build in `LinkedHashMap` order, then copy every value with `List.copyOf` and expose an unmodifiable copy preserving insertion order, e.g.:
+
+```java
+var copy = new LinkedHashMap<ShoppingItemId, List<RecipeIngredientRef>>();
+provenance.forEach((id, refs) -> copy.put(id, List.copyOf(refs)));
+this.provenance = Collections.unmodifiableMap(copy);
+```
+
+Do not use a mutable list/map reference supplied by converter internals.
+
+- [ ] **Step 6: Write collision RED test through the package-private ID seam**
+
+Inject an ID deriver that always returns the same fixed `ShoppingItemId` for two different merge keys. Expected conversion behavior:
+
+```java
+assertThatThrownBy(() -> collisionConverter.convert(recipeWithTwoDifferentKeys, target, listId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("collision");
+```
+
+- [ ] **Step 7: Implement fail-closed collision detection**
+
+Before adding a generated item, track `ShoppingItemId -> MergeKey`. If the same ID is already associated with a different merge key, throw `IllegalStateException`; do not overwrite/merge the groups.
+
+- [ ] **Step 8: Run Task 3 GREEN**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeShoppingListConverterTest test
+```
+
+Expected: PASS all identity/provenance/collision tests.
+
+- [ ] **Step 9: Commit Task 3**
+
+```bash
+git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe \
+        apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
+git commit -m "test(m2): harden recipe identity and provenance"
+```
+
+---
+
+### Task 4: Architecture Gate, Full Verification, and Project State
+
+**Files:**
+- Verify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/ApplicationArchitectureTest.java`
+- Modify after code GREEN: `docs/PROJECT_STATE.md`
+- Modify after code GREEN: `docs/ROADMAP.md`
+- Modify after code GREEN: `CHANGELOG.md`
+- Create: `docs/superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md` only at shipping marker stage.
+
+**Interfaces:**
+- Consumes: all Tasks 1–3.
+- Produces: verified M2.1 candidate with durable project-state evidence.
+
+- [ ] **Step 1: Run focused recipe suite**
+
+```bash
+cd apps/api
+./mvnw -Dtest=RecipeValueObjectsTest,RecipeTest,RecipeShoppingListConverterTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Spring Modulith architecture verification explicitly**
+
+```bash
+cd apps/api
+./mvnw -Dtest=ApplicationArchitectureTest test
+```
+
+Expected: PASS. The new top-level `recipe` module may depend on `shopping`; no reverse dependency/cycle may appear.
+
+- [ ] **Step 3: Run full API verification**
+
+```bash
+cd apps/api
+./mvnw verify
+```
+
+Expected: `BUILD SUCCESS` with all API tests green.
+
+- [ ] **Step 4: Review production code for forbidden dependencies/scope**
+
+Check the changed production files and confirm:
+
+```text
+recipe imports shopping: allowed
+shopping imports recipe: none
+Spring annotations in recipe converter/domain: none
+network/database/clock dependencies: none
+new Maven dependency: none
+REST/OpenAPI/web changes: none
+```
+
+If any forbidden dependency exists, remove it and repeat Steps 1–3.
+
+- [ ] **Step 5: Update canonical docs only after code is GREEN**
+
+Record:
+- #93 / M2.1 `IMPLEMENTED / TESTED / SHIPPING` until merge;
+- exact-safe merge semantics;
+- deterministic DECIMAL128 fallback for non-terminating serving ratios;
+- deterministic list-scoped item identity;
+- provenance remains outside Shopping Core;
+- next slice is Recipe application/API boundary, not AI import or fuzzy matching.
+
+- [ ] **Step 6: Run repository PR gates on exact head**
+
+Required workflow groups:
+
+```text
+API CI
+Contract CI
+Web CI / Web E2E
+CodeQL
+Dependency Review
+Container Security CI
+Retailer Bridge CI
+Release Contract CI
+Release Bundle CI
+```
+
+Expected: 9/9 workflow groups success; no P0/P1/P2 review findings.
+
+- [ ] **Step 7: Add shipping evidence marker and re-run exact-head gate**
+
+Shipping marker must record:
+- reviewed implementation SHA;
+- focused recipe tests PASS;
+- full `./mvnw verify` PASS;
+- architecture verification PASS;
+- review verdict;
+- final 9/9 workflow status.
+
+The marker commit itself must receive a second exact-head 9/9 PASS before merge.
+
+- [ ] **Step 8: Squash merge and verify main**
+
+Merge strictly against the verified final head SHA. Then require all push-triggered main workflows to complete successfully before closing #93 as `completed`.
+
+- [ ] **Step 9: Commit project-state/shipping docs**
+
+```bash
+git add docs/PROJECT_STATE.md docs/ROADMAP.md CHANGELOG.md docs/superpowers/plans
+git commit -m "docs(m2): record recipe domain shipping evidence"
+```
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: all domain validation, scaling, merge, identity, provenance, module-boundary, network-free and shipping requirements are mapped to Tasks 1–4.
+- Placeholder scan: no TBD/TODO/"implement later" instructions remain.
+- Type consistency: converter, provenance and identity signatures are defined once and reused consistently.
+- Scope: one domain/conversion subsystem only; REST/OpenAPI/UI/persistence remain explicit follow-up work.
+- Numerical correctness: exact division is attempted first; only non-terminating division uses `MathContext.DECIMAL128`; group amounts are summed before scaling.
+- Shopping boundary: no production Shopping Core file is planned for modification.

--- a/docs/superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md
+++ b/docs/superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md
@@ -1,0 +1,339 @@
+# M2.1 — Deterministic Recipe Domain and Recipe → ShoppingList Conversion
+
+Date: 2026-08-13  
+Status: **DESIGN APPROVED / SPEC REVIEW**  
+Issue: #93  
+Baseline: `7fc38a8ef5c9866c015a3b63f913d7acee3675f7`  
+Parent decision: M1 Shopping Core **COMPLETE / ACCEPTED**, GO to M2 Recipes
+
+## 1. Goal
+
+Introduce recipes as a first-class deterministic source of shopping requirements without weakening the accepted M1 Shopping Core boundaries.
+
+The first M2 slice is deliberately domain-only:
+
+`Recipe → explicit ingredients → serving scaling → exact-safe merge → ShoppingList + provenance`
+
+REST/OpenAPI, generated client and web UI are separate follow-up slices after this model is accepted.
+
+## 2. Architectural decision
+
+Use a **separate Recipe aggregate plus a converter into Shopping Core**.
+
+Dependency direction:
+
+```text
+recipe domain
+    |
+    | uses existing ShoppingRequirement / Quantity / ShoppingList types
+    v
+shopping domain
+```
+
+`shopping` must not import or reference `recipe`.
+
+Recipe-specific lineage is not added to `ShoppingItem`. Manual lists therefore remain recipe-agnostic and the M1 aggregate does not gain optional origin fields that only M2 understands.
+
+## 3. Domain model
+
+### 3.1 RecipeId
+
+`RecipeId` is a non-null UUID-backed value object.
+
+### 3.2 RecipeIngredientId
+
+`RecipeIngredientId` is a non-null UUID-backed value object.
+
+Ingredient IDs must be unique inside one recipe. Duplicate IDs fail construction.
+
+### 3.3 RecipeTitle
+
+`RecipeTitle` owns presentation-safe normalization:
+
+- non-null;
+- `strip()` leading/trailing whitespace;
+- collapse internal whitespace to one space;
+- blank after normalization is invalid;
+- preserve case and punctuation.
+
+Title normalization is not ingredient semantic normalization.
+
+### 3.4 RecipeServings
+
+`RecipeServings` is a positive integer value object.
+
+The first slice intentionally does not support fractional servings. This keeps scaling input and identity semantics explicit while still allowing non-integer scale ratios such as 1 serving from a 3-serving recipe.
+
+No arbitrary upper bound is introduced without product evidence.
+
+### 3.5 RecipeIngredient
+
+Each ingredient contains:
+
+- `RecipeIngredientId id`;
+- existing `ShoppingRequirement requirement`;
+- existing `Quantity quantity`.
+
+The Recipe domain does not introduce another unit enum or quantity-normalization implementation. `Quantity` remains authoritative for canonical `kg → g` and `l → ml` conversion and positive-amount validation.
+
+### 3.6 Recipe
+
+`Recipe` contains:
+
+- `RecipeId id`;
+- `RecipeTitle title`;
+- `RecipeServings baseServings`;
+- ordered immutable `List<RecipeIngredient> ingredients`.
+
+Rules:
+
+- recipe must contain at least one ingredient;
+- ingredient order is preserved;
+- duplicate `RecipeIngredientId` values are rejected;
+- duplicate requirements are allowed because the converter owns safe merging.
+
+The initial aggregate is immutable. Mutation commands/persistence are intentionally deferred until an API/storage slice needs them.
+
+## 4. Conversion contract
+
+Introduce a pure converter with no network, database, Spring context or clock dependency.
+
+Input:
+
+- `Recipe recipe`;
+- `RecipeServings targetServings`;
+- caller-provided `ShoppingListId shoppingListId`.
+
+Output:
+
+`RecipeShoppingListConversion` containing:
+
+1. generated `ShoppingList`;
+2. immutable provenance map keyed by generated `ShoppingItemId`.
+
+Each provenance value is an ordered immutable list of `RecipeIngredientRef(recipeId, ingredientId)` so lineage remains self-contained even when future M3 work combines multiple recipes.
+
+The converter does not mutate the input recipe.
+
+## 5. Serving scaling
+
+For each merge group, calculate:
+
+```text
+scaledAmount = canonicalBaseAmount * targetServings / baseServings
+```
+
+Rules:
+
+1. Use `BigDecimal` only; never `double`/`float`.
+2. Sum canonical base amounts inside a merge group **before** scaling. This prevents repeated rounding from changing a merged result.
+3. Multiply by target servings before division.
+4. If division terminates, keep the exact decimal result.
+5. If division is non-terminating, use `MathContext.DECIMAL128` for the division.
+6. Construct the resulting existing `Quantity`, which performs the established canonical normalization.
+
+Examples:
+
+- 400 g at 4 → 2 servings = 200 g exactly;
+- 0.5 kg at 2 → 4 servings = 1000 g through existing canonicalization;
+- 100 g at 3 → 1 serving = deterministic DECIMAL128 representation of 100/3 g.
+
+Formatting/rounding for human recipe presentation is a later UI concern and must not silently alter the shopping requirement in this domain slice.
+
+## 6. Exact-safe ingredient merge
+
+Ingredients merge only when both values are equal **after existing value-object normalization**:
+
+```text
+MergeKey = (ShoppingRequirement, canonical QuantityUnit)
+```
+
+Consequences:
+
+- `"Молоко"` + `"Молоко"`, both volume → merge;
+- `" Молоко   "` + `"Молоко"`, both volume → merge because `ShoppingRequirement` already normalizes whitespace;
+- `"Молоко"` + `"молоко"` → do not merge;
+- `"томаты"` + `"помидоры"` → do not merge;
+- same requirement in grams + kilograms → merge because `Quantity` canonicalizes both to grams;
+- same requirement in grams + pieces → do not merge;
+- same requirement in milliliters + liters → merge because both canonicalize to milliliters.
+
+No fuzzy matching, synonym dictionary, category inference or AI equivalence is introduced.
+
+Group order follows the first ingredient that introduced each merge key. Provenance order follows original recipe ingredient order.
+
+## 7. Deterministic ShoppingItem identity
+
+The same conversion inputs must produce the same generated shopping-item IDs.
+
+For each merge group, derive `ShoppingItemId` from a canonical UTF-8 identity payload containing:
+
+- `ShoppingListId` UUID;
+- normalized requirement text;
+- canonical quantity-unit name.
+
+Use Java's deterministic name-based UUID facility over this payload. IDs do not depend on amount, ingredient order after grouping, recipe title or target servings.
+
+Rationale:
+
+- changing servings changes quantity but not the logical shopping requirement identity;
+- kg/g input representation does not change identity after canonicalization;
+- a caller can intentionally obtain a new identity namespace by supplying a different `ShoppingListId`.
+
+The converter must fail closed if a generated ID collision maps two different merge keys to the same ID, even though such a collision is practically improbable.
+
+## 8. Provenance semantics
+
+For every generated `ShoppingItem` there must be exactly one provenance-map entry.
+
+For a non-merged ingredient:
+
+```text
+ShoppingItemId -> [RecipeIngredientRef(recipeId, ingredientId)]
+```
+
+For a merged group:
+
+```text
+ShoppingItemId -> [ref(first ingredient), ref(second ingredient), ...]
+```
+
+No contributing ingredient may be lost or duplicated.
+
+Provenance is read-only output metadata. Shopping Core types remain unchanged.
+
+## 9. Error handling / fail-closed rules
+
+Reject at construction/conversion boundary:
+
+- null IDs/value objects/lists;
+- blank recipe title;
+- zero/negative servings;
+- empty recipe ingredient list;
+- duplicate ingredient IDs;
+- null ingredients;
+- impossible/null conversion inputs;
+- generated ShoppingItem ID collision across different merge keys.
+
+Existing `ShoppingRequirement` and `Quantity` continue to reject their own invalid states.
+
+There is no best-effort conversion that silently drops a malformed ingredient.
+
+## 10. Package/module boundary
+
+New production code belongs under a dedicated recipe package/module, e.g.:
+
+```text
+io.github.trueruslan.zakupgotov.recipe
+```
+
+Allowed direction:
+
+```text
+recipe -> shopping
+```
+
+Forbidden direction:
+
+```text
+shopping -> recipe
+```
+
+Add/extend architecture verification so the accepted Shopping Core cannot acquire a Recipe dependency accidentally.
+
+## 11. Testing strategy
+
+Follow RED → GREEN with focused deterministic tests.
+
+### Domain validation
+
+- ID null rejection;
+- title whitespace normalization and blank rejection;
+- positive servings only;
+- non-empty ingredient collection;
+- duplicate ingredient-ID rejection;
+- immutable ingredient exposure.
+
+### Scaling
+
+- target == base;
+- integer scale up/down;
+- exact non-integer ratio;
+- non-terminating ratio (`1/3`) uses deterministic DECIMAL128;
+- kg/g and l/ml reuse existing canonicalization;
+- repeated conversion returns equal quantities.
+
+### Merge
+
+- exact normalized requirement + canonical unit merges;
+- whitespace-normalized text merges;
+- case difference does not merge;
+- synonym-like text does not merge;
+- unit-dimension mismatch does not merge;
+- merged quantity sums before scaling;
+- first-occurrence output order is stable.
+
+### Identity
+
+- same list ID + merge key → same item ID;
+- servings change → same item ID;
+- kg/g representation after canonicalization → same item ID;
+- different list ID → different item ID;
+- different requirement/unit → different item ID.
+
+### Provenance
+
+- every item has one provenance entry;
+- non-merged item points to the exact recipe/ingredient;
+- merged item preserves all contributing refs in source order;
+- output map/lists are immutable.
+
+### Architecture
+
+- recipe may depend on shopping;
+- shopping must not depend on recipe;
+- no Spring/network/persistence dependency in converter.
+
+Then run full API verification and repository PR gates.
+
+## 12. Non-goals
+
+Not part of this slice:
+
+- REST endpoints;
+- OpenAPI schemas;
+- generated TypeScript client;
+- recipe web UI;
+- persistence/repository layer;
+- AI/NLP ingredient extraction;
+- arbitrary website import;
+- fuzzy/case-insensitive ingredient equivalence;
+- nutrition/calorie calculations;
+- pantry prediction;
+- unit conversion across physical dimensions;
+- fractional servings input;
+- combining multiple recipes into one list (M3 concern).
+
+## 13. Acceptance criteria
+
+M2.1 domain slice is accepted when:
+
+1. Recipe value objects and immutable aggregate enforce all invariants.
+2. Existing Shopping Core quantity/text semantics are reused rather than reimplemented.
+3. Serving scaling is deterministic for terminating and non-terminating ratios.
+4. Only exact-safe compatible requirements merge.
+5. Generated shopping-item identity is deterministic and list-scoped.
+6. Complete immutable recipe/ingredient provenance accompanies every generated item.
+7. Shopping Core has no dependency on Recipe.
+8. Normal CI remains network-free.
+9. Full API/repository gates pass on exact PR head.
+10. Independent review reports no P0/P1/P2.
+11. Merge is followed by green post-merge `main` verification.
+
+## 14. Follow-up after acceptance
+
+The next slice may add the contract/application boundary:
+
+`Recipe request → Recipe domain → RecipeShoppingListConversion → comparison input`
+
+That follow-up will own REST/OpenAPI/generated-client decisions and only then introduce the minimal responsive recipe flow.


### PR DESCRIPTION
## Goal

Implement #93 / M2.1 from the approved design and implementation plan.

## Scope

- separate immutable Recipe aggregate;
- deterministic serving scaling;
- exact-safe ingredient merge using existing ShoppingRequirement/Quantity semantics;
- deterministic list-scoped ShoppingItem IDs;
- immutable RecipeId + RecipeIngredientId provenance;
- Shopping Core remains recipe-agnostic.

## Non-goals

No persistence, REST/OpenAPI, generated client, web UI, AI/NLP import, fuzzy ingredient equivalence, nutrition or pantry logic.

## Process

TDD RED→GREEN. This PR is draft until focused/full API verification, Modulith architecture verification, independent review and all repository workflow groups are green.