### PR TITLE
M2.4: add responsive Recipe comparison UI

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,27 +1,43 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
-async function fillComparisonForm(page: Page) {
-  await page.getByRole("textbox", { name: "Населённый пункт", exact: true }).fill("Москва");
-  await page.getByRole("textbox", { name: "Товар", exact: true }).fill("Молоко");
-  await page.getByRole("spinbutton", { name: "Количество", exact: true }).fill("2");
-  await page.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
-
-  await page.getByRole("button", { name: "Добавить товар" }).click();
-  await page.getByRole("textbox", { name: "Товар", exact: true }).nth(1).fill("Яйца");
-  await page.getByRole("spinbutton", { name: "Количество", exact: true }).nth(1).fill("10");
-  await page.getByRole("combobox", { name: "Единица", exact: true }).nth(1).selectOption("PIECE");
+function recipeForm(page: Page): Locator {
+  return page.locator("section[aria-labelledby='recipe-comparison']");
 }
 
-test("runs the deterministic comparison preview journey without horizontal overflow", async ({ page }) => {
-  await page.goto("/");
+function manualForm(page: Page): Locator {
+  return page.locator("section[aria-labelledby='comparison-preview']");
+}
 
-  await expect(page.getByRole("heading", { level: 1, name: "Закуп готов" })).toBeVisible();
-  await expect(page.getByText(/M1 · Shopping Core/i)).toBeVisible();
-  await expect(page.getByRole("heading", { level: 2, name: "Сравнить корзину" })).toBeVisible();
+async function fillRecipeForm(page: Page, locality = "Москва") {
+  const form = recipeForm(page);
+  await form.getByRole("textbox", { name: "Название рецепта", exact: true }).fill("Блины");
+  await form.getByRole("spinbutton", { name: "Порций в рецепте", exact: true }).fill("2");
+  await form.getByRole("spinbutton", { name: "Нужно порций", exact: true }).fill("4");
+  await form.getByRole("textbox", { name: "Населённый пункт", exact: true }).fill(locality);
+  await form.getByRole("textbox", { name: "Ингредиент", exact: true }).fill("Молоко");
+  await form.getByRole("spinbutton", { name: "Количество", exact: true }).fill("0.5");
+  await form.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
 
-  await fillComparisonForm(page);
-  await page.getByRole("button", { name: "Сравнить корзину" }).click();
+  await form.getByRole("button", { name: "Добавить ингредиент" }).click();
+  await form.getByRole("textbox", { name: "Ингредиент", exact: true }).nth(1).fill("Яйца");
+  await form.getByRole("spinbutton", { name: "Количество", exact: true }).nth(1).fill("5");
+  await form.getByRole("combobox", { name: "Единица", exact: true }).nth(1).selectOption("PIECE");
+}
 
+async function fillManualComparisonForm(page: Page) {
+  const form = manualForm(page);
+  await form.getByRole("textbox", { name: "Населённый пункт", exact: true }).fill("Москва");
+  await form.getByRole("textbox", { name: "Товар", exact: true }).fill("Молоко");
+  await form.getByRole("spinbutton", { name: "Количество", exact: true }).fill("2");
+  await form.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
+
+  await form.getByRole("button", { name: "Добавить товар" }).click();
+  await form.getByRole("textbox", { name: "Товар", exact: true }).nth(1).fill("Яйца");
+  await form.getByRole("spinbutton", { name: "Количество", exact: true }).nth(1).fill("10");
+  await form.getByRole("combobox", { name: "Единица", exact: true }).nth(1).selectOption("PIECE");
+}
+
+async function expectSafeComparisonResult(page: Page) {
   await expect(page.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeVisible();
   const retailerList = page.getByRole("list", { name: "Сравнение магазинов" });
   await expect(retailerList.locator(":scope > li")).toHaveCount(8);
@@ -39,23 +55,31 @@ test("runs the deterministic comparison preview journey without horizontal overf
     await expect(page.getByRole("heading", { level: 3, name })).toBeVisible();
   }
 
-  await expect(page.getByText("Корзина рассчитана")).toHaveCount(1);
-  await expect(page.getByText("Есть неопределённость")).toHaveCount(1);
-  await expect(page.getByText("Корзина неполная")).toHaveCount(4);
-  await expect(page.getByText("Сравнение пока недоступно")).toHaveCount(2);
-
-  const magnit = page.getByRole("article", { name: "Магнит" });
-  await expect(magnit.getByText("Неизвестен размер упаковки", { exact: true })).toHaveCount(1);
-
-  const lenta = page.getByRole("article", { name: "Лента" });
-  await expect(lenta.getByText("Товар не найден", { exact: true })).toHaveCount(1);
-
   const body = await page.locator("body").innerText();
   expect(body).not.toContain("sourceProviderId");
   expect(body).not.toContain("acquisitionMode");
   expect(body).not.toContain("fulfillmentContextId");
   expect(body).not.toContain("sku-");
   expect(body).not.toMatch(/самый дешёвый|лучший выбор|рекомендуем/i);
+}
+
+test("runs the desktop Recipe → shopping list → retailer comparison journey", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { level: 1, name: "Закуп готов" })).toBeVisible();
+  await expect(page.getByText(/M2 · Recipes/i)).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Сравнить рецепт" })).toBeVisible();
+
+  await fillRecipeForm(page);
+  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
+
+  await expect(page.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeVisible();
+  const shoppingList = page.getByRole("list", { name: "Покупки из рецепта" });
+  await expect(shoppingList.getByText("Молоко", { exact: true })).toBeVisible();
+  await expect(shoppingList.getByText("1000 MILLILITER", { exact: true })).toBeVisible();
+  await expect(shoppingList.getByText("Яйца", { exact: true })).toBeVisible();
+  await expect(shoppingList.getByText("10 PIECE", { exact: true })).toBeVisible();
+  await expectSafeComparisonResult(page);
 
   const overflowsHorizontally = await page.evaluate(
     () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
@@ -63,36 +87,68 @@ test("runs the deterministic comparison preview journey without horizontal overf
   expect(overflowsHorizontally).toBe(false);
 });
 
-test("shows one accessible error and no fabricated results when the API is unavailable", async ({ page }) => {
+test("Recipe journey remains usable without horizontal overflow on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
 
-  await page.getByRole("textbox", { name: "Населённый пункт", exact: true }).fill("Недоступно");
-  await page.getByRole("textbox", { name: "Товар", exact: true }).fill("Молоко");
-  await page.getByRole("spinbutton", { name: "Количество", exact: true }).fill("1");
-  await page.getByRole("button", { name: "Сравнить корзину" }).click();
+  await fillRecipeForm(page);
+  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
 
-  const serviceAlert = page.getByRole("alert").filter({
-    hasText: "Не удалось выполнить сравнение. Основной сервис временно недоступен.",
-  });
-  await expect(serviceAlert).toHaveCount(1);
-  await expect(page.getByRole("list", { name: "Сравнение магазинов" })).toHaveCount(0);
-  await expect(page.getByRole("heading", { level: 3 })).toHaveCount(0);
+  await expect(page.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeVisible();
+  const dimensions = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
 });
 
-test("comparison form has a visible keyboard focus path", async ({ page }) => {
+test("Recipe journey shows one accessible error and no fabricated results when the API is unavailable", async ({ page }) => {
   await page.goto("/");
 
-  const locality = page.getByRole("textbox", { name: "Населённый пункт", exact: true });
-  await page.keyboard.press("Tab");
-  await expect(locality).toBeFocused();
+  await fillRecipeForm(page, "Недоступно");
+  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
 
-  const focusIsVisible = await locality.evaluate((element) => {
+  const serviceAlert = page.getByRole("alert").filter({
+    hasText: "Не удалось сравнить рецепт. Основной сервис временно недоступен.",
+  });
+  await expect(serviceAlert).toHaveCount(1);
+  await expect(page.getByRole("list", { name: "Покупки из рецепта" })).toHaveCount(0);
+  await expect(page.getByRole("list", { name: "Сравнение магазинов" })).toHaveCount(0);
+});
+
+test("Recipe form has a visible keyboard focus path", async ({ page }) => {
+  await page.goto("/");
+
+  const title = recipeForm(page).getByRole("textbox", { name: "Название рецепта", exact: true });
+  await page.keyboard.press("Tab");
+  await expect(title).toBeFocused();
+
+  const focusIsVisible = await title.evaluate((element) => {
     const style = window.getComputedStyle(element);
     return (
       (style.outlineStyle !== "none" && style.outlineWidth !== "0px") ||
       style.boxShadow !== "none"
     );
   });
-
   expect(focusIsVisible).toBe(true);
+});
+
+test("preserves the deterministic manual comparison journey as a secondary path", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { level: 2, name: "Сравнить корзину" })).toBeVisible();
+  await fillManualComparisonForm(page);
+  await manualForm(page).getByRole("button", { name: "Сравнить корзину" }).click();
+
+  await expectSafeComparisonResult(page);
+  await expect(page.getByText("Корзина рассчитана")).toHaveCount(1);
+  await expect(page.getByText("Есть неопределённость")).toHaveCount(1);
+  await expect(page.getByText("Корзина неполная")).toHaveCount(4);
+  await expect(page.getByText("Сравнение пока недоступно")).toHaveCount(2);
+
+  const magnit = page.getByRole("article", { name: "Магнит" });
+  await expect(magnit.getByText("Неизвестен размер упаковки", { exact: true })).toHaveCount(1);
+  const lenta = page.getByRole("article", { name: "Лента" });
+  await expect(lenta.getByText("Товар не найден", { exact: true })).toHaveCount(1);
 });

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -14,6 +14,10 @@ const retailerNames = {
   samokat: "Самокат",
 };
 
+function normalizeText(value) {
+  return String(value).trim().replace(/\s+/g, " ");
+}
+
 function canonicalQuantity(quantity) {
   if (quantity.unit === "KILOGRAM") {
     return { amount: quantity.amount * 1000, unit: "GRAM" };
@@ -21,7 +25,7 @@ function canonicalQuantity(quantity) {
   if (quantity.unit === "LITER") {
     return { amount: quantity.amount * 1000, unit: "MILLILITER" };
   }
-  return quantity;
+  return { amount: quantity.amount, unit: quantity.unit };
 }
 
 function readJson(request) {
@@ -59,14 +63,21 @@ function requestedItem(item) {
   };
 }
 
-function selection(item, productName, packageQuantity, packageCount, lineTotal) {
+function selection(item, productName, packageQuantity, packagePrice) {
   const requested = canonicalQuantity(item.quantity);
+  const packageCount =
+    requested.unit === packageQuantity.unit
+      ? Math.max(1, Math.ceil(requested.amount / packageQuantity.amount))
+      : 1;
   return {
     productName,
     packageQuantity,
     packageCount,
-    coveredQuantity: requested,
-    lineTotal,
+    coveredQuantity: {
+      amount: packageQuantity.amount * packageCount,
+      unit: packageQuantity.unit,
+    },
+    lineTotal: packagePrice * packageCount,
     currencyCode: "RUB",
   };
 }
@@ -100,14 +111,12 @@ function buildPreview(request) {
     milk,
     "Молоко",
     { amount: 1000, unit: "MILLILITER" },
-    2,
-    200,
+    100,
   );
   const eggsSelection = selection(
     eggs,
     "Яйца",
     { amount: 10, unit: "PIECE" },
-    1,
     120,
   );
 
@@ -122,7 +131,10 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "READY",
         reasons: [],
-        total: { amount: 320, currencyCode: "RUB" },
+        total: {
+          amount: milkSelection.lineTotal + eggsSelection.lineTotal,
+          currencyCode: "RUB",
+        },
         freshness: {
           basis: "OBSERVATION_ONLY",
           observedAt: "2026-08-12T10:00:00Z",
@@ -139,7 +151,10 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "UNCERTAIN",
         reasons: ["AVAILABILITY_UNKNOWN"],
-        total: { amount: 330, currencyCode: "RUB" },
+        total: {
+          amount: milkSelection.lineTotal + eggsSelection.lineTotal + 10,
+          currencyCode: "RUB",
+        },
         freshness: {
           basis: "PROVIDER_TIMESTAMP",
           observedAt: "2026-08-12T10:00:00Z",
@@ -147,10 +162,10 @@ function buildPreview(request) {
         },
         items: [
           itemResult(milk, "AVAILABILITY_UNKNOWN", {
-            selection: { ...milkSelection, lineTotal: 205 },
+            selection: { ...milkSelection, lineTotal: milkSelection.lineTotal + 5 },
           }),
           itemResult(eggs, "FULFILLED", {
-            selection: { ...eggsSelection, lineTotal: 125 },
+            selection: { ...eggsSelection, lineTotal: eggsSelection.lineTotal + 5 },
           }),
         ],
       },
@@ -209,6 +224,85 @@ function buildPreview(request) {
   };
 }
 
+function fixedUuid(prefix, index = 1) {
+  return `${prefix}0000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
+}
+
+function buildRecipeComparisonPreview(request) {
+  const recipe = request.recipe;
+  const scale = recipe.targetServings / recipe.baseServings;
+  const recipeId = fixedUuid("1");
+  const shoppingListId = fixedUuid("3");
+
+  const sourceIngredients = recipe.ingredients.map((ingredient, index) => ({
+    id: fixedUuid("2", index + 1),
+    requirement: normalizeText(ingredient.requirement),
+    quantity: canonicalQuantity(ingredient.quantity),
+  }));
+
+  const groups = new Map();
+  for (const ingredient of sourceIngredients) {
+    const key = `${ingredient.requirement}\u0000${ingredient.quantity.unit}`;
+    const scaledAmount = ingredient.quantity.amount * scale;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.quantity.amount += scaledAmount;
+      existing.sourceIngredientIds.push(ingredient.id);
+    } else {
+      groups.set(key, {
+        requirement: ingredient.requirement,
+        quantity: { amount: scaledAmount, unit: ingredient.quantity.unit },
+        sourceIngredientIds: [ingredient.id],
+      });
+    }
+  }
+
+  const shoppingItems = Array.from(groups.values()).map((item, index) => ({
+    id: fixedUuid("4", index + 1),
+    ...item,
+  }));
+
+  return {
+    recipeShoppingPreview: {
+      recipe: {
+        id: recipeId,
+        title: normalizeText(recipe.title),
+        baseServings: recipe.baseServings,
+        targetServings: recipe.targetServings,
+        ingredients: sourceIngredients,
+      },
+      shoppingList: {
+        id: shoppingListId,
+        items: shoppingItems,
+      },
+    },
+    comparisonPreview: buildPreview({
+      locality: request.locality,
+      items: shoppingItems,
+    }),
+  };
+}
+
+function invalidComparison(response, message = "deterministic acceptance requires two items") {
+  writeJson(response, 400, {
+    type: "https://zakup-gotov.dev/problems/invalid-comparison-preview",
+    title: "Invalid comparison preview request",
+    status: 400,
+    code: "INVALID_COMPARISON_PREVIEW",
+    errors: [{ field: "items", message }],
+  });
+}
+
+function invalidRecipeComparison(response, field, message) {
+  writeJson(response, 400, {
+    type: "https://zakup-gotov.dev/problems/invalid-recipe-comparison-preview",
+    title: "Invalid recipe comparison preview request",
+    status: 400,
+    code: "INVALID_RECIPE_COMPARISON_PREVIEW",
+    errors: [{ field, message }],
+  });
+}
+
 const server = http.createServer(async (request, response) => {
   if (request.method === "GET" && request.url === "/health") {
     response.writeHead(204);
@@ -216,34 +310,55 @@ const server = http.createServer(async (request, response) => {
     return;
   }
 
-  if (request.method !== "POST" || request.url !== "/api/v1/comparison-previews") {
+  if (request.method !== "POST") {
     writeJson(response, 404, { error: "not found" });
     return;
   }
 
   try {
     const body = await readJson(request);
-    if (body.locality === "Недоступно") {
-      writeJson(response, 503, { error: "deterministic unavailable scenario" });
+
+    if (request.url === "/api/v1/recipe-comparison-previews") {
+      if (body.locality === "Недоступно") {
+        writeJson(response, 503, { error: "deterministic unavailable scenario" });
+        return;
+      }
+      if (
+        !body.recipe ||
+        !Array.isArray(body.recipe.ingredients) ||
+        body.recipe.ingredients.length < 2
+      ) {
+        invalidRecipeComparison(
+          response,
+          "recipe.ingredients",
+          "deterministic acceptance requires two ingredients",
+        );
+        return;
+      }
+      writeJson(response, 200, buildRecipeComparisonPreview(body));
       return;
     }
-    if (!Array.isArray(body.items) || body.items.length < 2) {
-      writeJson(response, 400, {
-        type: "https://zakup-gotov.dev/problems/invalid-comparison-preview",
-        title: "Invalid comparison preview request",
-        status: 400,
-        code: "INVALID_COMPARISON_PREVIEW",
-        errors: [{ field: "items", message: "deterministic acceptance requires two items" }],
-      });
+
+    if (request.url === "/api/v1/comparison-previews") {
+      if (body.locality === "Недоступно") {
+        writeJson(response, 503, { error: "deterministic unavailable scenario" });
+        return;
+      }
+      if (!Array.isArray(body.items) || body.items.length < 2) {
+        invalidComparison(response);
+        return;
+      }
+      writeJson(response, 200, buildPreview(body));
       return;
     }
-    writeJson(response, 200, buildPreview(body));
+
+    writeJson(response, 404, { error: "not found" });
   } catch {
     writeJson(response, 400, {
-      type: "https://zakup-gotov.dev/problems/invalid-comparison-preview",
-      title: "Invalid comparison preview request",
+      type: "https://zakup-gotov.dev/problems/invalid-recipe-comparison-preview",
+      title: "Invalid recipe comparison preview request",
       status: 400,
-      code: "INVALID_COMPARISON_PREVIEW",
+      code: "INVALID_RECIPE_COMPARISON_PREVIEW",
       errors: [{ field: "$request", message: "malformed JSON request" }],
     });
   }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -8,6 +8,14 @@ vi.mock("./retailer-readiness", () => ({
   loadRetailerReadiness: vi.fn(),
 }));
 
+vi.mock("./recipe-comparison-form", () => ({
+  RecipeComparisonForm: () => (
+    <section aria-labelledby="recipe-comparison">
+      <h2 id="recipe-comparison">Сравнить рецепт</h2>
+    </section>
+  ),
+}));
+
 vi.mock("./comparison-preview-form", () => ({
   ComparisonPreviewForm: () => (
     <section aria-labelledby="comparison-preview">
@@ -24,14 +32,21 @@ afterEach(() => {
 });
 
 describe("home page", () => {
-  it("renders the M1 comparison journey without an initial readiness network dependency", async () => {
+  it("renders the M2 Recipe journey first while preserving manual basket comparison", async () => {
     render(await Home());
 
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
     expect(screen.getByRole("heading", { level: 1, name: "Закуп готов" })).toBeDefined();
-    expect(screen.getByText(/M1 · Shopping Core/i)).toBeDefined();
+    expect(screen.getByText(/M2 · Recipes/i)).toBeDefined();
+    expect(screen.queryByText(/M1 · Shopping Core/i)).toBeNull();
     expect(screen.queryByText(/M0 · Product & Integration Discovery/i)).toBeNull();
-    expect(screen.getByRole("heading", { level: 2, name: "Сравнить корзину" })).toBeDefined();
+
+    const recipeHeading = screen.getByRole("heading", { level: 2, name: "Сравнить рецепт" });
+    const manualHeading = screen.getByRole("heading", { level: 2, name: "Сравнить корзину" });
+    expect(recipeHeading).toBeDefined();
+    expect(manualHeading).toBeDefined();
+    expect(recipeHeading.compareDocumentPosition(manualHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
     expect(screen.queryByRole("heading", { level: 2, name: "Покрытие магазинов" })).toBeNull();
     expect(mockedLoadRetailerReadiness).not.toHaveBeenCalled();
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { ComparisonPreviewForm } from "./comparison-preview-form";
+import { RecipeComparisonForm } from "./recipe-comparison-form";
 
 export default function Home() {
   return (
@@ -6,7 +7,7 @@ export default function Home() {
       <div className="mx-auto w-full max-w-5xl px-6 py-16 sm:px-10 lg:px-16 lg:py-24">
         <div className="max-w-2xl">
           <p className="text-sm font-medium uppercase tracking-[0.18em] text-stone-500">
-            M1 · Shopping Core
+            M2 · Recipes
           </p>
 
           <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-6xl">
@@ -14,9 +15,9 @@ export default function Home() {
           </h1>
 
           <p className="mt-6 max-w-xl text-lg leading-8 text-stone-600 sm:text-xl">
-            Соберите список покупок и сравните, что действительно можно посчитать
-            по подтверждённым данным магазинов. Неполные корзины и неопределённость
-            остаются видимыми.
+            Превратите рецепт в список покупок для нужного числа порций и сравните
+            корзину по подтверждённым данным магазинов. Неполные корзины и
+            неопределённость остаются видимыми.
           </p>
 
           <section
@@ -27,13 +28,20 @@ export default function Home() {
               Сейчас
             </h2>
             <p className="mt-2 text-base leading-7 text-stone-600">
-              Сравнение работает как stateless preview: без аккаунта и сохранения
-              адреса. Если для магазина нет безопасных данных, мы не подставляем
-              фиктивную цену.
+              Рецепт и сравнение работают как stateless preview: без аккаунта,
+              сохранения рецепта или адреса. Если для магазина нет безопасных данных,
+              мы не подставляем фиктивную цену.
             </p>
           </section>
         </div>
 
+        <RecipeComparisonForm />
+
+        <div className="mt-16 border-t border-stone-200 pt-8">
+          <p className="max-w-2xl text-sm leading-6 text-stone-600">
+            Уже есть готовый список покупок? Его можно сравнить напрямую, без рецепта.
+          </p>
+        </div>
         <ComparisonPreviewForm />
 
         <a

--- a/apps/web/src/app/recipe-comparison-form.test.tsx
+++ b/apps/web/src/app/recipe-comparison-form.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createRecipeComparisonPreview } from "./recipe-comparison";
+import { RecipeComparisonForm } from "./recipe-comparison-form";
+
+vi.mock("./recipe-comparison", () => ({
+  createRecipeComparisonPreview: vi.fn(),
+}));
+
+vi.mock("./recipe-comparison-results", () => ({
+  RecipeComparisonResults: () => <section aria-label="Результаты рецепта">Результаты рецепта</section>,
+}));
+
+const mockedCreateRecipeComparisonPreview = vi.mocked(createRecipeComparisonPreview);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Recipe comparison form", () => {
+  it("starts with sensible serving defaults and one removable-protected ingredient", () => {
+    render(<RecipeComparisonForm />);
+
+    expect((screen.getByLabelText("Порций в рецепте") as HTMLInputElement).value).toBe("2");
+    expect((screen.getByLabelText("Нужно порций") as HTMLInputElement).value).toBe("2");
+    expect(screen.getAllByLabelText("Ингредиент")).toHaveLength(1);
+    expect((screen.getByLabelText("Количество") as HTMLInputElement).value).toBe("1");
+    expect((screen.getByLabelText("Единица") as HTMLSelectElement).value).toBe("PIECE");
+    expect((screen.getByRole("button", { name: "Удалить ингредиент" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("adds and removes ingredient rows without allowing an empty recipe", () => {
+    render(<RecipeComparisonForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Добавить ингредиент" }));
+    expect(screen.getAllByLabelText("Ингредиент")).toHaveLength(2);
+    expect((screen.getAllByRole("button", { name: "Удалить ингредиент" })[0] as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Удалить ингредиент" })[1]!);
+    expect(screen.getAllByLabelText("Ингредиент")).toHaveLength(1);
+    expect((screen.getByRole("button", { name: "Удалить ингредиент" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("submits locality, servings and ingredients through the generated M2.3 request shape", async () => {
+    mockedCreateRecipeComparisonPreview.mockResolvedValue({
+      kind: "ready",
+      data: {
+        recipeShoppingPreview: {
+          recipe: {
+            id: "10000000-0000-0000-0000-000000000001",
+            title: "Блины",
+            baseServings: 2,
+            targetServings: 4,
+            ingredients: [],
+          },
+          shoppingList: { id: "30000000-0000-0000-0000-000000000001", items: [] },
+        },
+        comparisonPreview: { locality: "Москва", items: [], retailers: [] },
+      },
+    });
+    render(<RecipeComparisonForm />);
+
+    fireEvent.change(screen.getByLabelText("Название рецепта"), { target: { value: "  Блины  " } });
+    fireEvent.change(screen.getByLabelText("Порций в рецепте"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Нужно порций"), { target: { value: "4" } });
+    fireEvent.change(screen.getByLabelText("Населённый пункт"), { target: { value: "  Москва  " } });
+    fireEvent.change(screen.getByLabelText("Ингредиент"), { target: { value: "  Молоко  " } });
+    fireEvent.change(screen.getByLabelText("Количество"), { target: { value: "0.5" } });
+    fireEvent.change(screen.getByLabelText("Единица"), { target: { value: "LITER" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Добавить ингредиент" }));
+    fireEvent.change(screen.getAllByLabelText("Ингредиент")[1]!, { target: { value: "Яйца" } });
+    fireEvent.change(screen.getAllByLabelText("Количество")[1]!, { target: { value: "5" } });
+    fireEvent.change(screen.getAllByLabelText("Единица")[1]!, { target: { value: "PIECE" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить рецепт" }));
+
+    await waitFor(() => expect(mockedCreateRecipeComparisonPreview).toHaveBeenCalledTimes(1));
+    expect(mockedCreateRecipeComparisonPreview).toHaveBeenCalledWith({
+      locality: "Москва",
+      recipe: {
+        title: "Блины",
+        baseServings: 2,
+        targetServings: 4,
+        ingredients: [
+          { requirement: "Молоко", quantity: { amount: 0.5, unit: "LITER" } },
+          { requirement: "Яйца", quantity: { amount: 5, unit: "PIECE" } },
+        ],
+      },
+    });
+    expect(screen.getByLabelText("Результаты рецепта")).toBeDefined();
+  });
+
+  it("rejects incomplete or invalid input before contacting the backend", () => {
+    render(<RecipeComparisonForm />);
+
+    fireEvent.change(screen.getByLabelText("Порций в рецепте"), { target: { value: "1.5" } });
+    fireEvent.change(screen.getByLabelText("Нужно порций"), { target: { value: "0" } });
+    fireEvent.change(screen.getByLabelText("Количество"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить рецепт" }));
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Укажите название рецепта");
+    expect(alert.textContent).toContain("Укажите населённый пункт");
+    expect(alert.textContent).toContain("Порций в рецепте должно быть целым числом больше 0");
+    expect(alert.textContent).toContain("Нужно порций должно быть целым числом больше 0");
+    expect(alert.textContent).toContain("Укажите ингредиент");
+    expect(alert.textContent).toContain("Количество ингредиента должно быть больше 0");
+    expect(mockedCreateRecipeComparisonPreview).not.toHaveBeenCalled();
+  });
+
+  it("shows backend field errors without exposing transport metadata", async () => {
+    mockedCreateRecipeComparisonPreview.mockResolvedValue({
+      kind: "invalid",
+      errors: [{ field: "recipe.ingredients[0].quantity.amount", message: "must be greater than 0" }],
+    });
+    render(<RecipeComparisonForm />);
+
+    fireEvent.change(screen.getByLabelText("Название рецепта"), { target: { value: "Блины" } });
+    fireEvent.change(screen.getByLabelText("Населённый пункт"), { target: { value: "Москва" } });
+    fireEvent.change(screen.getByLabelText("Ингредиент"), { target: { value: "Молоко" } });
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить рецепт" }));
+
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toContain("recipe.ingredients[0].quantity.amount");
+    expect(screen.getByRole("alert").textContent).not.toContain("sourceProviderId");
+    expect(screen.queryByLabelText("Результаты рецепта")).toBeNull();
+  });
+
+  it("shows one accessible fail-closed state when the service is unavailable", async () => {
+    mockedCreateRecipeComparisonPreview.mockResolvedValue({ kind: "unavailable" });
+    render(<RecipeComparisonForm />);
+
+    fireEvent.change(screen.getByLabelText("Название рецепта"), { target: { value: "Блины" } });
+    fireEvent.change(screen.getByLabelText("Населённый пункт"), { target: { value: "Москва" } });
+    fireEvent.change(screen.getByLabelText("Ингредиент"), { target: { value: "Молоко" } });
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить рецепт" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Не удалось сравнить рецепт. Основной сервис временно недоступен.");
+    expect(screen.queryByLabelText("Результаты рецепта")).toBeNull();
+  });
+});

--- a/apps/web/src/app/recipe-comparison-form.tsx
+++ b/apps/web/src/app/recipe-comparison-form.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import type { components } from "@zakup-gotov/api-client";
+
+import {
+  createRecipeComparisonPreview,
+  type RecipeComparisonPreviewRequest,
+  type RecipeComparisonState,
+} from "./recipe-comparison";
+import { RecipeComparisonResults } from "./recipe-comparison-results";
+
+type QuantityUnit = components["schemas"]["QuantityInputUnit"];
+
+type IngredientRow = {
+  key: string;
+  requirement: string;
+  amount: string;
+  unit: QuantityUnit;
+};
+
+const units: Array<{ value: QuantityUnit; label: string }> = [
+  { value: "PIECE", label: "шт." },
+  { value: "GRAM", label: "г" },
+  { value: "KILOGRAM", label: "кг" },
+  { value: "MILLILITER", label: "мл" },
+  { value: "LITER", label: "л" },
+];
+
+function newIngredient(): IngredientRow {
+  return {
+    key: globalThis.crypto.randomUUID(),
+    requirement: "",
+    amount: "1",
+    unit: "PIECE",
+  };
+}
+
+function clientErrors(
+  title: string,
+  locality: string,
+  baseServings: string,
+  targetServings: string,
+  ingredients: IngredientRow[],
+) {
+  const errors: string[] = [];
+
+  if (!title.trim()) {
+    errors.push("Укажите название рецепта.");
+  }
+  if (!locality.trim()) {
+    errors.push("Укажите населённый пункт.");
+  }
+
+  const base = Number(baseServings);
+  if (!Number.isInteger(base) || base <= 0) {
+    errors.push("Порций в рецепте должно быть целым числом больше 0.");
+  }
+
+  const target = Number(targetServings);
+  if (!Number.isInteger(target) || target <= 0) {
+    errors.push("Нужно порций должно быть целым числом больше 0.");
+  }
+
+  for (const [index, ingredient] of ingredients.entries()) {
+    if (!ingredient.requirement.trim()) {
+      errors.push(
+        ingredients.length === 1
+          ? "Укажите ингредиент."
+          : `Укажите ингредиент в строке ${index + 1}.`,
+      );
+    }
+    const amount = Number(ingredient.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      errors.push(
+        ingredients.length === 1
+          ? "Количество ингредиента должно быть больше 0."
+          : `Количество ингредиента в строке ${index + 1} должно быть больше 0.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+export function RecipeComparisonForm() {
+  const [title, setTitle] = useState("");
+  const [baseServings, setBaseServings] = useState("2");
+  const [targetServings, setTargetServings] = useState("2");
+  const [locality, setLocality] = useState("");
+  const [ingredients, setIngredients] = useState<IngredientRow[]>(() => [newIngredient()]);
+  const [state, setState] = useState<RecipeComparisonState | null>(null);
+  const [clientMessages, setClientMessages] = useState<string[]>([]);
+  const [pending, setPending] = useState(false);
+
+  function updateIngredient(key: string, patch: Partial<IngredientRow>) {
+    setIngredients((current) =>
+      current.map((ingredient) =>
+        ingredient.key === key ? { ...ingredient, ...patch } : ingredient,
+      ),
+    );
+  }
+
+  function removeIngredient(key: string) {
+    setIngredients((current) =>
+      current.length === 1
+        ? current
+        : current.filter((ingredient) => ingredient.key !== key),
+    );
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (pending) {
+      return;
+    }
+
+    const validationErrors = clientErrors(
+      title,
+      locality,
+      baseServings,
+      targetServings,
+      ingredients,
+    );
+    if (validationErrors.length > 0) {
+      setState(null);
+      setClientMessages(validationErrors);
+      return;
+    }
+
+    const request: RecipeComparisonPreviewRequest = {
+      locality: locality.trim(),
+      recipe: {
+        title: title.trim(),
+        baseServings: Number(baseServings),
+        targetServings: Number(targetServings),
+        ingredients: ingredients.map((ingredient) => ({
+          requirement: ingredient.requirement.trim(),
+          quantity: {
+            amount: Number(ingredient.amount),
+            unit: ingredient.unit,
+          },
+        })),
+      },
+    };
+
+    setClientMessages([]);
+    setPending(true);
+    try {
+      setState(await createRecipeComparisonPreview(request));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const errorContent =
+    clientMessages.length > 0
+      ? clientMessages.join(" ")
+      : state?.kind === "invalid"
+        ? state.errors.map((error) => `${error.field}: ${error.message}`).join("; ")
+        : state?.kind === "unavailable"
+          ? "Не удалось сравнить рецепт. Основной сервис временно недоступен."
+          : null;
+
+  return (
+    <section aria-labelledby="recipe-comparison" className="mt-12">
+      <div className="max-w-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+          Рецепт → покупки → магазины
+        </p>
+        <h2
+          id="recipe-comparison"
+          className="mt-2 text-2xl font-semibold tracking-tight text-stone-950"
+        >
+          Сравнить рецепт
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-stone-600">
+          Укажите рецепт, число порций и населённый пункт. Сервис сам пересчитает
+          ингредиенты в список покупок и сравнит его по доступным данным магазинов.
+        </p>
+      </div>
+
+      <form onSubmit={submit} className="mt-6 space-y-6" noValidate>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <label htmlFor="recipe-title" className="block text-sm font-medium text-stone-800">
+              Название рецепта
+            </label>
+            <input
+              id="recipe-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={240}
+              autoComplete="off"
+              className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-4 py-2 text-base outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="recipe-base-servings" className="block text-sm font-medium text-stone-800">
+              Порций в рецепте
+            </label>
+            <input
+              id="recipe-base-servings"
+              type="number"
+              inputMode="numeric"
+              min="1"
+              step="1"
+              value={baseServings}
+              onChange={(event) => setBaseServings(event.target.value)}
+              className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-4 py-2 text-base outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="recipe-target-servings" className="block text-sm font-medium text-stone-800">
+              Нужно порций
+            </label>
+            <input
+              id="recipe-target-servings"
+              type="number"
+              inputMode="numeric"
+              min="1"
+              step="1"
+              value={targetServings}
+              onChange={(event) => setTargetServings(event.target.value)}
+              className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-4 py-2 text-base outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+            />
+          </div>
+
+          <div className="sm:col-span-2 max-w-xl">
+            <label htmlFor="recipe-locality" className="block text-sm font-medium text-stone-800">
+              Населённый пункт
+            </label>
+            <input
+              id="recipe-locality"
+              value={locality}
+              onChange={(event) => setLocality(event.target.value)}
+              maxLength={160}
+              autoComplete="address-level2"
+              className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-4 py-2 text-base outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-4" aria-label="Ингредиенты рецепта">
+          {ingredients.map((ingredient, index) => {
+            const requirementId = `recipe-ingredient-${ingredient.key}`;
+            const amountId = `recipe-amount-${ingredient.key}`;
+            const unitId = `recipe-unit-${ingredient.key}`;
+            return (
+              <fieldset
+                key={ingredient.key}
+                className="rounded-2xl border border-stone-200 bg-white p-4 sm:p-5"
+              >
+                <legend className="px-1 text-sm font-semibold text-stone-800">
+                  Ингредиент {index + 1}
+                </legend>
+                <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_8rem_7rem_auto] sm:items-end">
+                  <div>
+                    <label htmlFor={requirementId} className="block text-sm font-medium text-stone-700">
+                      Ингредиент
+                    </label>
+                    <input
+                      id={requirementId}
+                      value={ingredient.requirement}
+                      onChange={(event) =>
+                        updateIngredient(ingredient.key, { requirement: event.target.value })
+                      }
+                      maxLength={240}
+                      className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor={amountId} className="block text-sm font-medium text-stone-700">
+                      Количество
+                    </label>
+                    <input
+                      id={amountId}
+                      type="number"
+                      inputMode="decimal"
+                      min="0"
+                      step="any"
+                      value={ingredient.amount}
+                      onChange={(event) =>
+                        updateIngredient(ingredient.key, { amount: event.target.value })
+                      }
+                      className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor={unitId} className="block text-sm font-medium text-stone-700">
+                      Единица
+                    </label>
+                    <select
+                      id={unitId}
+                      value={ingredient.unit}
+                      onChange={(event) =>
+                        updateIngredient(ingredient.key, {
+                          unit: event.target.value as QuantityUnit,
+                        })
+                      }
+                      className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+                    >
+                      {units.map((unit) => (
+                        <option key={unit.value} value={unit.value}>
+                          {unit.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeIngredient(ingredient.key)}
+                    disabled={ingredients.length === 1}
+                    aria-label="Удалить ингредиент"
+                    className="min-h-11 rounded-xl border border-stone-300 px-3 text-sm font-medium text-stone-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Удалить
+                  </button>
+                </div>
+              </fieldset>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() =>
+              setIngredients((current) =>
+                current.length >= 100 ? current : [...current, newIngredient()],
+              )
+            }
+            disabled={ingredients.length >= 100}
+            className="min-h-11 rounded-full border border-stone-300 bg-white px-5 py-2.5 text-sm font-medium text-stone-900 hover:bg-stone-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Добавить ингредиент
+          </button>
+          <button
+            type="submit"
+            disabled={pending}
+            className="min-h-11 rounded-full bg-stone-950 px-5 py-2.5 text-sm font-medium text-white hover:bg-stone-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:cursor-wait disabled:opacity-60"
+          >
+            {pending ? "Сравниваем…" : "Сравнить рецепт"}
+          </button>
+        </div>
+      </form>
+
+      {errorContent ? (
+        <div
+          role="alert"
+          className="mt-6 rounded-2xl border border-amber-300 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950"
+        >
+          {errorContent}
+        </div>
+      ) : null}
+
+      {state?.kind === "ready" ? <RecipeComparisonResults preview={state.data} /> : null}
+    </section>
+  );
+}

--- a/apps/web/src/app/recipe-comparison-form.tsx
+++ b/apps/web/src/app/recipe-comparison-form.tsx
@@ -14,7 +14,7 @@ import { RecipeComparisonResults } from "./recipe-comparison-results";
 type QuantityUnit = components["schemas"]["QuantityInputUnit"];
 
 type IngredientRow = {
-  key: string;
+  key: number;
   requirement: string;
   amount: string;
   unit: QuantityUnit;
@@ -28,9 +28,9 @@ const units: Array<{ value: QuantityUnit; label: string }> = [
   { value: "LITER", label: "л" },
 ];
 
-function newIngredient(): IngredientRow {
+function newIngredient(key: number): IngredientRow {
   return {
-    key: globalThis.crypto.randomUUID(),
+    key,
     requirement: "",
     amount: "1",
     unit: "PIECE",
@@ -89,12 +89,12 @@ export function RecipeComparisonForm() {
   const [baseServings, setBaseServings] = useState("2");
   const [targetServings, setTargetServings] = useState("2");
   const [locality, setLocality] = useState("");
-  const [ingredients, setIngredients] = useState<IngredientRow[]>(() => [newIngredient()]);
+  const [ingredients, setIngredients] = useState<IngredientRow[]>(() => [newIngredient(1)]);
   const [state, setState] = useState<RecipeComparisonState | null>(null);
   const [clientMessages, setClientMessages] = useState<string[]>([]);
   const [pending, setPending] = useState(false);
 
-  function updateIngredient(key: string, patch: Partial<IngredientRow>) {
+  function updateIngredient(key: number, patch: Partial<IngredientRow>) {
     setIngredients((current) =>
       current.map((ingredient) =>
         ingredient.key === key ? { ...ingredient, ...patch } : ingredient,
@@ -102,12 +102,22 @@ export function RecipeComparisonForm() {
     );
   }
 
-  function removeIngredient(key: string) {
+  function removeIngredient(key: number) {
     setIngredients((current) =>
       current.length === 1
         ? current
         : current.filter((ingredient) => ingredient.key !== key),
     );
+  }
+
+  function addIngredient() {
+    setIngredients((current) => {
+      if (current.length >= 100) {
+        return current;
+      }
+      const nextKey = Math.max(...current.map((ingredient) => ingredient.key)) + 1;
+      return [...current, newIngredient(nextKey)];
+    });
   }
 
   async function submit(event: FormEvent<HTMLFormElement>) {
@@ -328,11 +338,7 @@ export function RecipeComparisonForm() {
         <div className="flex flex-wrap gap-3">
           <button
             type="button"
-            onClick={() =>
-              setIngredients((current) =>
-                current.length >= 100 ? current : [...current, newIngredient()],
-              )
-            }
+            onClick={addIngredient}
             disabled={ingredients.length >= 100}
             className="min-h-11 rounded-full border border-stone-300 bg-white px-5 py-2.5 text-sm font-medium text-stone-900 hover:bg-stone-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:cursor-not-allowed disabled:opacity-40"
           >

--- a/apps/web/src/app/recipe-comparison-results.test.tsx
+++ b/apps/web/src/app/recipe-comparison-results.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { components } from "@zakup-gotov/api-client";
+import { RecipeComparisonResults } from "./recipe-comparison-results";
+
+afterEach(cleanup);
+
+const preview: components["schemas"]["RecipeComparisonPreviewResponse"] = {
+  recipeShoppingPreview: {
+    recipe: {
+      id: "10000000-0000-0000-0000-000000000001",
+      title: "Блины",
+      baseServings: 2,
+      targetServings: 4,
+      ingredients: [
+        {
+          id: "20000000-0000-0000-0000-000000000001",
+          requirement: "Молоко",
+          quantity: { amount: 500, unit: "MILLILITER" },
+        },
+      ],
+    },
+    shoppingList: {
+      id: "30000000-0000-0000-0000-000000000001",
+      items: [
+        {
+          id: "40000000-0000-0000-0000-000000000001",
+          requirement: "Молоко",
+          quantity: { amount: 1000, unit: "MILLILITER" },
+          sourceIngredientIds: ["20000000-0000-0000-0000-000000000001"],
+        },
+        {
+          id: "40000000-0000-0000-0000-000000000002",
+          requirement: "Яйца",
+          quantity: { amount: 10, unit: "PIECE" },
+          sourceIngredientIds: ["20000000-0000-0000-0000-000000000002"],
+        },
+      ],
+    },
+  },
+  comparisonPreview: {
+    locality: "Москва",
+    items: [
+      {
+        id: "40000000-0000-0000-0000-000000000001",
+        requirement: "Молоко",
+        quantity: { amount: 1000, unit: "MILLILITER" },
+      },
+      {
+        id: "40000000-0000-0000-0000-000000000002",
+        requirement: "Яйца",
+        quantity: { amount: 10, unit: "PIECE" },
+      },
+    ],
+    retailers: [],
+  },
+};
+
+describe("Recipe comparison results", () => {
+  it("shows canonical generated shopping requirements before the retailer comparison", () => {
+    render(<RecipeComparisonResults preview={preview} />);
+
+    expect(screen.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeDefined();
+    expect(screen.getByText("Молоко")).toBeDefined();
+    expect(screen.getByText("1000 MILLILITER")).toBeDefined();
+    expect(screen.getByText("Яйца")).toBeDefined();
+    expect(screen.getByText("10 PIECE")).toBeDefined();
+    expect(screen.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeDefined();
+  });
+
+  it("does not render transient UUIDs as user-facing content", () => {
+    const { container } = render(<RecipeComparisonResults preview={preview} />);
+    const text = container.textContent ?? "";
+
+    expect(text).not.toContain("10000000-0000-0000-0000-000000000001");
+    expect(text).not.toContain("20000000-0000-0000-0000-000000000001");
+    expect(text).not.toContain("30000000-0000-0000-0000-000000000001");
+    expect(text).not.toContain("40000000-0000-0000-0000-000000000001");
+  });
+});

--- a/apps/web/src/app/recipe-comparison-results.tsx
+++ b/apps/web/src/app/recipe-comparison-results.tsx
@@ -3,6 +3,7 @@ import type { components } from "@zakup-gotov/api-client";
 import { ComparisonPreviewResults } from "./comparison-preview-results";
 
 type Preview = components["schemas"]["RecipeComparisonPreviewResponse"];
+type ShoppingItem = components["schemas"]["RecipeShoppingPreviewShoppingItem"];
 
 export function RecipeComparisonResults({ preview }: { preview: Preview }) {
   return (
@@ -21,7 +22,7 @@ export function RecipeComparisonResults({ preview }: { preview: Preview }) {
         </div>
 
         <ul className="mt-6 grid gap-3 sm:grid-cols-2" aria-label="Покупки из рецепта">
-          {preview.recipeShoppingPreview.shoppingList.items.map((item) => (
+          {preview.recipeShoppingPreview.shoppingList.items.map((item: ShoppingItem) => (
             <li
               key={item.id}
               className="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm"

--- a/apps/web/src/app/recipe-comparison-results.tsx
+++ b/apps/web/src/app/recipe-comparison-results.tsx
@@ -1,0 +1,41 @@
+import type { components } from "@zakup-gotov/api-client";
+
+import { ComparisonPreviewResults } from "./comparison-preview-results";
+
+type Preview = components["schemas"]["RecipeComparisonPreviewResponse"];
+
+export function RecipeComparisonResults({ preview }: { preview: Preview }) {
+  return (
+    <>
+      <section aria-labelledby="recipe-shopping-results" className="mt-12">
+        <div className="max-w-2xl">
+          <h2
+            id="recipe-shopping-results"
+            className="text-2xl font-semibold tracking-tight text-stone-950"
+          >
+            Список покупок из рецепта
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-stone-600">
+            Количества пересчитаны для выбранного числа порций и приведены к каноническим единицам.
+          </p>
+        </div>
+
+        <ul className="mt-6 grid gap-3 sm:grid-cols-2" aria-label="Покупки из рецепта">
+          {preview.recipeShoppingPreview.shoppingList.items.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm"
+            >
+              <p className="font-medium text-stone-950">{item.requirement}</p>
+              <p className="mt-1 text-sm text-stone-600">
+                {item.quantity.amount} {item.quantity.unit}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <ComparisonPreviewResults preview={preview.comparisonPreview} />
+    </>
+  );
+}

--- a/apps/web/src/app/recipe-comparison.test.ts
+++ b/apps/web/src/app/recipe-comparison.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "@zakup-gotov/api-client";
+import { createRecipeComparisonPreview } from "./recipe-comparison";
+
+const originalApiBaseUrl = process.env.API_BASE_URL;
+
+type Request = components["schemas"]["RecipeComparisonPreviewRequest"];
+
+const request: Request = {
+  locality: "Москва",
+  recipe: {
+    title: "Блины",
+    baseServings: 2,
+    targetServings: 4,
+    ingredients: [
+      {
+        requirement: "Молоко",
+        quantity: { amount: 0.5, unit: "LITER" },
+      },
+    ],
+  },
+};
+
+function restoreApiBaseUrl() {
+  if (originalApiBaseUrl === undefined) {
+    delete process.env.API_BASE_URL;
+  } else {
+    process.env.API_BASE_URL = originalApiBaseUrl;
+  }
+}
+
+afterEach(() => {
+  restoreApiBaseUrl();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("recipe comparison transport", () => {
+  it("fails closed without API_BASE_URL and performs no request", async () => {
+    delete process.env.API_BASE_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createRecipeComparisonPreview(request)).resolves.toEqual({ kind: "unavailable" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the typed composed preview for a successful response", async () => {
+    process.env.API_BASE_URL = "http://api.test";
+    const response: components["schemas"]["RecipeComparisonPreviewResponse"] = {
+      recipeShoppingPreview: {
+        recipe: {
+          id: "10000000-0000-0000-0000-000000000001",
+          title: "Блины",
+          baseServings: 2,
+          targetServings: 4,
+          ingredients: [
+            {
+              id: "20000000-0000-0000-0000-000000000001",
+              requirement: "Молоко",
+              quantity: { amount: 500, unit: "MILLILITER" },
+            },
+          ],
+        },
+        shoppingList: {
+          id: "30000000-0000-0000-0000-000000000001",
+          items: [
+            {
+              id: "40000000-0000-0000-0000-000000000001",
+              requirement: "Молоко",
+              quantity: { amount: 1000, unit: "MILLILITER" },
+              sourceIngredientIds: ["20000000-0000-0000-0000-000000000001"],
+            },
+          ],
+        },
+      },
+      comparisonPreview: {
+        locality: "Москва",
+        items: [
+          {
+            id: "40000000-0000-0000-0000-000000000001",
+            requirement: "Молоко",
+            quantity: { amount: 1000, unit: "MILLILITER" },
+          },
+        ],
+        retailers: [],
+      },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(createRecipeComparisonPreview(request)).resolves.toEqual({
+      kind: "ready",
+      data: response,
+    });
+  });
+
+  it("returns only product-safe validation fields for any generated HTTP 400 problem", async () => {
+    process.env.API_BASE_URL = "http://api.test";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            type: "https://zakup-gotov.dev/problems/invalid-recipe-shopping-preview",
+            title: "Invalid recipe shopping preview request",
+            status: 400,
+            code: "INVALID_RECIPE_SHOPPING_PREVIEW",
+            errors: [{ field: "ingredients[0].quantity.amount", message: "must be greater than 0" }],
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/problem+json" },
+          },
+        ),
+      ),
+    );
+
+    await expect(createRecipeComparisonPreview(request)).resolves.toEqual({
+      kind: "invalid",
+      errors: [{ field: "ingredients[0].quantity.amount", message: "must be greater than 0" }],
+    });
+  });
+
+  it("aborts a hanging backend request within the bounded timeout", async () => {
+    vi.useFakeTimers();
+    process.env.API_BASE_URL = "http://api.test";
+    let aborted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = input instanceof globalThis.Request ? input.signal : init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              reject(new DOMException("aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        });
+      }),
+    );
+
+    const result = createRecipeComparisonPreview(request);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(aborted).toBe(true);
+    await expect(result).resolves.toEqual({ kind: "unavailable" });
+  });
+});

--- a/apps/web/src/app/recipe-comparison.ts
+++ b/apps/web/src/app/recipe-comparison.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import {
+  RECIPE_COMPARISON_PREVIEWS_PATH,
+  createZakupGotovClient,
+  type components,
+} from "@zakup-gotov/api-client";
+
+const RECIPE_COMPARISON_PREVIEW_TIMEOUT_MS = 3_000;
+
+export type RecipeComparisonPreviewRequest =
+  components["schemas"]["RecipeComparisonPreviewRequest"];
+export type RecipeComparisonPreviewResponse =
+  components["schemas"]["RecipeComparisonPreviewResponse"];
+export type RecipeComparisonPreviewValidationError =
+  | components["schemas"]["RecipeComparisonPreviewValidationError"]
+  | components["schemas"]["RecipeShoppingPreviewValidationError"]
+  | components["schemas"]["ComparisonPreviewValidationError"];
+
+export type RecipeComparisonState =
+  | { kind: "ready"; data: RecipeComparisonPreviewResponse }
+  | { kind: "invalid"; errors: RecipeComparisonPreviewValidationError[] }
+  | { kind: "unavailable" };
+
+export async function createRecipeComparisonPreview(
+  request: RecipeComparisonPreviewRequest,
+): Promise<RecipeComparisonState> {
+  const baseUrl = process.env.API_BASE_URL;
+  if (!baseUrl) {
+    return { kind: "unavailable" };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RECIPE_COMPARISON_PREVIEW_TIMEOUT_MS);
+
+  try {
+    const client = createZakupGotovClient(baseUrl);
+    const { data, error, response } = await client.POST(RECIPE_COMPARISON_PREVIEWS_PATH, {
+      body: request,
+      signal: controller.signal,
+    });
+
+    if (data) {
+      return { kind: "ready", data };
+    }
+    if (response.status === 400 && error) {
+      return {
+        kind: "invalid",
+        errors: error.errors.map(({ field, message }) => ({ field, message })),
+      };
+    }
+    return { kind: "unavailable" };
+  } catch {
+    return { kind: "unavailable" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/web/src/app/recipe-comparison.ts
+++ b/apps/web/src/app/recipe-comparison.ts
@@ -44,9 +44,13 @@ export async function createRecipeComparisonPreview(
       return { kind: "ready", data };
     }
     if (response.status === 400 && error) {
+      const errors = error.errors as RecipeComparisonPreviewValidationError[];
       return {
         kind: "invalid",
-        errors: error.errors.map(({ field, message }) => ({ field, message })),
+        errors: errors.map((validationError) => ({
+          field: validationError.field,
+          message: validationError.message,
+        })),
       };
     }
     return { kind: "unavailable" };

--- a/docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md
+++ b/docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md
@@ -1,0 +1,133 @@
+# M2.4 Responsive Recipe UI — Shipping Evidence
+
+Date: 2026-08-14  
+Issue: #103  
+PR: #104  
+Status: **IMPLEMENTED / TESTED / SHIPPING — acceptance pending**
+
+Authoritative design: `docs/superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md`  
+Implementation plan: `docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md`
+
+## Delivered scope
+
+M2.4 adds the first real Recipe-first browser journey over the accepted M2.3 API:
+
+`Recipe title/servings + ingredient editing + locality → POST /api/v1/recipe-comparison-previews → generated shopping requirements → existing truthful retailer comparison renderer`
+
+Delivered behavior:
+
+- generated-client-only server action for `RECIPE_COMPARISON_PREVIEWS_PATH`;
+- finite request timeout and fail-closed unavailable state;
+- product-safe generated 400 validation messages without problem metadata/internal leakage;
+- responsive Recipe form with title, base/target servings, locality and 1..100 editable ingredient rows;
+- quantity/unit editing over generated `QuantityInputUnit`;
+- client preflight for blank required values, positive integer servings and positive finite quantities;
+- no browser-side Recipe scaling, unit canonicalization, merge, identity, provenance or comparison-domain implementation;
+- generated canonical shopping requirements rendered before retailer comparison;
+- transient Recipe/ingredient/list/item UUIDs remain hidden from user-facing output;
+- existing `ComparisonPreviewResults` reused unchanged, preserving READY/UNCERTAIN/INCOMPLETE/UNAVAILABLE semantics and no invented winner;
+- Recipe-first homepage positioning with manual basket comparison retained as a secondary path;
+- deterministic E2E-only M2.3 mock endpoint; production code contains no fixture retailer data;
+- desktop/mobile Recipe journey, unavailable state, keyboard focus and manual regression coverage.
+
+## Explicit TDD evidence
+
+### Server transport
+
+RED head `69a209a80054b1f8f545b3ed68d395bd157336b8`:
+
+- Web CI reached TypeScript compilation;
+- expected failure: `TS2307 Cannot find module './recipe-comparison'` from the new transport contract test.
+
+GREEN sequence:
+
+- production server action added;
+- generated 400 union typing tightened after TypeScript caught an implicit-any projection;
+- head `71539f3c4a8c930e32c4aa6b5678da8c7fc5bf7e` passed lint, typecheck, component tests and production build.
+
+### Generated shopping result projection
+
+RED head `b455e030ce4873528f2e5f454e6bca982466c472`:
+
+- expected failure because `recipe-comparison-results` did not exist.
+
+GREEN sequence:
+
+- canonical shopping item projection added;
+- generated item type made explicit after TypeScript rejected an implicit-any map parameter;
+- head `51664143f46198284db6c17cbb6a3fa93ac606f7` passed lint, typecheck, component tests and production build.
+
+### Recipe form
+
+RED head `7cce42123ff3a6f17345d163c90bb292f107c857`:
+
+- Web CI lint succeeded;
+- expected typecheck failure: `TS2307 Cannot find module './recipe-comparison-form'`.
+
+GREEN head `da628eef9694c0ce4cfff9e9dd1b763cfe253162`:
+
+- lint PASS;
+- typecheck PASS;
+- all component tests PASS;
+- production build PASS.
+
+Covered form behavior includes sensible serving defaults, one-row floor, add/remove editing, exact generated M2.3 request shape, serving/quantity/unit changes, client validation, generated backend validation and unavailable state.
+
+### Homepage + browser journey
+
+RED head `1b20fbf8feaef621da016e68597f26328d3bec1b`:
+
+- lint PASS;
+- typecheck PASS;
+- 29 existing/new component tests PASS;
+- only the new homepage test failed because production still rendered `M1 · Shopping Core` and no Recipe-first form.
+
+GREEN implementation checkpoint `dab2c9f8c32ef89684d0fdc326b100f033f78117`:
+
+- Web lint PASS;
+- Web typecheck PASS;
+- **30/30 component/unit tests PASS**;
+- production Next.js build PASS;
+- **Playwright responsive browser suite PASS**, covering:
+  - desktop `Блины`, base 2 → target 4, `0.5 LITER` milk + `5 PIECE` eggs;
+  - generated `Молоко 1000 MILLILITER` and `Яйца 10 PIECE`;
+  - eight truthful retailer results;
+  - mobile viewport with no horizontal overflow;
+  - fail-closed unavailable API state with one accessible alert and no fabricated results;
+  - visible keyboard focus path;
+  - unchanged manual basket comparison journey.
+
+## Repository-wide CI checkpoint
+
+On implementation checkpoint `dab2c9f8c32ef89684d0fdc326b100f033f78117`:
+
+- API CI — SUCCESS;
+- Contract CI — SUCCESS;
+- Web CI + E2E — SUCCESS;
+- CodeQL — SUCCESS;
+- Dependency Review — SUCCESS;
+- Container Security CI — SUCCESS;
+- Retailer Bridge CI — SUCCESS;
+- Release Contract CI — SUCCESS;
+- Release Bundle CI was still running when this shipping record was authored.
+
+The final PR head after this documentation commit must re-run all normal PR workflow groups. This checkpoint is evidence of implementation correctness, not final acceptance evidence.
+
+## Security/privacy and architecture review points
+
+- browser code imports generated OpenAPI types/path; no duplicate backend request/response DTO is introduced;
+- Recipe business semantics remain server-owned by accepted M2.1–M2.3 boundaries;
+- no exact address, account/session persistence, localStorage, provider identifier, SKU, acquisition mode, fulfillment context or retailer credential is introduced;
+- deterministic retailer data lives only in `apps/web/e2e/mock-api.mjs`;
+- service failures never fabricate shopping requirements or retailer results;
+- no cheapest/best/recommended retailer claim is introduced.
+
+## Remaining acceptance gates
+
+M2.4 is **not ACCEPTED** until all of the following hold on the final reviewed PR head:
+
+1. all 9 normal PR workflow groups succeed on the exact same head;
+2. independent read-only review reports no unresolved P0/P1/P2 finding;
+3. PR #104 is marked ready and squash-merged with expected-head protection;
+4. all normal push-triggered workflows on the resulting `main` SHA succeed;
+5. only then may #103 and canonical state/roadmap/changelog be marked COMPLETE / ACCEPTED.

--- a/docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md
+++ b/docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md
@@ -1,0 +1,184 @@
+# M2.4 Responsive Recipe UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a responsive Recipe-first web journey backed exclusively by the accepted generated M2.3 Recipe → Comparison contract while preserving the manual comparison flow.
+
+**Architecture:** Add a generated-client server action, a focused client Recipe form, and a generated-shopping result projection that reuses the existing comparison result renderer. Extend deterministic browser fixtures only under `apps/web/e2e`; production browser code never reimplements Recipe scaling/merge/comparison logic or retailer evidence.
+
+**Tech Stack:** Next.js 16.3.0, React 19.2.8, TypeScript, Tailwind CSS 4, generated OpenAPI client, Vitest/Testing Library, Playwright.
+
+## Global Constraints
+
+- Use `RECIPE_COMPARISON_PREVIEWS_PATH` and generated request/response/problem schemas from `@zakup-gotov/api-client`.
+- Recipe-first becomes primary; manual basket comparison remains functional below it.
+- Browser code owns form state and preflight UX only; backend remains authoritative for Recipe and comparison semantics.
+- No persistence/local storage, exact address, provider identifiers, retailer credentials, fuzzy/AI logic, recommendation ranking or production retailer calls.
+- Keep existing stone-based visual language; M2.4 is not a redesign.
+- Component behavior and desktop/mobile Playwright journey start RED-first.
+
+---
+
+### Task 1: Generated-client server action
+
+**Files:**
+- Create: `apps/web/src/app/recipe-comparison.ts`
+- Create: `apps/web/src/app/recipe-comparison.test.ts`
+
+**Interfaces:**
+- Consumes: `RECIPE_COMPARISON_PREVIEWS_PATH`, `createZakupGotovClient`, generated `RecipeComparisonPreviewRequest`, `RecipeComparisonPreviewResponse` and 400 problem schemas.
+- Produces: `createRecipeComparisonPreview(request): Promise<RecipeComparisonState>` and exported generated-type aliases used by the form.
+
+- [ ] **Step 1: Write the failing server-action contract test**
+
+Assert that a successful generated-client POST returns `{kind: "ready"}`, a generated 400 problem returns `{kind: "invalid"}` with only `{field,message}` errors, and missing/unreachable `API_BASE_URL` returns `{kind: "unavailable"}`.
+
+- [ ] **Step 2: Run the focused test and preserve RED evidence**
+
+Run through Web CI / `pnpm --filter web test -- recipe-comparison.test.ts`; expected failure is missing `recipe-comparison` production module/action.
+
+- [ ] **Step 3: Implement the minimal server action**
+
+Use the existing finite-timeout pattern from `comparison-preview.ts`; POST only `RECIPE_COMPARISON_PREVIEWS_PATH`; map 200/400/unavailable without leaking problem metadata or internal errors.
+
+- [ ] **Step 4: Verify GREEN**
+
+Focused test, web typecheck and existing `comparison-preview.test.ts` pass.
+
+### Task 2: Recipe form component
+
+**Files:**
+- Create: `apps/web/src/app/recipe-comparison-form.tsx`
+- Create: `apps/web/src/app/recipe-comparison-form.test.tsx`
+
+**Interfaces:**
+- Consumes: `createRecipeComparisonPreview`, generated `RecipeComparisonPreviewRequest`, generated `QuantityInputUnit`.
+- Produces: `<RecipeComparisonForm />` with primary Recipe editing workflow.
+
+- [ ] **Step 1: Write component RED tests**
+
+Require default base/target servings `2`, one ingredient row, add/remove behavior, quantity/unit editing, serving changes, client preflight messages, submit request shape, pending state, generated 400 display and unavailable display.
+
+- [ ] **Step 2: Run focused test and preserve RED**
+
+Expected failure: missing `RecipeComparisonForm` and/or missing controls.
+
+- [ ] **Step 3: Implement minimal form state and validation**
+
+Use labels `Название рецепта`, `Порций в рецепте`, `Нужно порций`, `Населённый пункт`, `Ингредиент`, `Количество`, `Единица`; actions `Добавить ингредиент`, `Удалить ингредиент`, `Сравнить рецепт`.
+
+Client validation rejects blank title/locality, non-positive or non-integer servings, blank ingredient requirement and non-positive/non-finite quantity. Do not calculate serving scaling in browser code.
+
+- [ ] **Step 4: Verify GREEN**
+
+Focused component tests and typecheck pass.
+
+### Task 3: Recipe result projection
+
+**Files:**
+- Create: `apps/web/src/app/recipe-comparison-results.tsx`
+- Create: `apps/web/src/app/recipe-comparison-results.test.tsx`
+- Reuse: `apps/web/src/app/comparison-preview-results.tsx`
+
+**Interfaces:**
+- Consumes: generated `RecipeComparisonPreviewResponse`.
+- Produces: `<RecipeComparisonResults preview={...} />`.
+
+- [ ] **Step 1: Write result RED tests**
+
+Require heading `Список покупок из рецепта`, canonical generated shopping items in order, no raw UUID rendering, and reuse of the existing comparison result output including uncertainty/incomplete/unavailable states.
+
+- [ ] **Step 2: Run RED**
+
+Expected failure: missing result component.
+
+- [ ] **Step 3: Implement minimal projection**
+
+Render each generated item requirement plus canonical amount/unit and pass `preview.comparisonPreview` directly to `ComparisonPreviewResults`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Focused result tests and existing comparison result tests pass.
+
+### Task 4: Homepage integration and deterministic browser fixture
+
+**Files:**
+- Modify: `apps/web/src/app/page.tsx`
+- Modify: `apps/web/src/app/page.test.tsx`
+- Modify: `apps/web/e2e/home.spec.ts`
+- Modify: `apps/web/e2e/mock-api.mjs`
+
+**Interfaces:**
+- Homepage renders Recipe journey first and manual comparison second.
+- Mock API supports both accepted endpoints without live retailer traffic.
+
+- [ ] **Step 1: Write homepage and Playwright RED tests before production integration**
+
+Desktop Recipe scenario:
+1. open `/`;
+2. fill title `Блины`, base servings `2`, target servings `4`, locality `Москва`;
+3. fill first ingredient `Молоко`, `0.5 LITER`;
+4. add second ingredient `Яйца`, `5 PIECE`;
+5. submit `Сравнить рецепт`;
+6. expect `Список покупок из рецепта` with canonical scaled `Молоко 1000 MILLILITER` and `Яйца 10 PIECE`;
+7. expect `Результат для Москва` and eight retailer entries with truthful mixed statuses.
+
+Mobile scenario uses a mobile viewport, edits Recipe fields, submits, and asserts `scrollWidth <= clientWidth`.
+
+Failure scenario uses locality `Недоступно`, expects exactly one alert and no generated shopping list/comparison results.
+
+Keyboard scenario tabs into the first Recipe field and verifies visible focus.
+
+Keep the existing manual comparison journey as a regression scenario.
+
+- [ ] **Step 2: Run Playwright and preserve RED**
+
+Expected failures: Recipe controls/endpoint are not yet integrated.
+
+- [ ] **Step 3: Extend deterministic mock API**
+
+Handle `/api/v1/recipe-comparison-previews` separately. Construct deterministic recipe/ingredient/list/item UUIDs only in the test fixture; canonicalize units and scale each test ingredient by `targetServings/baseServings`; feed generated shopping items into the existing deterministic comparison builder. Return the accepted response shape.
+
+This fixture is browser-test evidence only and must not be imported by production code.
+
+- [ ] **Step 4: Integrate Recipe form on homepage**
+
+Update page copy from stale `M1 · Shopping Core` positioning to Recipe-first M2 language. Render `<RecipeComparisonForm />` before the existing `<ComparisonPreviewForm />`; clearly present manual comparison as an alternate entry without hiding it.
+
+- [ ] **Step 5: Verify GREEN across desktop/mobile Playwright**
+
+Run full browser suite; expected all Recipe and manual scenarios PASS with no horizontal overflow and no provider/internal fields in visible text.
+
+### Task 5: Full verification, review and shipping
+
+**Files:**
+- Update: `docs/PROJECT_STATE.md` only to `IMPLEMENTED / TESTED / SHIPPING` before merge, never `ACCEPTED` prematurely.
+- Update: `docs/ROADMAP.md`
+- Update: `CHANGELOG.md`
+- Create/update shipping evidence under `docs/superpowers/plans/`.
+
+- [ ] **Step 1: Run complete Web gates**
+
+`lint`, `typecheck`, unit tests, build and Playwright all pass. Generated API client stays unchanged/fresh because M2.4 changes no backend/OpenAPI contract.
+
+- [ ] **Step 2: Require exact-head repository CI**
+
+API CI, Contract CI, Web CI/E2E, CodeQL, Dependency Review, Container Security, Retailer Bridge, Release Contract and Release Bundle all succeed on the same reviewed PR head.
+
+- [ ] **Step 3: Perform read-only review**
+
+Review request/response typing, no browser domain duplication, failure behavior, accessibility/responsiveness, test-fixture isolation, privacy/security and regression scope. Block P0/P1/P2.
+
+- [ ] **Step 4: Mark PR ready and squash-merge with exact head SHA**
+
+Do not merge from a stale or partially checked head.
+
+- [ ] **Step 5: Run post-merge acceptance gate**
+
+Require all normal push-triggered workflows on the merged `main` SHA to succeed. Only then close #103 as accepted and synchronize canonical docs in a docs-only acceptance PR if needed.
+
+## Self-review
+
+- Spec coverage: product workflow, generated contract boundary, error UX, manual-flow retention, accessibility, responsive behavior, deterministic fixture isolation and acceptance gates are each mapped to a task.
+- Placeholder scan: no TODO/TBD implementation placeholders.
+- Type consistency: all web request/response types come from `components["schemas"]`; no duplicate backend DTO is introduced.

--- a/docs/superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md
+++ b/docs/superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md
@@ -1,0 +1,153 @@
+# M2.4 Responsive Recipe UI — Design
+
+Date: 2026-08-14  
+Issue: #103  
+Baseline: `main=09db5801ed03c3a9243f1a6e7285dbd7c6af3489`  
+Status: **AUTHORITATIVE DESIGN — approved for implementation by the user**
+
+## Goal
+
+Deliver the first real responsive Recipe experience on the existing Zakup Gotov web surface:
+
+`Recipe title/servings + ingredient editing + locality → POST /api/v1/recipe-comparison-previews → generated shopping requirements + truthful retailer comparison`
+
+M2.4 is a frontend vertical slice over the accepted M2.3 API. It must not recreate Recipe conversion or comparison semantics in the browser.
+
+## Product position
+
+Recipe-first is now the primary user journey. The existing manual basket comparison remains available below it as a secondary entry path and regression surface.
+
+The page keeps the existing restrained Zakup Gotov visual system: stone palette, readable typography, rounded inputs/panels, responsive single-column flow and existing retailer result cards. M2.4 is not a redesign and introduces no decorative imagery or unrelated marketing sections.
+
+## Primary form
+
+The Recipe form contains:
+
+- Recipe title, required, max 240 characters;
+- base servings, positive JSON integer;
+- target servings, positive JSON integer;
+- locality, required, max 160 characters;
+- 1..100 ingredient rows;
+- ingredient requirement, required, max 240 characters;
+- positive decimal quantity;
+- unit from generated `QuantityInputUnit`: `PIECE`, `GRAM`, `KILOGRAM`, `MILLILITER`, `LITER`;
+- add ingredient;
+- remove ingredient, disabled while only one row remains;
+- submit action `Сравнить рецепт`.
+
+Initial local UI state:
+
+- title empty;
+- base servings `2`;
+- target servings `2`;
+- locality empty;
+- one ingredient with amount `1` and unit `PIECE`.
+
+The browser owns only form state and user-friendly preflight checks. Backend validation remains authoritative.
+
+## Generated result
+
+On success, the UI renders two ordered sections:
+
+1. `Список покупок из рецепта` using `recipeShoppingPreview.shoppingList.items`;
+2. the existing `ComparisonPreviewResults` using `comparisonPreview` unchanged.
+
+Generated shopping items display normalized requirement and canonical quantity. Raw Recipe, ingredient, ShoppingList and ShoppingItem UUIDs are not shown because they are not useful to the user, though they remain present in the typed response and are preserved by M2.3.
+
+No cheapest/best/recommended winner is invented. `READY`, `UNCERTAIN`, `INCOMPLETE` and `UNAVAILABLE` retailer states continue to use the accepted comparison result renderer.
+
+## Transport boundary
+
+Create one server action using only the generated API client:
+
+- `RECIPE_COMPARISON_PREVIEWS_PATH`;
+- `components["schemas"]["RecipeComparisonPreviewRequest"]`;
+- `components["schemas"]["RecipeComparisonPreviewResponse"]`;
+- generated 400 problem union.
+
+Do not define duplicate backend request/response DTOs in web code.
+
+The action uses the existing `API_BASE_URL` pattern and a finite timeout. It maps:
+
+- 200 → `ready`;
+- 400 problem union → `invalid` with product-safe field/message errors;
+- missing configuration, timeout, network failure and unexpected status → `unavailable`.
+
+Do not surface problem `type`, stack traces, provider internals or arbitrary server exception text.
+
+## Error UX
+
+Client preflight covers:
+
+- missing title;
+- missing locality;
+- non-positive/non-integer base/target servings;
+- missing ingredient requirement;
+- non-positive/non-finite quantity.
+
+Known backend 400 errors render one accessible `role=alert` summary based on generated problem `errors`.
+
+Unavailable service renders one accessible alert and no fabricated generated shopping list or comparison results.
+
+## Responsive and accessibility
+
+- no horizontal overflow at desktop or mobile widths;
+- labels are programmatically associated with every field;
+- keyboard focus remains visible;
+- add/remove/submit are real buttons with minimum comfortable hit area;
+- ingredient rows collapse to a vertical layout on narrow screens;
+- base/target servings stay legible and editable on mobile;
+- pending submit state is explicit and prevents duplicate submission;
+- existing comparison cards continue their responsive one/two-column behavior.
+
+## TDD / browser acceptance
+
+Frontend implementation is RED-first.
+
+Required component/server-action coverage:
+
+- request shape uses generated M2.3 contract;
+- default servings and ingredient row;
+- ingredient add/remove;
+- quantity/unit editing;
+- serving changes;
+- local validation;
+- success result shows generated shopping requirements and comparison result;
+- 400 and unavailable states do not fabricate results.
+
+Required Playwright RED-first scenarios:
+
+- desktop Recipe journey with at least two ingredients, serving scaling and generated shopping-list output;
+- mobile Recipe journey with no horizontal overflow;
+- unavailable API produces one accessible error and no results;
+- keyboard-visible focus path through the Recipe form;
+- existing manual basket comparison journey remains functional.
+
+The deterministic E2E mock gains `POST /api/v1/recipe-comparison-previews`. It may deterministically emulate the accepted contract for browser testing, but production web code must never contain fixture retailer data.
+
+## Architecture / security / privacy
+
+- Recipe UI depends on the generated API client, not backend implementation packages;
+- no retailer credentials, browser bridge, provider IDs, SKUs, acquisition modes or fulfillment-context IDs enter client code;
+- locality only; no exact-address UI in M2.4;
+- no request persistence/local storage by default;
+- no analytics payload containing recipe/ingredient text is introduced;
+- no live retailer requests originate from browser tests.
+
+## Non-goals
+
+No saved Recipe CRUD/history, accounts, persistence, pantry state, multi-recipe aggregation, meal planning, nutrition, fuzzy/synonym/AI ingredient parsing, recipe import, exact-address/store picker, retailer activation, provider/acquisition changes, cheapest-retailer recommendation or visual redesign.
+
+## Acceptance
+
+Before merge require:
+
+- explicit component and Playwright RED checkpoints for the new journey;
+- Web unit tests, typecheck, lint and build green;
+- Playwright desktop/mobile regression green against deterministic mock API;
+- API/Contract regression green despite no backend behavior changes;
+- CodeQL, Dependency Review, Container Security, Retailer Bridge, Release Contract and Release Bundle green;
+- read-only review with no unresolved P0/P1/P2;
+- exact PR head green across all normal workflow groups;
+- squash merge with expected-head protection;
+- all normal post-merge `main` workflows green before M2.4 becomes COMPLETE / ACCEPTED.


### PR DESCRIPTION
## Summary

Implements #103: the first real responsive Recipe-first web journey over the accepted M2.3 contract.

Delivered:
- generated-client server action for `POST /api/v1/recipe-comparison-previews` with finite timeout and fail-closed errors;
- Recipe title/base servings/target servings/locality editing;
- ingredient add/remove + quantity/unit editing;
- generated canonical shopping requirements followed by the existing truthful retailer comparison renderer;
- no browser-side Recipe scaling/merge/comparison-domain duplication;
- Recipe-first homepage positioning with manual basket comparison retained as a secondary path;
- deterministic E2E-only M2.3 fixture endpoint, no live retailer traffic;
- desktop/mobile, unavailable-state, keyboard-focus and manual-regression Playwright coverage.

## TDD evidence

Explicit RED checkpoints were preserved for:
- server transport: `69a209a…` → missing `recipe-comparison`;
- generated result projection: `b455e03…` → missing `recipe-comparison-results`;
- Recipe form: `7cce421…` → missing `recipe-comparison-form`;
- homepage/browser integration: `1b20fbf…` → old M1 homepage / absent Recipe-first journey.

Implementation checkpoint `dab2c9f…` passed Web lint, typecheck, 30/30 unit/component tests, production build and the full responsive Playwright suite. Shipping evidence is recorded in `docs/superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md`.

## Current checkpoint

**IMPLEMENTED / TESTED / SHIPPING — acceptance pending.**

Final documentation head must pass all 9 normal PR workflow groups and read-only review before this draft becomes ready. Squash merge only from the reviewed exact head with expected-head protection. M2.4/#103 becomes COMPLETE / ACCEPTED only after all normal post-merge `main` workflows succeed.

Closes #103 after merge/acceptance.