### PR TITLE
docs(m2): finalize recipe shopping preview acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,11 +73,12 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M1 Shopping Core is **COMPLETE / ACCEPTED** on the post-merge pre-acquisition-gate baseline `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 - The M1→M2 decision is **GO for deterministic product/core development**; it does not claim every retailer is production-ready.
 - M2.1 `Recipe → explicit ingredients → canonical quantities → ShoppingList` is **COMPLETE / ACCEPTED** after squash merge `423eb14f7c565bbe264257a92df89a6b42d0d158` and 8/8 successful post-merge `main` workflows.
-- M2.2 is **implemented/tested and in shipping review, not yet accepted**: the stateless recipe application boundary, OpenAPI/generated client and regression coverage exist in PR #97, while final exact-head review/merge/post-merge proof remains required.
+- M2.2 stateless Recipe application/API boundary is **COMPLETE / ACCEPTED** after final exact-head 9/9 PR workflow success, independent review with no P0/P1/P2/P3 findings, squash merge `8f0c1d8d31cfc1673656780a7989512d38788aff`, and 8/8 successful post-merge `main` workflows; issue #96 is closed `completed`.
+- M2.3 composed Recipe → Comparison flow is the current next deterministic design target; it must preserve Recipe provenance and accepted comparison/production-access semantics without duplicating either boundary.
 - Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
 - Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`; M2.2 projects that provenance publicly as self-contained source ingredient IDs instead of modifying Shopping Core types.
 - The M2.2 lifecycle decision is stateless for the current hypothesis-testing phase; persistence remains deferred until reusable saved recipes become a demonstrated product requirement.
-- Recipe preview conversion does not directly orchestrate retailer comparison. The next deterministic slice after M2.2 acceptance is explicit composition of the recipe-shopping preview with the accepted comparison-preview boundary.
+- Recipe preview conversion does not directly orchestrate retailer comparison. M2.3 will explicitly compose the accepted recipe-shopping-preview and comparison-preview capabilities while keeping their domain semantics separate.
 - Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
 - `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -13,8 +13,8 @@ M0 status: **technical discovery COMPLETE**
 M1 status: **Shopping Core COMPLETE / ACCEPTED**  
 M1→M2 decision: **GO** — [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md)  
 M2.1 status: **Recipe domain + Recipe → ShoppingList COMPLETE / ACCEPTED (#94 / #93)**  
-M2.2 status: **Recipe application/API boundary IMPLEMENTED / TESTED / SHIPPING (#97 / #96); not yet accepted**  
-Current focus: **finish exact-head verification and independent review for M2.2, then merge/post-merge acceptance proof**
+M2.2 status: **Stateless Recipe application/API boundary COMPLETE / ACCEPTED (#97 / #96)**  
+Current focus: **design M2.3 composed Recipe → Comparison flow while preserving Recipe provenance and accepted comparison/production-access invariants**
 
 ## Permanent connectivity rule
 
@@ -131,53 +131,65 @@ Verification evidence before merge:
 
 M2.1 intentionally did **not** add REST/OpenAPI/generated-client contracts, persistence, recipe UI, AI/NLP import, fuzzy ingredient equivalence, nutrition optimization, pantry prediction, fractional servings, or multi-recipe aggregation.
 
-### M2.2 — Stateless Recipe shopping preview application/API boundary — IMPLEMENTED / TESTED / SHIPPING (#97 / #96)
+### M2.2 — Stateless Recipe shopping preview application/API boundary — COMPLETE / ACCEPTED (#97 / #96)
 
 Authoritative design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`](superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md).  
-Execution plan: [`superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md`](superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md).
+Execution plan: [`superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md`](superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md).  
+Shipping/acceptance evidence: [`superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md`](superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md).
 
-Implemented boundary:
+Accepted boundary:
 
 `POST /api/v1/recipe-shopping-previews`
 
 `HTTP recipe request → request validation + server-owned transient IDs → Recipe domain → RecipeShoppingListConverter → self-contained ShoppingList projection`
 
-Implemented behavior:
+Accepted behavior:
 
 - stateless request/response; no Recipe persistence or CRUD;
 - server-owned Recipe, ingredient and ShoppingList UUIDs; clients cannot supply internal identities;
 - normalized title/requirements, positive integer base/target servings and 1..100 explicit ingredients;
-- strict JSON integer handling for servings so fractional serving counts fail as unreadable input rather than being silently coerced;
+- strict recipe-scoped JSON integer handling for servings; fractional serving counts fail as unreadable input instead of being silently coerced, while decimal ingredient quantities remain valid;
 - input quantity units reuse `PIECE / GRAM / KILOGRAM / MILLILITER / LITER`; output uses existing canonical `PIECE / GRAM / MILLILITER` semantics;
 - all scaling, exact-safe merge grouping, ordering and deterministic ShoppingItem identity remain delegated to accepted M2.1 `RecipeShoppingListConverter`;
-- response contains canonical base-recipe ingredients plus generated shopping items;
-- every shopping item exposes ordered `sourceIngredientIds` resolving to exactly one ingredient in the same response;
+- response contains normalized/canonical base-recipe ingredients plus generated shopping items;
+- every shopping item exposes ordered `sourceIngredientIds` resolving to ingredients in the same response;
 - missing, orphan, cross-recipe or mismatched-list provenance fails closed as an internal invariant failure;
 - request validation returns ordered `INVALID_RECIPE_SHOPPING_PREVIEW` problem details; malformed/unknown-field/unknown-unit/non-integer binding failures return one sanitized `$request` error;
-- controller is thin; controller-scoped advice handles only known request validation/unreadable-body failures; internal invariant failures are not mislabeled as 400;
+- controller remains thin; controller-scoped advice handles only known semantic/unreadable request failures; internal invariant failures are not mislabeled as 400;
 - OpenAPI 3.1 is source of truth for the endpoint and schemas;
 - generated TypeScript client exports `RECIPE_SHOPPING_PREVIEWS_PATH` and generated request/response types;
 - architecture guards preserve `recipepreview → recipe → shopping` / `recipepreview → shopping` direction and forbid provider/retailer/matching/basket/comparison/database dependencies;
 - no retailer network request, address/location data, persistence, recipe UI, comparison orchestration or fuzzy/AI matching is introduced.
 
-Verification evidence achieved before the final documentation/review head:
+Acceptance evidence:
 
-- application wiring defect was found by API CI and fixed with explicit recipe-preview Spring configuration plus production UUID generator;
-- unreadable-body regression exposed fractional JSON serving coercion in standalone controller tests; the test stack was aligned with production Jackson 3 while strictness remains recipe-scoped through `StrictIntegerDeserializer`;
-- OpenAPI/client TDD RED was observed for missing path/export/response schema before contract implementation;
-- generated-schema freshness RED was observed after the OpenAPI change, and the committed `schema.d.ts` matches the actual `openapi-typescript 7.13.0` output;
-- exact code checkpoint `b451dacbec41e3d7bd75ce4580f76fb6f86d5cae` completed **13/13 check runs successfully across all 9 normal PR workflow groups**, including API CI/full Maven verification, Contract CI, Web CI + Web E2E, Retailer Bridge CI, CodeQL Java + JS/TS, Dependency Review, Container Security API/Web, Release Contract CI and Release Bundle CI;
-- read-only review of that checkpoint found one low-risk design drift: unreadable-body handling lived in the controller instead of the approved controller-scoped advice; the drift was corrected before shipping documentation.
+- granular TDD recorded clean behavioral/contract RED checkpoints before their corresponding GREEN implementations; syntax/compile mistakes were corrected and rerun rather than counted as behavioral RED;
+- full API verification continued to exercise Spring Boot context, Spring Modulith and the existing PostgreSQL 18/Testcontainers/Flyway integration baseline; no artificial M2.2 persistence was introduced for test-count optics;
+- a real fractional-servings RED exposed Jackson's default `1.5 → Integer` coercion, fixed locally through `StrictIntegerDeserializer` without changing global API binding behavior;
+- OpenAPI/generated-client RED and generated-schema freshness RED were observed before contract synchronization;
+- final exact PR head `318a48c569d0d001a4c27b5792e1681f7884e518` passed all 9 normal PR workflow groups, including full API CI, Contract CI, Web CI + responsive Playwright E2E, Retailer Bridge CI + Chromium E2E, CodeQL Java + JS/TS, Dependency Review, Container Security, Release Contract and Release Bundle;
+- final independent review: **Looks good**, no P0/P1/P2/P3; review threads empty;
+- accepted squash merge: `8f0c1d8d31cfc1673656780a7989512d38788aff` (`feat(m2): add stateless recipe shopping preview API (#97)`);
+- post-merge proof on exact `main=8f0c1d8d31cfc1673656780a7989512d38788aff`: 8 push-triggered workflows total, 8/8 `success`, 0 failures;
+- issue #96 closed automatically with `state_reason=completed`.
 
-**Acceptance is not claimed yet.** The final documentation/review head must pass exact-head CI, complete independent review with no unresolved P0/P1/P2, squash-merge, and then pass normal post-merge `main` workflows before M2.2 can be marked `COMPLETE / ACCEPTED`.
+### M2.3 — Composed Recipe → Comparison flow — CURRENT NEXT DESIGN TARGET
 
-### M2.3 direction after M2.2 acceptance
-
-Next deterministic vertical slice:
+Target deterministic path:
 
 `Recipe input → recipe-shopping preview → generated shopping requirements → comparison preview`
 
-Only after that composed flow is stable should the real responsive Recipe UI be implemented with frontend component TDD and desktop/mobile Playwright. Persistence, saved recipes and fuzzy/AI ingestion remain separate product decisions.
+Required design constraints:
+
+- compose accepted Recipe and Comparison semantics without duplicating either domain;
+- preserve Recipe/ingredient provenance through the composed result instead of losing identity at an HTTP handoff;
+- keep server-owned transient identity and provider/fulfillment internals on the correct side of the boundary;
+- preserve existing production-access gating before evidence acquisition;
+- preserve complete/uncertain/incomplete/unavailable comparison states and no-total-on-incomplete behavior;
+- keep ordinary CI retailer-network-free;
+- define application/contract tests RED-first before introducing Recipe UI.
+
+Only after the composed flow is accepted should the first real responsive Recipe UI be implemented with frontend component TDD and desktop/mobile Playwright RED-first. Persistence, saved recipes and fuzzy/AI ingestion remain separate product decisions.
 
 ## Parallel mandatory work
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,24 +98,25 @@ Post-merge proof on exact `main`:
 - fractional servings;
 - multi-recipe aggregation.
 
-### M2.2 — Stateless Recipe application/API boundary — IMPLEMENTED / TESTED / SHIPPING (#97 / #96)
+### M2.2 — Stateless Recipe application/API boundary — COMPLETE / ACCEPTED (#97 / #96)
 
 Authoritative design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`](superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md).  
-Execution plan: [`superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md`](superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md).
+Execution plan: [`superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md`](superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md).  
+Shipping/acceptance evidence: [`superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md`](superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md).
 
-Approved and implemented direction:
+Accepted direction:
 
 `POST /api/v1/recipe-shopping-previews`
 
 `Recipe request → application validation/server-owned transient IDs → Recipe domain → RecipeShoppingListConverter → canonical ShoppingList projection`
 
-#### Implemented scope
+#### Accepted scope
 
 - stateless lifecycle; no saved Recipe persistence/CRUD;
 - server-generated Recipe, ingredient and ShoppingList identities;
 - request: normalized title, positive integer base/target servings, 1..100 explicit ingredient requirements/quantities;
 - input quantities reuse Shopping Core units; output uses canonical Shopping Core quantities;
-- strict JSON integer binding for servings; fractional ingredient quantities remain allowed;
+- strict recipe-scoped JSON integer binding for servings; fractional ingredient quantities remain allowed;
 - conversion semantics remain exclusively owned by accepted M2.1 `RecipeShoppingListConverter`;
 - self-contained response provenance through ordered `sourceIngredientIds` resolving within the returned recipe;
 - fail-closed projection invariants for mismatched list identity and missing/orphan/cross-recipe provenance;
@@ -124,13 +125,18 @@ Approved and implemented direction:
 - application architecture guards preventing provider/retailer/matching/basket/comparison/database coupling;
 - no retailer traffic, location lookup, persistence, Recipe→Comparison orchestration, Recipe UI or fuzzy/AI matching.
 
-#### Verification state
+#### Acceptance verification
 
-A fully implemented code checkpoint `b451dacbec41e3d7bd75ce4580f76fb6f86d5cae` passed **13/13 PR checks across all 9 normal workflow groups**, including API/full Maven verification, generated-contract verification, Web + desktop/mobile Playwright regression, retailer bridge, CodeQL, dependency review, container security, release contract and release bundle.
+- TDD evidence records clean RED→GREEN cycles for architecture, mapping/IDs, null/limit/nested validation, service/projection, fail-closed provenance invariants, HTTP error contracts, strict servings binding and OpenAPI/generated-client synchronization;
+- full API `verify` preserved the Spring Boot/Modulith and PostgreSQL 18/Testcontainers/Flyway integration baseline without inventing Recipe persistence;
+- final exact PR head `318a48c569d0d001a4c27b5792e1681f7884e518` passed all 9 normal PR workflow groups;
+- Web CI responsive Chromium Playwright E2E and Retailer Bridge Chromium E2E both passed on that exact head;
+- final independent review: **Looks good**, no P0/P1/P2/P3; review threads empty;
+- accepted squash merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`;
+- exact merged `main=8f0c1d8d31cfc1673656780a7989512d38788aff`: 8/8 push workflows success, 0 failures;
+- #96 closed `completed`.
 
-Read-only review then found one low-risk design drift: malformed-body handling was in the controller instead of the approved controller-scoped advice. The correction keeps the controller thin and centralizes both known request-failure paths in the advice. Because that correction and these documentation changes move the PR head, M2.2 remains **not accepted** until the final exact head is green, independent review has no unresolved P0/P1/P2, the PR is squash-merged, and normal post-merge `main` workflows pass.
-
-### M2.3 — Composed Recipe → Comparison flow — NEXT AFTER M2.2 ACCEPTANCE
+### M2.3 — Composed Recipe → Comparison flow — CURRENT NEXT DESIGN TARGET
 
 Target deterministic path:
 
@@ -138,11 +144,13 @@ Target deterministic path:
 
 Goals:
 
-- compose the two accepted stateless boundaries without duplicating recipe or comparison semantics;
-- preserve self-contained recipe provenance while keeping retailer/provider internals out of the Recipe API;
-- preserve existing production-access gating and fail-closed comparison states;
-- add contract/application tests before introducing UI;
-- keep retailer traffic absent from ordinary CI.
+- compose the two accepted stateless capabilities without duplicating recipe or comparison semantics;
+- preserve Recipe/ingredient provenance through the composed application result rather than losing item identity at a public two-step HTTP handoff;
+- keep server-owned transient identity, provider and fulfillment internals behind appropriate boundaries;
+- preserve production-access gating before any evidence source invocation;
+- preserve complete / uncertain / incomplete / unavailable comparison semantics, including no aggregate total for incomplete baskets;
+- add application/contract/architecture tests RED-first before introducing UI;
+- keep ordinary CI retailer-network-free.
 
 After the composed flow is accepted, implement the first real responsive Recipe UI using frontend component TDD and desktop/mobile Playwright RED-first.
 
@@ -150,7 +158,7 @@ Do **not** add persistence, saved recipes or fuzzy/AI ingestion merely because M
 
 ### M2 exit direction
 
-After the stateless application boundary and composed comparison flow are accepted, extend toward the minimal usable Recipe UI and then deterministic multi-recipe aggregation needed by M3 Weekly Planning. Do not introduce fuzzy/AI ingestion until deterministic recipe semantics remain stable through these application boundaries.
+After the composed comparison flow is accepted, extend toward the minimal usable Recipe UI and then deterministic multi-recipe aggregation needed by M3 Weekly Planning. Do not introduce fuzzy/AI ingestion until deterministic recipe semantics remain stable through these application boundaries.
 
 ## Parallel connectivity / operational work
 

--- a/docs/superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md
+++ b/docs/superpowers/plans/2026-08-14-m2-2-recipe-shopping-preview-shipping.md
@@ -5,7 +5,7 @@ Issue: #96
 PR: #97  
 Authoritative design: `docs/superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`  
 Execution plan: `docs/superpowers/plans/2026-08-13-m2-2-recipe-shopping-preview-v2.md`  
-Status: **SHIPPING CANDIDATE — merge/post-merge acceptance pending**
+Status: **COMPLETE / ACCEPTED**
 
 ## Scope delivered
 
@@ -59,11 +59,13 @@ At implementation checkpoint `b451dacbec41e3d7bd75ce4580f76fb6f86d5cae`:
 
 The same SHA produced 13/13 successful check runs across all 9 normal PR workflow groups, including separate Web E2E, CodeQL language and container-security jobs.
 
+Final exact PR head `318a48c569d0d001a4c27b5792e1681f7884e518` independently passed all 9 normal PR workflow groups after the review correction and canonical documentation updates.
+
 ## Frontend / browser regression
 
-M2.2 introduces no browser-visible Recipe UI. The existing frontend regression gate remains mandatory instead of fabricating a screen only to claim E2E coverage.
+M2.2 introduces no browser-visible Recipe UI. The existing frontend regression gate remained mandatory instead of fabricating a screen only to claim E2E coverage.
 
-At `b451dacb...`, Web CI `31777817425` succeeded for both jobs. `Web E2E` successfully built the production Next.js app, installed Chromium and completed the responsive Playwright regression.
+At the final PR head, Web CI completed both the normal web job and responsive Chromium Playwright E2E successfully. Retailer Bridge CI also completed its independent Chromium E2E successfully.
 
 The next real Recipe frontend slice must start RED-first and add desktop/mobile Playwright coverage for recipe editing, servings, ingredient add/remove, quantity/unit input, API errors, generated shopping list and transition into comparison.
 
@@ -71,30 +73,30 @@ The next real Recipe frontend slice must start RED-first and add desktop/mobile 
 
 Independent read-only review checked the authoritative v2 design, request and response contracts, ID ownership, validation ordering, Jackson binding, conversion delegation, provenance integrity, internal-error propagation, OpenAPI/generated-client synchronization, architecture boundaries, regression surface and security/privacy implications.
 
-Initial verdict: **Caution**, with no P0/P1/P2 findings and one P3 structural drift: unreadable-body handling lived in the controller instead of the controller-scoped advice required by the approved design.
+Initial review found one P3 structural drift: unreadable-body handling lived in the controller instead of the controller-scoped advice required by the approved design. The P3 was corrected before merge:
 
-The P3 was corrected before final shipping:
+- `RecipeShoppingPreviewController` only delegates to the application service;
+- `RecipeShoppingPreviewExceptionHandler` is the controller-scoped advice handling both `InvalidRecipeShoppingPreviewRequestException` and `HttpMessageNotReadableException`;
+- there is no catch-all conversion of internal invariant failures to public 400 responses.
 
-- `RecipeShoppingPreviewController` now only delegates to the application service;
-- `RecipeShoppingPreviewExceptionHandler` is the single controller-scoped advice handling both `InvalidRecipeShoppingPreviewRequestException` and `HttpMessageNotReadableException`;
-- there is still no catch-all conversion of internal invariant failures to public 400 responses.
-
-After that correction, no known P0/P1/P2/P3 review finding remains. The final exact documentation/cleanup head still requires CI proof because every code or documentation commit invalidates exact-head shipping evidence.
+Final exact-head re-review verdict: **Looks good**. P0: none. P1: none. P2: none. P3: none. Review threads were empty.
 
 A transient execution-marker file used during branch setup was removed before shipping.
 
-## Final gates still required
+## Merge and post-merge acceptance evidence
 
-Before merge:
+PR #97 was marked ready only after exact-head verification and review, then squash-merged with GitHub-side `expected_head_sha` protection against exact head `318a48c569d0d001a4c27b5792e1681f7884e518`.
 
-1. require all normal PR workflows on the final exact head to succeed;
-2. confirm no unresolved review threads or blocking reviews;
-3. mark the PR ready for review;
-4. squash-merge using the exact reviewed/verified head SHA;
-5. require all normal push workflows on the resulting `main` SHA to succeed.
+Accepted squash merge:
 
-Only after those gates may issue #96 and canonical project state be marked **COMPLETE / ACCEPTED**.
+`8f0c1d8d31cfc1673656780a7989512d38788aff` — `feat(m2): add stateless recipe shopping preview API (#97)`
 
-## Post-merge acceptance evidence
+Post-merge proof on exact `main=8f0c1d8d31cfc1673656780a7989512d38788aff`:
 
-Pending.
+- 8 push-triggered workflow runs total;
+- 8/8 completed with `conclusion=success`;
+- failures: 0;
+- CodeQL Java and JavaScript/TypeScript both completed successfully;
+- issue #96 closed automatically with `state_reason=completed`.
+
+This establishes the code/behavior acceptance gate for M2.2. The follow-up docs-only acceptance PR records this evidence in canonical project state and is itself required to pass its normal exact-head PR and post-merge workflow gates before the repository documentation is considered synchronized.


### PR DESCRIPTION
This M2.2 acceptance documentation PR is obsolete and must not be merged.

Its target state was superseded by later accepted M2–M5 work and by the canonical documentation synchronization in PRs #172 and #175. Current release state is tracked by `docs/PROJECT_STATE.md`, `docs/ROADMAP.md`, root `CHANGELOG.md`, and release issue #152.

Closing as superseded preserves the historical PR discussion while preventing stale M2.2-era documentation from being merged into the frozen `v0.1.0-rc.3` target.