### PR TITLE
M2.5: add deterministic multi-recipe aggregation

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntry.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntry.java
@@ -1,0 +1,15 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+
+public record RecipeAggregationEntry(
+        RecipeAggregationEntryId id,
+        Recipe recipe,
+        RecipeServings targetServings) {
+
+    public RecipeAggregationEntry {
+        id = Objects.requireNonNull(id, "id must not be null");
+        recipe = Objects.requireNonNull(recipe, "recipe must not be null");
+        targetServings = Objects.requireNonNull(targetServings, "targetServings must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntryId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntryId.java
@@ -1,0 +1,10 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RecipeAggregationEntryId(UUID value) {
+    public RecipeAggregationEntryId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationIngredientRef.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationIngredientRef.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import java.util.Objects;
+
+public record RecipeAggregationIngredientRef(
+        RecipeAggregationEntryId entryId,
+        RecipeIngredientRef ingredientRef) {
+
+    public RecipeAggregationIngredientRef {
+        entryId = Objects.requireNonNull(entryId, "entryId must not be null");
+        ingredientRef = Objects.requireNonNull(ingredientRef, "ingredientRef must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIds.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIds.java
@@ -1,0 +1,24 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+final class RecipeShoppingItemIds {
+    private RecipeShoppingItemIds() {}
+
+    static ShoppingItemId derive(
+            ShoppingListId shoppingListId,
+            ShoppingRequirement requirement,
+            QuantityUnit unit) {
+        var payload = shoppingListId.value()
+                + "\n"
+                + requirement.text()
+                + "\n"
+                + unit.name();
+        return new ShoppingItemId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregation.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregation.java
@@ -1,0 +1,25 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record RecipeShoppingListAggregation(
+        ShoppingList shoppingList,
+        Map<ShoppingItemId, List<RecipeAggregationIngredientRef>> provenance) {
+
+    public RecipeShoppingListAggregation {
+        shoppingList = Objects.requireNonNull(shoppingList, "shoppingList must not be null");
+        provenance = Objects.requireNonNull(provenance, "provenance must not be null");
+
+        var copy = new LinkedHashMap<ShoppingItemId, List<RecipeAggregationIngredientRef>>();
+        provenance.forEach((itemId, refs) -> copy.put(
+                Objects.requireNonNull(itemId, "provenance itemId must not be null"),
+                List.copyOf(Objects.requireNonNull(refs, "provenance refs must not be null"))));
+        provenance = Collections.unmodifiableMap(copy);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregator.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregator.java
@@ -8,6 +8,7 @@ import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -34,10 +35,17 @@ public final class RecipeShoppingListAggregator {
             ShoppingListId aggregateShoppingListId) {
         Objects.requireNonNull(entries, "entries must not be null");
         Objects.requireNonNull(aggregateShoppingListId, "aggregateShoppingListId must not be null");
+        if (entries.isEmpty()) {
+            throw new IllegalArgumentException("entries must not be empty");
+        }
 
         var groups = new LinkedHashMap<RecipeShoppingMergeKey, GroupAccumulator>();
+        var seenEntryIds = new HashSet<RecipeAggregationEntryId>();
         for (var entry : entries) {
             Objects.requireNonNull(entry, "entry must not be null");
+            if (!seenEntryIds.add(entry.id())) {
+                throw new IllegalArgumentException("duplicate aggregation entry id");
+            }
             var conversion = converter.convert(
                     entry.recipe(),
                     entry.targetServings(),

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregator.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregator.java
@@ -1,0 +1,113 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RecipeShoppingListAggregator {
+
+    private final RecipeShoppingListConverter converter;
+    private final RecipeShoppingItemIdDeriver itemIdDeriver;
+
+    public RecipeShoppingListAggregator() {
+        this(new RecipeShoppingListConverter(), RecipeShoppingItemIds::derive);
+    }
+
+    RecipeShoppingListAggregator(
+            RecipeShoppingListConverter converter,
+            RecipeShoppingItemIdDeriver itemIdDeriver) {
+        this.converter = Objects.requireNonNull(converter, "converter must not be null");
+        this.itemIdDeriver = Objects.requireNonNull(itemIdDeriver, "itemIdDeriver must not be null");
+    }
+
+    public RecipeShoppingListAggregation aggregate(
+            List<RecipeAggregationEntry> entries,
+            ShoppingListId aggregateShoppingListId) {
+        Objects.requireNonNull(entries, "entries must not be null");
+        Objects.requireNonNull(aggregateShoppingListId, "aggregateShoppingListId must not be null");
+
+        var groups = new LinkedHashMap<RecipeShoppingMergeKey, GroupAccumulator>();
+        for (var entry : entries) {
+            Objects.requireNonNull(entry, "entry must not be null");
+            var conversion = converter.convert(
+                    entry.recipe(),
+                    entry.targetServings(),
+                    deriveEntryShoppingListId(aggregateShoppingListId, entry.id()));
+            for (var item : conversion.shoppingList().items()) {
+                var refs = Objects.requireNonNull(
+                        conversion.provenance().get(item.id()),
+                        "converted item provenance must not be null");
+                if (refs.isEmpty()) {
+                    throw new IllegalStateException("converted item provenance must not be empty");
+                }
+                var key = new RecipeShoppingMergeKey(item.requirement(), item.quantity().unit());
+                groups.computeIfAbsent(key, ignored -> new GroupAccumulator())
+                        .add(item.quantity().amount(), entry.id(), refs);
+            }
+        }
+
+        var shoppingList = new ShoppingList(aggregateShoppingListId);
+        var provenance = new LinkedHashMap<ShoppingItemId, List<RecipeAggregationIngredientRef>>();
+        var itemKeys = new LinkedHashMap<ShoppingItemId, RecipeShoppingMergeKey>();
+        for (var group : groups.entrySet()) {
+            var key = group.getKey();
+            var accumulator = group.getValue();
+            var itemId = Objects.requireNonNull(
+                    itemIdDeriver.derive(aggregateShoppingListId, key.requirement(), key.unit()),
+                    "derived item id must not be null");
+            var previousKey = itemKeys.putIfAbsent(itemId, key);
+            if (previousKey != null && !previousKey.equals(key)) {
+                throw new IllegalStateException("generated shopping item id collision");
+            }
+            shoppingList.add(new ShoppingItem(
+                    itemId,
+                    key.requirement(),
+                    new Quantity(accumulator.totalAmount(), key.unit())));
+            provenance.put(itemId, accumulator.refs());
+        }
+
+        return new RecipeShoppingListAggregation(shoppingList, provenance);
+    }
+
+    private static ShoppingListId deriveEntryShoppingListId(
+            ShoppingListId aggregateShoppingListId,
+            RecipeAggregationEntryId entryId) {
+        var payload = "recipe-aggregation-entry-list\n"
+                + aggregateShoppingListId.value()
+                + "\n"
+                + entryId.value();
+        return new ShoppingListId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static final class GroupAccumulator {
+        private BigDecimal totalAmount = BigDecimal.ZERO;
+        private final ArrayList<RecipeAggregationIngredientRef> refs = new ArrayList<>();
+
+        void add(
+                BigDecimal amount,
+                RecipeAggregationEntryId entryId,
+                List<RecipeIngredientRef> ingredientRefs) {
+            totalAmount = totalAmount.add(amount);
+            for (var ingredientRef : ingredientRefs) {
+                refs.add(new RecipeAggregationIngredientRef(entryId, ingredientRef));
+            }
+        }
+
+        BigDecimal totalAmount() {
+            return totalAmount;
+        }
+
+        List<RecipeAggregationIngredientRef> refs() {
+            return refs;
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java
@@ -6,21 +6,18 @@ import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
-import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Objects;
-import java.util.UUID;
 
 public final class RecipeShoppingListConverter {
 
     private final RecipeShoppingItemIdDeriver itemIdDeriver;
 
     public RecipeShoppingListConverter() {
-        this(RecipeShoppingListConverter::deriveDefaultItemId);
+        this(RecipeShoppingItemIds::derive);
     }
 
     RecipeShoppingListConverter(RecipeShoppingItemIdDeriver itemIdDeriver) {
@@ -35,16 +32,16 @@ public final class RecipeShoppingListConverter {
         Objects.requireNonNull(targetServings, "targetServings must not be null");
         Objects.requireNonNull(shoppingListId, "shoppingListId must not be null");
 
-        var groups = new LinkedHashMap<MergeKey, GroupAccumulator>();
+        var groups = new LinkedHashMap<RecipeShoppingMergeKey, GroupAccumulator>();
         for (var ingredient : recipe.ingredients()) {
-            var key = new MergeKey(ingredient.requirement(), ingredient.quantity().unit());
+            var key = new RecipeShoppingMergeKey(ingredient.requirement(), ingredient.quantity().unit());
             groups.computeIfAbsent(key, ignored -> new GroupAccumulator())
                     .add(ingredient.quantity().amount(), new RecipeIngredientRef(recipe.id(), ingredient.id()));
         }
 
         var shoppingList = new ShoppingList(shoppingListId);
         var provenance = new LinkedHashMap<ShoppingItemId, java.util.List<RecipeIngredientRef>>();
-        var itemKeys = new LinkedHashMap<ShoppingItemId, MergeKey>();
+        var itemKeys = new LinkedHashMap<ShoppingItemId, RecipeShoppingMergeKey>();
         for (var entry : groups.entrySet()) {
             var key = entry.getKey();
             var accumulator = entry.getValue();
@@ -75,20 +72,6 @@ public final class RecipeShoppingListConverter {
             return numerator.divide(BigDecimal.valueOf(baseServings), MathContext.DECIMAL128);
         }
     }
-
-    private static ShoppingItemId deriveDefaultItemId(
-            ShoppingListId shoppingListId,
-            ShoppingRequirement requirement,
-            QuantityUnit unit) {
-        var payload = shoppingListId.value()
-                + "\n"
-                + requirement.text()
-                + "\n"
-                + unit.name();
-        return new ShoppingItemId(UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    private record MergeKey(ShoppingRequirement requirement, QuantityUnit unit) {}
 
     private static final class GroupAccumulator {
         private BigDecimal totalAmount = BigDecimal.ZERO;

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingMergeKey.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingMergeKey.java
@@ -1,0 +1,6 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+
+record RecipeShoppingMergeKey(ShoppingRequirement requirement, QuantityUnit unit) {}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregatorTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregatorTest.java
@@ -1,0 +1,77 @@
+package io.github.trueruslan.zakupgotov.recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RecipeShoppingListAggregatorTest {
+
+    private static final ShoppingListId AGGREGATE_LIST_ID =
+            new ShoppingListId(UUID.fromString("70000000-0000-0000-0000-000000000001"));
+    private static final RecipeAggregationEntryId ENTRY_A =
+            new RecipeAggregationEntryId(UUID.fromString("71000000-0000-0000-0000-000000000001"));
+    private static final RecipeAggregationEntryId ENTRY_B =
+            new RecipeAggregationEntryId(UUID.fromString("71000000-0000-0000-0000-000000000002"));
+
+    @Test
+    void mergesCompatibleCanonicalItemsAcrossRecipeEntriesWithOrderedOccurrenceProvenance() {
+        var milkA = ingredient(
+                "72000000-0000-0000-0000-000000000001",
+                "  Milk  ",
+                "0.5",
+                QuantityUnit.LITER);
+        var milkB = ingredient(
+                "72000000-0000-0000-0000-000000000002",
+                "Milk",
+                "250",
+                QuantityUnit.MILLILITER);
+        var recipeA = recipe("73000000-0000-0000-0000-000000000001", 2, milkA);
+        var recipeB = recipe("73000000-0000-0000-0000-000000000002", 1, milkB);
+
+        var result = new RecipeShoppingListAggregator().aggregate(
+                List.of(
+                        new RecipeAggregationEntry(ENTRY_A, recipeA, new RecipeServings(4)),
+                        new RecipeAggregationEntry(ENTRY_B, recipeB, new RecipeServings(2))),
+                AGGREGATE_LIST_ID);
+
+        assertThat(result.shoppingList().id()).isEqualTo(AGGREGATE_LIST_ID);
+        assertThat(result.shoppingList().items()).singleElement().satisfies(item -> {
+            assertThat(item.requirement()).isEqualTo(new ShoppingRequirement("Milk"));
+            assertThat(item.quantity())
+                    .isEqualTo(new Quantity(new BigDecimal("1500"), QuantityUnit.MILLILITER));
+            assertThat(result.provenance().get(item.id())).containsExactly(
+                    new RecipeAggregationIngredientRef(
+                            ENTRY_A,
+                            new RecipeIngredientRef(recipeA.id(), milkA.id())),
+                    new RecipeAggregationIngredientRef(
+                            ENTRY_B,
+                            new RecipeIngredientRef(recipeB.id(), milkB.id())));
+        });
+    }
+
+    private static Recipe recipe(String id, int servings, RecipeIngredient... ingredients) {
+        return new Recipe(
+                new RecipeId(UUID.fromString(id)),
+                new RecipeTitle("Test recipe"),
+                new RecipeServings(servings),
+                List.of(ingredients));
+    }
+
+    private static RecipeIngredient ingredient(
+            String id,
+            String requirement,
+            String amount,
+            QuantityUnit unit) {
+        return new RecipeIngredient(
+                new RecipeIngredientId(UUID.fromString(id)),
+                new ShoppingRequirement(requirement),
+                new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregatorTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregatorTest.java
@@ -1,9 +1,11 @@
 package io.github.trueruslan.zakupgotov.recipe;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.trueruslan.zakupgotov.shopping.Quantity;
 import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
 import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
 import java.math.BigDecimal;
@@ -54,6 +56,164 @@ class RecipeShoppingListAggregatorTest {
                             ENTRY_B,
                             new RecipeIngredientRef(recipeB.id(), milkB.id())));
         });
+    }
+
+    @Test
+    void preservesFirstOccurrenceOrderAndKeepsCaseAndUnitDifferencesSeparate() {
+        var recipeA = recipe(
+                "73000000-0000-0000-0000-000000000011",
+                1,
+                ingredient("72000000-0000-0000-0000-000000000011", "Milk", "100", QuantityUnit.MILLILITER),
+                ingredient("72000000-0000-0000-0000-000000000012", "Flour", "100", QuantityUnit.GRAM));
+        var recipeB = recipe(
+                "73000000-0000-0000-0000-000000000012",
+                1,
+                ingredient("72000000-0000-0000-0000-000000000013", "Milk", "200", QuantityUnit.MILLILITER),
+                ingredient("72000000-0000-0000-0000-000000000014", "milk", "50", QuantityUnit.MILLILITER),
+                ingredient("72000000-0000-0000-0000-000000000015", "Eggs", "2", QuantityUnit.PIECE),
+                ingredient("72000000-0000-0000-0000-000000000016", "Eggs", "100", QuantityUnit.GRAM));
+
+        var result = new RecipeShoppingListAggregator().aggregate(
+                List.of(
+                        new RecipeAggregationEntry(ENTRY_A, recipeA, new RecipeServings(1)),
+                        new RecipeAggregationEntry(ENTRY_B, recipeB, new RecipeServings(1))),
+                AGGREGATE_LIST_ID);
+
+        var keys = result.shoppingList().items().stream()
+                .map(item -> item.requirement().text() + ":" + item.quantity().unit())
+                .toList();
+        assertThat(keys).containsExactly(
+                "Milk:MILLILITER",
+                "Flour:GRAM",
+                "milk:MILLILITER",
+                "Eggs:PIECE",
+                "Eggs:GRAM");
+        assertThat(result.shoppingList().items().getFirst().quantity().amount())
+                .isEqualByComparingTo("300");
+    }
+
+    @Test
+    void allowsSameRecipeToAppearTwiceWhenOccurrenceIdsDiffer() {
+        var milk = ingredient(
+                "72000000-0000-0000-0000-000000000021",
+                "Milk",
+                "500",
+                QuantityUnit.MILLILITER);
+        var sharedRecipe = recipe("73000000-0000-0000-0000-000000000021", 1, milk);
+        var sourceRef = new RecipeIngredientRef(sharedRecipe.id(), milk.id());
+
+        var result = new RecipeShoppingListAggregator().aggregate(
+                List.of(
+                        new RecipeAggregationEntry(ENTRY_A, sharedRecipe, new RecipeServings(1)),
+                        new RecipeAggregationEntry(ENTRY_B, sharedRecipe, new RecipeServings(2))),
+                AGGREGATE_LIST_ID);
+
+        var item = result.shoppingList().items().getFirst();
+        assertThat(item.quantity().amount()).isEqualByComparingTo("1500");
+        assertThat(result.provenance().get(item.id())).containsExactly(
+                new RecipeAggregationIngredientRef(ENTRY_A, sourceRef),
+                new RecipeAggregationIngredientRef(ENTRY_B, sourceRef));
+    }
+
+    @Test
+    void rejectsEmptyAggregationEntries() {
+        assertThatThrownBy(() -> new RecipeShoppingListAggregator().aggregate(List.of(), AGGREGATE_LIST_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("entries must not be empty");
+    }
+
+    @Test
+    void rejectsDuplicateAggregationEntryIdentity() {
+        var recipeA = recipe(
+                "73000000-0000-0000-0000-000000000031",
+                1,
+                ingredient("72000000-0000-0000-0000-000000000031", "Milk", "100", QuantityUnit.MILLILITER));
+        var recipeB = recipe(
+                "73000000-0000-0000-0000-000000000032",
+                1,
+                ingredient("72000000-0000-0000-0000-000000000032", "Flour", "100", QuantityUnit.GRAM));
+
+        assertThatThrownBy(() -> new RecipeShoppingListAggregator().aggregate(
+                        List.of(
+                                new RecipeAggregationEntry(ENTRY_A, recipeA, new RecipeServings(1)),
+                                new RecipeAggregationEntry(ENTRY_A, recipeB, new RecipeServings(1))),
+                        AGGREGATE_LIST_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duplicate aggregation entry id");
+    }
+
+    @Test
+    void finalItemIdentityIsStableAcrossAmountsAndServingsButScopedToAggregateList() {
+        var ingredientA = ingredient(
+                "72000000-0000-0000-0000-000000000041",
+                "Milk",
+                "100",
+                QuantityUnit.MILLILITER);
+        var ingredientB = ingredient(
+                "72000000-0000-0000-0000-000000000041",
+                "Milk",
+                "500",
+                QuantityUnit.MILLILITER);
+        var recipeA = recipe("73000000-0000-0000-0000-000000000041", 1, ingredientA);
+        var recipeB = recipe("73000000-0000-0000-0000-000000000041", 1, ingredientB);
+        var aggregator = new RecipeShoppingListAggregator();
+
+        var baseId = aggregator.aggregate(
+                        List.of(new RecipeAggregationEntry(ENTRY_A, recipeA, new RecipeServings(1))),
+                        AGGREGATE_LIST_ID)
+                .shoppingList().items().getFirst().id();
+        var changedAmountAndServingsId = aggregator.aggregate(
+                        List.of(new RecipeAggregationEntry(ENTRY_A, recipeB, new RecipeServings(3))),
+                        AGGREGATE_LIST_ID)
+                .shoppingList().items().getFirst().id();
+        var otherListId = aggregator.aggregate(
+                        List.of(new RecipeAggregationEntry(ENTRY_A, recipeA, new RecipeServings(1))),
+                        new ShoppingListId(UUID.fromString("70000000-0000-0000-0000-000000000002")))
+                .shoppingList().items().getFirst().id();
+
+        assertThat(changedAmountAndServingsId).isEqualTo(baseId);
+        assertThat(otherListId).isNotEqualTo(baseId);
+    }
+
+    @Test
+    void failsClosedWhenDifferentAggregateKeysDeriveSameItemIdentity() {
+        var fixedId = new ShoppingItemId(UUID.fromString("74000000-0000-0000-0000-000000000001"));
+        var aggregator = new RecipeShoppingListAggregator(
+                new RecipeShoppingListConverter(),
+                (listId, requirement, unit) -> fixedId);
+        var recipe = recipe(
+                "73000000-0000-0000-0000-000000000051",
+                1,
+                ingredient("72000000-0000-0000-0000-000000000051", "Milk", "100", QuantityUnit.MILLILITER),
+                ingredient("72000000-0000-0000-0000-000000000052", "Flour", "100", QuantityUnit.GRAM));
+
+        assertThatThrownBy(() -> aggregator.aggregate(
+                        List.of(new RecipeAggregationEntry(ENTRY_A, recipe, new RecipeServings(1))),
+                        AGGREGATE_LIST_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("generated shopping item id collision");
+    }
+
+    @Test
+    void exposesAggregateProvenanceAsDeeplyImmutableOutput() {
+        var milk = ingredient(
+                "72000000-0000-0000-0000-000000000061",
+                "Milk",
+                "100",
+                QuantityUnit.MILLILITER);
+        var recipe = recipe("73000000-0000-0000-0000-000000000061", 1, milk);
+        var result = new RecipeShoppingListAggregator().aggregate(
+                List.of(new RecipeAggregationEntry(ENTRY_A, recipe, new RecipeServings(1))),
+                AGGREGATE_LIST_ID);
+        var itemId = result.shoppingList().items().getFirst().id();
+
+        assertThatThrownBy(() -> result.provenance().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.provenance().get(itemId).add(
+                        new RecipeAggregationIngredientRef(
+                                ENTRY_B,
+                                new RecipeIngredientRef(recipe.id(), milk.id()))))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     private static Recipe recipe(String id, int servings, RecipeIngredient... ingredients) {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java
@@ -130,6 +130,17 @@ class RecipeShoppingListConverterTest {
     }
 
     @Test
+    void preservesAcceptedLiteralShoppingItemIdentityFixture() {
+        var recipe = recipe(1, ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Flour", "500", QuantityUnit.GRAM));
+
+        var itemId = converter.convert(recipe, new RecipeServings(1), LIST_ID)
+                .shoppingList().items().getFirst().id();
+
+        assertThat(itemId.value())
+                .isEqualTo(UUID.fromString("3d737f10-a263-39b3-b90a-fe7868c035b9"));
+    }
+
+    @Test
     void recordsCompleteOrderedProvenanceForMergedAndNonMergedIngredients() {
         var milkFirst = ingredient("81d23cd8-cd6f-4692-8a0f-a49e05c779cc", "Milk", "500", QuantityUnit.MILLILITER);
         var flour = ingredient("11388874-5a42-4863-b5cf-3c210fa70ddd", "Flour", "200", QuantityUnit.GRAM);

--- a/docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md
+++ b/docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md
@@ -1,0 +1,143 @@
+# M2.5 Deterministic Multi-Recipe Aggregation — Shipping Evidence
+
+Date: 2026-08-14  
+Issue: #106  
+PR: #107  
+Status: **IMPLEMENTED / TESTED / SHIPPING — acceptance pending**
+
+Authoritative design: `docs/superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md`  
+Implementation plan: `docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md`
+
+## Delivered scope
+
+M2.5 delivers the final pure-domain Recipe aggregation foundation required before M3 Weekly Planning:
+
+`ordered Recipe occurrences + target servings → accepted RecipeShoppingListConverter per occurrence → one canonical aggregate ShoppingList + occurrence-aware provenance`
+
+Delivered production behavior:
+
+- `RecipeAggregationEntryId` distinguishes one occurrence of a Recipe from the Recipe identity itself;
+- `RecipeAggregationEntry` binds one occurrence ID, accepted Recipe and target servings;
+- the same Recipe may appear multiple times under distinct occurrence IDs;
+- `RecipeAggregationIngredientRef` preserves occurrence ID plus accepted `RecipeIngredientRef` lineage;
+- `RecipeShoppingListAggregator` reuses the accepted `RecipeShoppingListConverter` per occurrence rather than duplicating serving scaling or source-unit canonicalization;
+- each intermediate converter ShoppingListId is derived deterministically from aggregate list ID + occurrence ID and remains internal;
+- aggregate merge key remains exact normalized ShoppingRequirement + canonical QuantityUnit;
+- already-canonical scaled amounts are summed with exact `BigDecimal.add`;
+- first compatible occurrence controls output ShoppingItem ordering;
+- final aggregate ShoppingItem IDs use the same accepted list+requirement+canonical-unit derivation as M2.1 and remain independent of amount/target servings;
+- aggregate provenance preserves entry order and accepted converter provenance order;
+- empty entry sets, null entries, duplicate occurrence IDs, missing converted provenance and generated final-ID collisions fail closed;
+- provenance map and nested lineage lists are defensive, ordered and immutable;
+- no HTTP/OpenAPI/generated-client/web/persistence/planner/provider/retailer behavior was introduced.
+
+## Shared-semantics compatibility proof
+
+M2.5 needed the exact M2.1 merge-key and ShoppingItem-ID semantics without copying them.
+
+Before refactoring, a literal characterization fixture locked the accepted identity:
+
+- ShoppingListId `4ea3a925-1d2a-4246-a970-7a82ffc96402`;
+- requirement `Flour`;
+- canonical unit `GRAM`;
+- expected ShoppingItem UUID `3d737f10-a263-39b3-b90a-fe7868c035b9`.
+
+The characterization passed on the pre-refactor implementation.
+
+Package-private shared helpers were then extracted:
+
+- `RecipeShoppingMergeKey`;
+- `RecipeShoppingItemIds.derive(...)`.
+
+The accepted UUID payload remains byte-for-byte:
+
+```text
+shoppingListId.value() + "\n" + requirement.text() + "\n" + unit.name()
+```
+
+After extraction, full API verification and the literal UUID fixture remained green. Existing M2.1 item identities therefore did not drift.
+
+## Explicit TDD evidence
+
+### Aggregation behavior
+
+RED head `d337ec12a739e0c9cc20be8233a69de435cb72ee`:
+
+- new `RecipeShoppingListAggregatorTest` failed compilation on the intentionally absent aggregation production types.
+
+GREEN head `e447e8bfdbcc55ddef20f4d9445de1c5e4080474`:
+
+- full API verification SUCCESS;
+- two different Recipe occurrences using `0.5 LITER` and `250 MILLILITER`, independently scaled by the accepted converter, aggregate to one exact `Milk 1500 MILLILITER` item;
+- provenance remains ordered `entry A → ingredient A`, then `entry B → ingredient B`.
+
+### Hardening
+
+RED head `3c377bc331c4a2a2bb8c0c8af57da2d62536a31c`:
+
+- `RecipeShoppingListAggregatorTest`: 8 tests, exactly 2 expected failures;
+- `rejectsEmptyAggregationEntries` failed because empty input was still accepted;
+- `rejectsDuplicateAggregationEntryIdentity` failed because duplicate occurrence ID was still accepted;
+- all six other new aggregation tests passed;
+- existing `RecipeShoppingListConverterTest`: 10 tests PASS;
+- overall Maven failure was exactly 2 failures / 0 errors in the intended hardening cases.
+
+GREEN head `42b0a7c22141f770d58e9bbdca35a26f62b1d2ae`:
+
+- only the two missing fail-closed checks were added;
+- full API CI / Maven verification SUCCESS.
+
+The green suite covers:
+
+- compatible cross-Recipe merge with exact canonical sum;
+- strict non-merge for case-different requirements and quantity-unit differences;
+- first compatible occurrence ordering;
+- repeated same Recipe under two different occurrence IDs;
+- duplicate occurrence rejection;
+- empty input rejection;
+- stable final item IDs across amount and target-serving changes;
+- different aggregate ShoppingListId → different final item ID;
+- injected final-ID collision fail-closed behavior;
+- deep immutable aggregate provenance;
+- accepted single-Recipe UUID compatibility.
+
+## Architecture / scope evidence
+
+All new production classes live in `io.github.trueruslan.zakupgotov.recipe` and depend only on accepted Recipe types, neutral Shopping value/aggregate types and JDK classes.
+
+No M2.5 production code was added to:
+
+- `shopping`;
+- preview/application HTTP packages;
+- provider/retailer/matching/basket/comparison;
+- database/persistence;
+- OpenAPI/generated client;
+- web/browser code.
+
+Existing architecture verification continues to enforce Shopping Core independence from Recipe code. Ordinary CI remains retailer-network-free.
+
+## Repository-wide code checkpoint
+
+On implementation/hardening GREEN head `42b0a7c22141f770d58e9bbdca35a26f62b1d2ae`:
+
+- API CI — SUCCESS;
+- Contract CI — SUCCESS;
+- CodeQL — SUCCESS;
+- Dependency Review — SUCCESS;
+- Container Security CI — SUCCESS;
+- Retailer Bridge CI — SUCCESS;
+- Release Contract CI — SUCCESS;
+- Release Bundle CI — SUCCESS;
+- Web CI / E2E was still completing when this shipping record was authored.
+
+This is implementation evidence, not acceptance evidence. The documentation commit creates a new exact PR head and all normal workflow groups must run again before review/merge.
+
+## Remaining acceptance gates
+
+M2.5 is **not ACCEPTED** until:
+
+1. all 9 normal PR workflow groups succeed on the exact final head;
+2. read-only review reports no unresolved P0/P1/P2 finding and review threads are clear;
+3. PR #107 is marked ready and squash-merged using expected-head protection;
+4. all normal push-triggered workflows succeed on the merged `main` SHA;
+5. only then are #106, PROJECT_STATE, ROADMAP and CHANGELOG synchronized as COMPLETE / ACCEPTED and the next milestone becomes M3 Weekly Planning.

--- a/docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md
+++ b/docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md
@@ -1,0 +1,186 @@
+# M2.5 Deterministic Multi-Recipe Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggregate several ordered Recipe occurrences into one deterministic canonical ShoppingList with occurrence-aware Recipe/ingredient provenance for M3 Weekly Planning.
+
+**Architecture:** Keep all behavior inside the existing `recipe` domain package. Reuse `RecipeShoppingListConverter` per aggregation entry, extract only the accepted merge-key/item-ID semantics into package-private shared helpers, and build one final ShoppingList whose provenance adds an aggregation-entry identity around the existing `RecipeIngredientRef`.
+
+**Tech Stack:** Java 25, JUnit 5, AssertJ, Spring Modulith verification, Maven/Testcontainers repository baseline.
+
+## Global Constraints
+
+- M2.5 is pure domain/core: no HTTP/OpenAPI/generated client/web/persistence/provider/retailer changes.
+- `shopping` must remain independent from `recipe`.
+- Serving scaling and source unit canonicalization remain owned by accepted `RecipeShoppingListConverter`.
+- Automatic merge key remains exact normalized ShoppingRequirement + canonical QuantityUnit only.
+- Repeated RecipeId is allowed under distinct aggregation-entry IDs.
+- Duplicate aggregation-entry ID fails closed.
+- Final ShoppingItem identity remains aggregate-list + requirement + canonical-unit scoped and independent of amount/servings.
+- Provenance remains outside neutral Shopping Core types and is deeply immutable.
+
+---
+
+### Task 1: Characterize and share accepted ShoppingItem identity semantics
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingMergeKey.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingItemIds.java`
+- Modify: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverter.java`
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListConverterTest.java`
+
+**Interfaces:**
+- `RecipeShoppingMergeKey(ShoppingRequirement requirement, QuantityUnit unit)` package-private record.
+- `RecipeShoppingItemIds.derive(ShoppingListId, ShoppingRequirement, QuantityUnit)` package-private deterministic helper.
+- Existing `RecipeShoppingItemIdDeriver` remains the test seam.
+
+- [ ] **Step 1: Add a literal regression fixture before refactoring**
+
+Add a converter test with fixed ShoppingListId/requirement/unit and assert the exact currently produced UUID, not merely equality across two executions.
+
+- [ ] **Step 2: Run focused converter tests and preserve GREEN characterization**
+
+This is a refactor characterization gate: test must pass against current production code before extraction.
+
+- [ ] **Step 3: Extract shared key and ID helper without changing payload bytes**
+
+Move the exact existing payload:
+
+```text
+shoppingListId.value() + "\n" + requirement.text() + "\n" + unit.name()
+```
+
+into `RecipeShoppingItemIds.derive`; replace private converter `MergeKey` with `RecipeShoppingMergeKey`.
+
+- [ ] **Step 4: Re-run converter tests**
+
+Require the literal UUID fixture and all existing M2.1 converter behavior to remain green.
+
+### Task 2: Define aggregation contract with RED tests
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntryId.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationEntry.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeAggregationIngredientRef.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregation.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregator.java`
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeShoppingListAggregatorTest.java`
+
+**Interfaces:**
+
+```java
+public record RecipeAggregationEntryId(UUID value) {}
+public record RecipeAggregationEntry(
+    RecipeAggregationEntryId id,
+    Recipe recipe,
+    RecipeServings targetServings) {}
+public record RecipeAggregationIngredientRef(
+    RecipeAggregationEntryId entryId,
+    RecipeIngredientRef ingredientRef) {}
+public record RecipeShoppingListAggregation(
+    ShoppingList shoppingList,
+    Map<ShoppingItemId, List<RecipeAggregationIngredientRef>> provenance) {}
+public final class RecipeShoppingListAggregator {
+    public RecipeShoppingListAggregation aggregate(
+        List<RecipeAggregationEntry> entries,
+        ShoppingListId aggregateShoppingListId);
+}
+```
+
+- [ ] **Step 1: Add RED test for compatible cross-recipe merge**
+
+Two different recipes contribute normalized `milk` quantities in LITER/MILLILITER. After accepted per-recipe canonicalization/scaling, require one aggregate `milk` item with exact summed MILLILITER quantity and provenance ordered by entry.
+
+- [ ] **Step 2: Run focused test and preserve RED**
+
+Expected failure: aggregation production types/service do not exist.
+
+- [ ] **Step 3: Add RED coverage for ordering and non-merge**
+
+Require first compatible occurrence order across entries; case-different requirements and incompatible units remain separate.
+
+- [ ] **Step 4: Add repeated-Recipe occurrence RED**
+
+Use the same Recipe object/RecipeId twice with distinct `RecipeAggregationEntryId` values and different target servings. Require aggregation success and two distinct provenance refs for the same underlying RecipeIngredientRef.
+
+- [ ] **Step 5: Implement minimal aggregation value types and service**
+
+For every entry derive an internal conversion ShoppingListId via UTF-8 `UUID.nameUUIDFromBytes` over namespace line + aggregate list UUID + entry UUID, invoke accepted converter, accumulate by `RecipeShoppingMergeKey`, sum canonical quantities, derive final item IDs with `RecipeShoppingItemIds.derive`, and wrap lineage with the entry ID.
+
+- [ ] **Step 6: Run focused aggregation + converter tests GREEN**
+
+No other production package changes are allowed in this task.
+
+### Task 3: Fail-closed, identity and immutability hardening
+
+**Files:**
+- Modify: `RecipeShoppingListAggregator.java`
+- Modify: `RecipeShoppingListAggregation.java`
+- Modify: `RecipeShoppingListAggregatorTest.java`
+- Create/modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/recipe/RecipeArchitectureTest.java` only if an existing architecture test does not already cover shopping→recipe independence.
+
+- [ ] **Step 1: RED duplicate-entry and null/empty inputs**
+
+Require null aggregate ID, null/empty entry list, null entry and duplicate entry IDs to reject instead of skip.
+
+- [ ] **Step 2: RED identity stability**
+
+For a fixed aggregate list ID + merge key, change ingredient amount/target servings and require the final ShoppingItem ID to remain identical. Change aggregate list ID and require a different final item ID.
+
+- [ ] **Step 3: RED collision path**
+
+Use a package-private aggregator constructor with injected `RecipeShoppingItemIdDeriver` returning one fixed ID for two distinct merge keys. Require `IllegalStateException("generated shopping item id collision")`.
+
+- [ ] **Step 4: RED deep immutability**
+
+Require attempts to mutate the returned provenance map and nested lineage list to fail; changes to caller-owned input lists after aggregation cannot change output.
+
+- [ ] **Step 5: Implement minimal fail-closed checks / defensive copies**
+
+Do not add recovery, logging, fallback or fuzzy reconciliation.
+
+- [ ] **Step 6: Architecture regression**
+
+Require `shopping` production classes to remain dependency-free from `recipe`; M2.5 must not add preview/provider/retailer/matching/basket/comparison/database dependencies.
+
+- [ ] **Step 7: Focused GREEN**
+
+Run all Recipe tests and architecture tests.
+
+### Task 4: Full verification and shipping
+
+**Files:**
+- Update: `docs/PROJECT_STATE.md` to `M2.5 IMPLEMENTED / TESTED / SHIPPING` only before merge.
+- Update: `docs/ROADMAP.md` conservatively; do not mark M2.5 accepted before post-merge proof.
+- Update: `CHANGELOG.md`.
+- Create: `docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`.
+
+- [ ] **Step 1: Full backend verification**
+
+Run repository API/Maven verify through CI, including Modulith and existing PostgreSQL/Testcontainers baseline.
+
+- [ ] **Step 2: Contract/web regression**
+
+Require no OpenAPI/generated-client diff and existing Contract/Web/Playwright workflows green.
+
+- [ ] **Step 3: Exact-head CI**
+
+All normal PR workflow groups must succeed on the same head: API, Contract, Web/E2E, CodeQL, Dependency Review, Container Security, Retailer Bridge, Release Contract and Release Bundle.
+
+- [ ] **Step 4: Read-only review**
+
+Review merge semantics, repeated-Recipe lineage, ID stability, helper extraction compatibility, defensive immutability, dependency direction and scope containment. Block P0/P1/P2.
+
+- [ ] **Step 5: Squash merge with expected-head protection**
+
+Only after review threads are clear and exact-head CI remains green.
+
+- [ ] **Step 6: Post-merge acceptance**
+
+Require all normal push workflows on the merged main SHA to succeed. Only then close #106 as COMPLETE / ACCEPTED and synchronize canonical state/roadmap/changelog. The next milestone becomes M3 Weekly Planning.
+
+## Self-review
+
+- Spec coverage: repeated Recipe occurrence, exact merge semantics, ordering, stable IDs, shared identity helper, provenance, fail-closed validation, architecture and acceptance gates are all mapped.
+- Scope containment: no API/UI/persistence/planner/AI work is included.
+- Type consistency: occurrence-aware provenance wraps the existing accepted `RecipeIngredientRef` rather than duplicating Recipe/ingredient identity fields.

--- a/docs/superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md
@@ -1,0 +1,234 @@
+# M2.5 Deterministic Multi-Recipe Aggregation — Design
+
+Date: 2026-08-14  
+Issue: #106  
+Baseline: `main=3c8483a71124eb9acf94f956a14d9db635286a05`  
+Status: **AUTHORITATIVE DESIGN — approved for implementation by delegated development authority**
+
+## Goal
+
+Provide the deterministic Recipe-domain foundation required by M3 Weekly Planning:
+
+`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregated ShoppingList + occurrence-aware provenance`
+
+M2.5 is deliberately a pure domain/core slice. It does not add an HTTP endpoint, generated client, UI, persistence, weekly-plan aggregate, pantry semantics, retailer traffic or AI/fuzzy interpretation.
+
+## Why aggregation entry identity is required
+
+`RecipeId` identifies a Recipe, not one occurrence of that Recipe in a future plan.
+
+A weekly plan may intentionally contain the same Recipe twice, potentially with different target servings. Existing `RecipeIngredientRef(RecipeId, RecipeIngredientId)` cannot distinguish those occurrences.
+
+Introduce:
+
+```text
+RecipeAggregationEntryId
+RecipeAggregationEntry(
+  RecipeAggregationEntryId id,
+  Recipe recipe,
+  RecipeServings targetServings
+)
+```
+
+Entry IDs must be unique inside one aggregation request. Repeating the same `RecipeId` under different entry IDs is valid.
+
+## Output
+
+Introduce:
+
+```text
+RecipeAggregationIngredientRef(
+  RecipeAggregationEntryId entryId,
+  RecipeIngredientRef ingredientRef
+)
+
+RecipeShoppingListAggregation(
+  ShoppingList shoppingList,
+  Map<ShoppingItemId, List<RecipeAggregationIngredientRef>> provenance
+)
+```
+
+The provenance map and every nested list are deeply immutable and ordered.
+
+Every output ShoppingItem must have at least one provenance ref. Every provenance ref must resolve to the Recipe/ingredient of the corresponding aggregation entry.
+
+## Aggregation algorithm
+
+`RecipeShoppingListAggregator.aggregate(entries, aggregateShoppingListId)`:
+
+1. Reject null aggregate list ID, null/empty entries, null entries and duplicate `RecipeAggregationEntryId` values.
+2. Preserve caller entry order.
+3. For each entry, derive a deterministic internal conversion-list ID from:
+   `aggregateShoppingListId + entryId`.
+4. Call the accepted `RecipeShoppingListConverter` with that entry's Recipe, target servings and derived internal list ID.
+5. Traverse converted ShoppingItems in accepted converter order.
+6. Merge only by the same exact key as M2.1:
+   normalized `ShoppingRequirement` + canonical `QuantityUnit`.
+7. Sum already-scaled canonical amounts with exact `BigDecimal.add`.
+8. Preserve first compatible occurrence order across entry order, then converted-item order.
+9. Convert each accepted `RecipeIngredientRef` into `RecipeAggregationIngredientRef(entryId, ingredientRef)` and append it in the same order.
+10. Create one output `ShoppingItem` per aggregate group using the caller-supplied aggregate ShoppingListId.
+11. Derive its ID from aggregate list ID + requirement + canonical unit using the exact same accepted algorithm as M2.1.
+12. Fail closed if two different merge keys derive the same ShoppingItem ID.
+
+The aggregator must not recompute serving ratios, canonicalize source ingredient units itself or reinterpret Recipe ingredient meaning.
+
+## Shared internal seams
+
+M2.1 currently keeps the merge-key and default ShoppingItem ID algorithm private inside `RecipeShoppingListConverter`. M2.5 needs identical semantics and must not copy them.
+
+Extract package-private helpers inside `io.github.trueruslan.zakupgotov.recipe`:
+
+```text
+RecipeShoppingMergeKey(ShoppingRequirement requirement, QuantityUnit unit)
+RecipeShoppingItemIds.derive(ShoppingListId, ShoppingRequirement, QuantityUnit)
+```
+
+The converter and aggregator both use these helpers.
+
+This is a refactor only: existing single-recipe generated UUIDs must remain byte-for-byte identical for the same `ShoppingListId + requirement + unit` input.
+
+A package-private aggregator constructor may accept a `RecipeShoppingItemIdDeriver` to preserve deterministic collision testing. Production/default construction uses `RecipeShoppingItemIds::derive`.
+
+## Internal per-entry conversion-list identity
+
+The accepted converter requires a ShoppingListId even though its intermediate ShoppingItem IDs are not exposed by the aggregation result.
+
+Derive that internal ID deterministically with a distinct namespace payload containing:
+
+```text
+recipe-aggregation-entry-list
+aggregateShoppingListId
+entryId
+```
+
+using UTF-8 and `UUID.nameUUIDFromBytes`.
+
+Properties:
+
+- no randomness;
+- no persistence;
+- stable for one aggregate list + entry occurrence;
+- distinct from the final aggregate ShoppingListId;
+- not part of public/product output;
+- changing target servings does not change the intermediate list identity.
+
+## Merge semantics
+
+Automatic merge remains intentionally strict:
+
+- same normalized requirement object/value;
+- same canonical quantity unit;
+- no case folding beyond existing ShoppingRequirement normalization;
+- no synonyms;
+- no categories;
+- no fuzzy matching;
+- no embeddings/LLM;
+- no mass/volume/count interchange.
+
+Examples:
+
+- Recipe A `milk 500 ml` + Recipe B `milk 1 l` after accepted canonicalization → same requirement + `MILLILITER`, merge.
+- `Milk` and `milk` remain separate if accepted ShoppingRequirement semantics consider them different.
+- `2 PIECE onion` and `200 GRAM onion` remain separate.
+
+## Identity semantics
+
+Final aggregate ShoppingItem identity is list-scoped and merge-key-scoped exactly like M2.1.
+
+For a fixed aggregate ShoppingListId + normalized requirement + canonical unit:
+
+- amount changes do not change item ID;
+- target-serving changes do not change item ID;
+- adding/removing other unrelated recipes does not change that item's ID;
+- source entry order does not change the ID, although output list ordering remains first-occurrence based.
+
+Changing aggregate ShoppingListId changes derived ShoppingItem IDs.
+
+## Provenance semantics
+
+For each final aggregate item, provenance order is:
+
+1. aggregation entry order;
+2. accepted per-recipe converter provenance order within each entry.
+
+Repeated Recipe example:
+
+```text
+entry-A → Recipe R → ingredient I
+entry-B → Recipe R → ingredient I
+```
+
+Both refs remain present and distinct because `entry-A != entry-B`, even though the underlying Recipe/ingredient identity is the same.
+
+No Recipe/provenance field is added to neutral Shopping Core types.
+
+## Validation and fail-closed invariants
+
+Reject:
+
+- null aggregate ShoppingListId;
+- null entries list;
+- empty entries list;
+- null entry;
+- null entry ID / Recipe / target servings through value-type constructors;
+- duplicate entry IDs;
+- null derived internal/final item IDs;
+- generated final ShoppingItem ID collision across different merge keys;
+- impossible missing/empty provenance from an accepted conversion if encountered.
+
+Do not silently skip invalid entries or source items.
+
+## TDD requirements
+
+Explicit RED→GREEN checkpoints must cover:
+
+1. two compatible recipes merge with exact summed canonical quantity;
+2. incompatible requirement/unit stays separate;
+3. first compatible occurrence controls aggregate item order;
+4. same Recipe included twice under different entry IDs is valid and provenance distinguishes occurrences;
+5. duplicate entry IDs fail closed;
+6. final item ID is stable across amount and target-serving changes;
+7. changing aggregate list ID changes final item ID;
+8. existing single-recipe item-ID fixture remains unchanged after helper extraction;
+9. provenance map/lists are deeply immutable;
+10. null/empty inputs fail closed;
+11. injected item-ID collision fails closed;
+12. Shopping Core remains independent from Recipe aggregation.
+
+## Architecture
+
+All new production types live in the existing `recipe` package because this is Recipe composition logic over accepted Shopping value objects.
+
+Allowed dependencies remain:
+
+`recipe → shopping`
+
+Forbidden:
+
+`shopping → recipe`
+
+M2.5 introduces no dependency on preview/application HTTP adapters, provider, retailer, matching, basket, comparison, database or web code.
+
+## Verification / acceptance
+
+Before merge:
+
+- focused Recipe aggregation tests green after explicit RED evidence;
+- existing `RecipeShoppingListConverterTest` remains green and proves identity compatibility;
+- full Maven `verify` including Modulith/Testcontainers baseline;
+- no OpenAPI/generated-client diff;
+- existing Web/Playwright regression remains green;
+- CodeQL, Dependency Review, Container Security, Retailer Bridge, Release Contract and Release Bundle green;
+- read-only review with no unresolved P0/P1/P2;
+- exact PR head green across all normal workflow groups.
+
+Squash merge with expected-head protection. M2.5 becomes COMPLETE / ACCEPTED only after all normal push workflows succeed on the merged main SHA and canonical docs are synchronized.
+
+## Non-goals
+
+No public API, TypeScript client, Recipe UI changes, weekly-plan domain/UI, persistence, saved recipes, pantry/exclusions, multi-user state, exact-address behavior, retailer/provider changes, nutrition, arbitrary recipe import, fuzzy/synonym/semantic/AI merging or optimization/ranking changes.
+
+## Next milestone
+
+After M2.5 acceptance, deterministic M2 foundations are sufficient to begin **M3 Weekly Planning**. M3 may introduce planner-specific occurrence ownership, pantry/exclusions, API/UI and evidence-driven persistence without changing the accepted multi-recipe merge/provenance semantics.


### PR DESCRIPTION
## Summary

Implements #106: deterministic multi-recipe ShoppingList aggregation as the final pure-domain M2 foundation for M3 Weekly Planning.

Delivered:
- occurrence-aware `RecipeAggregationEntryId` separate from RecipeId;
- same Recipe may appear multiple times under distinct occurrence IDs;
- accepted `RecipeShoppingListConverter` reused per occurrence;
- exact normalized requirement + canonical unit merge only;
- exact canonical quantity summing and first-occurrence ordering;
- aggregate ShoppingItem IDs reuse accepted M2.1 list+requirement+unit derivation;
- provenance = aggregation occurrence + accepted RecipeIngredientRef;
- fail-closed empty/duplicate-entry/collision/missing-provenance behavior;
- deeply immutable ordered provenance;
- no API/OpenAPI/web/persistence/planner/provider/retailer scope.

## TDD / compatibility evidence

- Pre-refactor literal M2.1 UUID characterization locked `3d737f10-a263-39b3-b90a-fe7868c035b9` for the accepted list/requirement/unit fixture and remained green after shared-helper extraction.
- Aggregation RED `d337ec12…`: production aggregation types intentionally absent.
- Aggregation GREEN `e447e8bf…`: cross-Recipe canonical merge/provenance passed full API verification.
- Hardening RED `3c377bc3…`: 8 aggregation tests, exactly 2 intended failures (empty entries and duplicate occurrence ID), 0 errors; all other new invariants and all 10 converter tests passed.
- Hardening GREEN `42b0a7c…`: only those two fail-closed checks added; full API CI SUCCESS.

Shipping evidence: `docs/superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`.

## Current checkpoint

**IMPLEMENTED / TESTED / SHIPPING — acceptance pending.**

The shipping-doc commit creates a new exact head that must pass all 9 normal PR workflow groups. Then read-only review must report no unresolved P0/P1/P2, review threads must be clear, and the PR must be squash-merged with expected-head protection. M2.5/#106 becomes COMPLETE / ACCEPTED only after all normal post-merge `main` workflows succeed.