### PR TITLE
docs(m2): finalize multi-recipe aggregation acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Responsive desktop/mobile Recipe acceptance coverage for serving scaling, generated shopping output, unavailable API state, visible keyboard focus, no horizontal overflow and continued manual-list comparison regression.
 - Deterministic E2E-only `/api/v1/recipe-comparison-previews` fixture path; production browser code contains no retailer fixture evidence and browser acceptance makes no live retailer request.
 - M2.4 design, implementation plan, shipping evidence and acceptance decision documenting explicit RED→GREEN checkpoints, reviewed head `fb069d64b96f0d989951e67fd62b793277453024`, squash merge `aba20c9cee263a683c0d4383ad840d7415851861` and 8/8 successful post-merge `main` workflows.
+- M2.5 `RecipeAggregationEntryId` and `RecipeAggregationEntry` distinguish one Recipe occurrence from `RecipeId`, allowing the same Recipe to participate multiple times with independent target servings.
+- Deterministic `RecipeShoppingListAggregator` reuses the accepted per-Recipe converter, derives internal occurrence-list identities, merges only exact normalized requirement + canonical unit and sums already-canonical quantities with exact decimal addition.
+- Occurrence-aware `RecipeAggregationIngredientRef` lineage preserves aggregation-entry identity plus the accepted `RecipeIngredientRef`, so repeated inclusion of the same Recipe remains unambiguous.
+- Aggregate ShoppingItem order follows first compatible occurrence, while final ShoppingItem identity reuses the accepted list+requirement+canonical-unit derivation and remains independent of amount/target servings.
+- Shared package-private `RecipeShoppingMergeKey` and `RecipeShoppingItemIds` seams remove algorithm duplication while preserving the accepted M2.1 identity payload byte-for-byte.
+- Literal compatibility fixture locks accepted single-Recipe ShoppingItem UUID `3d737f10-a263-39b3-b90a-fe7868c035b9` across the shared-helper extraction.
+- Deep-immutable ordered multi-Recipe provenance plus fail-closed empty input, duplicate occurrence identity, missing provenance and generated-ID collision behavior.
+- M2.5 design, implementation plan, shipping evidence and acceptance decision documenting explicit RED→GREEN checkpoints, reviewed head `a6e1095696ebfd67fafe7675a37b125ae02b3170`, squash merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0` and 8/8 successful post-merge `main` workflows.
 
 #### Product and shopping core
 
@@ -84,18 +92,20 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 
 ### Changed
 
-- Project phase advanced from M0 Product & Integration Discovery to M1 Shopping Core and, after final acceptance, to **M2 Recipes**.
+- Project phase advanced from M0 Product & Integration Discovery to M1 Shopping Core, then to M2 Recipes, and after accepted M2.5 to **M3 Weekly Planning**.
 - M1 Shopping Core is **COMPLETE / ACCEPTED** on the post-merge pre-acquisition-gate baseline `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 - The M1→M2 decision is **GO for deterministic product/core development**; it does not claim every retailer is production-ready.
 - M2.1 `Recipe → explicit ingredients → canonical quantities → ShoppingList` is **COMPLETE / ACCEPTED** after squash merge `423eb14f7c565bbe264257a92df89a6b42d0d158` and 8/8 successful post-merge `main` workflows.
 - M2.2 stateless Recipe application/API boundary is **COMPLETE / ACCEPTED** after final reviewed head `318a48c569d0d001a4c27b5792e1681f7884e518`, squash merge `8f0c1d8d31cfc1673656780a7989512d38788aff`, issue #96 closure and 8/8 successful post-merge `main` workflows.
 - M2.3 composed Recipe → Comparison boundary is **COMPLETE / ACCEPTED** after final reviewed head `b6575f03b668f8bbaacd5b2897c4fb9301d94cdf`, squash merge `15a086d135f40277c655b39549c3e7a04c2e914e`, issue #100 closure and 8/8 successful post-merge `main` workflows.
 - M2.4 responsive Recipe UI is **COMPLETE / ACCEPTED** after final reviewed head `fb069d64b96f0d989951e67fd62b793277453024`, squash merge `aba20c9cee263a683c0d4383ad840d7415851861`, issue #103 closure and 8/8 successful post-merge `main` workflows.
+- M2.5 deterministic multi-Recipe aggregation is **COMPLETE / ACCEPTED** after final reviewed head `a6e1095696ebfd67fafe7675a37b125ae02b3170`, squash merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`, issue #106 closure and 8/8 successful post-merge `main` workflows.
+- M2 Recipes is **COMPLETE / ACCEPTED**; the deterministic roadmap now advances to **M3 Weekly Planning**, beginning with planner-specific domain/application semantics over accepted M2.5 aggregation.
 - Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
 - Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`; M2.2 projects that provenance publicly as self-contained source ingredient IDs instead of modifying Shopping Core types.
-- The Recipe lifecycle remains stateless for the current hypothesis-testing phase; persistence stays deferred until reusable saved recipes or weekly plans become a demonstrated product requirement.
-- Recipe → Comparison has an accepted primary product boundary at `/api/v1/recipe-comparison-previews`; M2.4 now consumes it directly as the primary Recipe-first browser journey.
-- After M2.4 acceptance, the next deterministic Recipe slice is **M2.5 multi-recipe aggregation** required by M3 Weekly Planning; persistence and AI ingestion remain separate decisions.
+- Recipe lifecycle and the first Weekly Planning direction remain stateless by default; persistence stays deferred until reusable saved plans/history demonstrate product value.
+- Recipe → Comparison has an accepted primary product boundary at `/api/v1/recipe-comparison-previews`; M2.4 consumes it directly as the primary Recipe-first browser journey.
+- Multi-Recipe aggregation distinguishes Recipe identity from occurrence identity; repeated Recipe use is valid only through distinct occurrence IDs and does not weaken accepted exact merge semantics.
 - Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
 - `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.
@@ -123,6 +133,9 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Recipe comparison wrapper rejects unknown/malformed JSON with a sanitized problem instead of exposing binding internals.
 - Recipe comparison composition fails closed if generated shopping items and returned comparison items drift in cardinality, identity/order, normalized requirement or canonical quantity.
 - Recipe UI ingredient row keys are deterministic local integers instead of random UUIDs so server render/hydration does not depend on nondeterministic initial IDs.
+- Shared Recipe ShoppingItem-ID extraction preserves the accepted literal single-Recipe UUID fixture instead of silently changing historical IDs.
+- Multi-Recipe aggregation rejects an empty occurrence set and duplicate aggregation occurrence IDs instead of producing an empty/ambiguous aggregate.
+- Multi-Recipe aggregation rejects generated final ShoppingItem-ID collisions across different merge keys and missing/empty converted provenance instead of silently overwriting lineage.
 - Provider offer validation rejects provenance/context mismatches before comparison logic.
 - Precise addresses are excluded from default string representations and provider routing.
 - Snapshot freshness rejects provider timestamps after observation time.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -8,15 +8,16 @@ Updated: 2026-08-14
 
 Repository: `True-Ruslan/zakup-gotov`  
 Visibility: Public  
-Current phase: **M2 — Recipes**  
+Current phase: **M3 — Weekly Planning**  
 M0 status: **technical discovery COMPLETE**  
 M1 status: **Shopping Core COMPLETE / ACCEPTED**  
-M1→M2 decision: **GO** — [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md)  
+M2 status: **Recipes COMPLETE / ACCEPTED**  
 M2.1 status: **Recipe domain + Recipe → ShoppingList COMPLETE / ACCEPTED (#94 / #93)**  
 M2.2 status: **Recipe application/API boundary COMPLETE / ACCEPTED (#97 / #96)**  
 M2.3 status: **Recipe → Comparison composition COMPLETE / ACCEPTED (#101 / #100)**  
 M2.4 status: **Responsive Recipe UI COMPLETE / ACCEPTED (#104 / #103)**  
-Current focus: **design M2.5 deterministic multi-recipe aggregation for M3 Weekly Planning**
+M2.5 status: **Deterministic multi-recipe aggregation COMPLETE / ACCEPTED (#107 / #106)**  
+Current focus: **design the first M3 Weekly Planning domain/application slice over accepted M2.5 aggregation semantics**
 
 ## Permanent connectivity rule
 
@@ -73,7 +74,9 @@ Current product state:
 
 `BLOCKED` is a Zakup Gotov operating policy because an affirmative right to operate the intended recurring production catalog-acquisition/reuse model has not been established. It is not a legal adjudication. No production Spring/HTTP Magnit acquisition is activated.
 
-## M2 — Recipes — CURRENT
+## M2 — Recipes — COMPLETE / ACCEPTED
+
+M2 established deterministic Recipe semantics, exposed them through stateless application/API composition, shipped a responsive Recipe-first user journey and completed the multi-recipe aggregation foundation required by M3.
 
 ### M2.1 — Recipe domain + Recipe → ShoppingList — COMPLETE / ACCEPTED
 
@@ -85,7 +88,6 @@ Accepted behavior:
 
 - immutable Recipe aggregate with stable Recipe/ingredient identities;
 - normalized title, positive integer servings and ordered explicit ingredients;
-- ingredients reuse Shopping Core requirement/quantity semantics;
 - deterministic Recipe → ShoppingList conversion;
 - exact-safe serving scaling and canonical unit handling;
 - exact merge only by normalized requirement + canonical unit;
@@ -101,20 +103,9 @@ Authoritative design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-previe
 Acceptance: [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md)  
 Accepted squash merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`.
 
-Accepted boundary:
+Accepted boundary: `POST /api/v1/recipe-shopping-previews`.
 
-`POST /api/v1/recipe-shopping-previews`
-
-Accepted behavior:
-
-- stateless Recipe request/response;
-- server-owned transient Recipe/ingredient/ShoppingList identities;
-- strict positive-integer serving counts and explicit decimal ingredient quantities;
-- accepted M2.1 converter remains authoritative for scaling/merge/order/ShoppingItem identity;
-- self-contained source ingredient provenance in the response;
-- sanitized request problem contract;
-- OpenAPI 3.1 + generated TypeScript contract;
-- no retailer traffic, persistence, Recipe UI or comparison orchestration.
+Accepted behavior includes server-owned transient identities, strict serving validation, accepted M2.1 scaling/merge/identity semantics, self-contained ingredient provenance, sanitized request problems and generated OpenAPI/TypeScript contracts without persistence or retailer traffic.
 
 Post-merge acceptance: 8/8 normal push workflows SUCCESS.
 
@@ -124,23 +115,13 @@ Authoritative design: [`superpowers/specs/2026-08-14-m2-3-recipe-comparison-prev
 Acceptance: [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md)  
 Accepted squash merge: `15a086d135f40277c655b39549c3e7a04c2e914e`.
 
-Accepted boundary:
-
-`POST /api/v1/recipe-comparison-previews`
+Accepted boundary: `POST /api/v1/recipe-comparison-previews`.
 
 Accepted journey:
 
 `Recipe input + locality → accepted RecipeShoppingPreview → canonical generated Shopping items → accepted ComparisonPreview`
 
-Accepted behavior:
-
-- one stateless use case composes the accepted Recipe and comparison application boundaries;
-- generated ShoppingItem UUID/order/requirement/canonical quantity are preserved end-to-end;
-- Recipe provenance remains self-contained;
-- comparison production-access gating stays authoritative before runtime evidence acquisition;
-- identity/order/requirement/quantity drift fails closed;
-- OpenAPI/generated client remains synchronized;
-- no retailer activation, persistence, exact-address flow, Recipe UI or fuzzy/AI semantics.
+Generated ShoppingItem identity/order/requirement/canonical quantity remain stable across the composition boundary, Recipe provenance remains self-contained and production-access gating remains authoritative before runtime evidence acquisition.
 
 Post-merge acceptance: 8/8 normal push workflows SUCCESS.
 
@@ -156,54 +137,67 @@ Accepted primary web journey:
 
 `Recipe title/servings + ingredient editing + locality → composed Recipe comparison endpoint → canonical generated shopping requirements → truthful retailer comparison`
 
+The browser remains a generated-contract client, internal IDs stay hidden, failure is fail-closed, manual list comparison remains available and desktop/mobile Playwright covers scaling, generated-list output, unavailable state, keyboard focus and horizontal-overflow safety.
+
+Post-merge acceptance: 8/8 normal push workflows SUCCESS.
+
+### M2.5 — Deterministic multi-recipe aggregation — COMPLETE / ACCEPTED
+
+Authoritative design: [`superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md`](superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md)  
+Acceptance: [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md)  
+Accepted squash merge: `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
+
+Accepted flow:
+
+`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregate ShoppingList + occurrence-aware provenance`
+
 Accepted behavior:
 
-- Recipe-first homepage flow with manual basket comparison preserved as a secondary path;
-- title, base/target servings, locality and 1..100 editable ingredients;
-- generated `QuantityInputUnit` vocabulary and generated M2.3 request/response types;
-- client preflight only; Recipe scaling/canonicalization/merge/identity/provenance/comparison semantics remain server-owned;
-- generated canonical shopping requirements render before retailer results;
-- transient IDs/provenance remain hidden from user-facing output;
-- existing READY / UNCERTAIN / INCOMPLETE / UNAVAILABLE comparison renderer is reused without invented winners;
-- finite timeout and product-safe fail-closed validation/unavailable UI;
-- deterministic hydration-safe local row identities;
-- desktop/mobile Playwright coverage for serving scaling, generated list, error state, keyboard focus and no horizontal overflow;
-- deterministic retailer evidence exists only in E2E test support; production web code contains no fixture retailer data.
+- occurrence identity is separate from Recipe identity so the same Recipe may appear multiple times;
+- accepted `RecipeShoppingListConverter` remains authoritative for serving scaling and source-unit canonicalization;
+- automatic cross-Recipe merge remains exact normalized requirement + canonical unit only;
+- canonical amounts are summed exactly and first compatible occurrence controls ordering;
+- aggregate ShoppingItem IDs reuse accepted M2.1 list+requirement+unit derivation and stay independent of amount/serving changes;
+- provenance preserves aggregation occurrence + accepted RecipeIngredientRef lineage and is deeply immutable;
+- empty/duplicate occurrence sets, missing provenance and generated-ID collisions fail closed;
+- no API, web, persistence, planner, provider or retailer behavior was added.
 
-Final reviewed PR head: `fb069d64b96f0d989951e67fd62b793277453024` — 9/9 normal PR workflow groups SUCCESS, read-only review `REVIEWED_READY / Looks good`, no unresolved P0/P1/P2, review threads empty.
+Compatibility proof locked accepted M2.1 ShoppingItem UUID `3d737f10-a263-39b3-b90a-fe7868c035b9` before shared-helper extraction and preserved it afterwards.
 
-Post-merge proof on exact `main=aba20c9cee263a683c0d4383ad840d7415851861`:
+Final reviewed PR head `a6e1095696ebfd67fafe7675a37b125ae02b3170`: 9/9 normal PR workflow groups SUCCESS; review `REVIEWED_READY / Looks good`; no unresolved P0/P1/P2; review threads empty.
 
-- issue #103 closed `completed`;
+Post-merge proof on exact `main=0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`:
+
+- issue #106 closed `completed`;
 - exactly 8 normal push workflow runs;
 - **8/8 SUCCESS; 0 failures**;
 - API, Contract, Web/E2E, CodeQL Java + JavaScript/TypeScript, Container Security, Retailer Bridge, Release Contract and Release Bundle all passed.
 
-## Next deterministic target — M2.5 multi-recipe aggregation
+## M3 — Weekly Planning — CURRENT / DESIGN NEXT
 
-M2 single-recipe product flow is complete from domain semantics through responsive UI.
+M2 has supplied the deterministic aggregation primitive. M3 may now add planner-specific semantics without changing accepted Recipe/Shopping merge behavior implicitly.
 
-Next focus:
+Recommended first design slice:
 
-`several accepted Recipe conversions → one deterministic aggregated ShoppingList + per-recipe provenance`
-
-M2.5 should provide the deterministic merge/provenance foundation required by **M3 Weekly Planning** while preserving accepted Shopping/Recipe invariants.
+`WeeklyPlan identity + ordered meal/day occurrences + per-occurrence target servings → accepted M2.5 aggregation → reviewable weekly ShoppingList projection`
 
 Design questions to resolve before implementation:
 
-1. Aggregate from Recipe domain inputs or accepted RecipeShoppingListConversion results?
-2. How are aggregate ShoppingList/ShoppingItem identities derived deterministically across multiple recipes?
-3. How is provenance represented so each aggregate item resolves back to recipe + ingredient identities without polluting Shopping Core?
-4. Should exact-safe merging remain requirement + canonical unit across recipes? Default direction: yes, with no fuzzy/synonym semantics.
-5. How are duplicate Recipe IDs and duplicate ingredient identities rejected/fail-closed?
-6. What ordering rule survives aggregation? Default direction: recipe input order, then first compatible requirement occurrence.
-7. What stateless application/API boundary is the smallest useful bridge into M3 weekly planning?
+1. What is the smallest WeeklyPlan aggregate: ordered meals only, or explicit day/slot ownership from the start?
+2. Should M3 reuse `RecipeAggregationEntryId` as an internal bridge while exposing planner-specific occurrence identity publicly?
+3. How are day/meal labels represented without contaminating Recipe or Shopping Core?
+4. Which planner invariants are deterministic domain rules versus UI-only organization?
+5. Should the first M3 slice remain stateless, with persistence deferred until saved weekly plans demonstrate value? Default direction: yes.
+6. Pantry/exclusions should be a separate explicit semantics layer after the base weekly-plan composition is accepted; they must not silently alter M2.5 provenance.
+7. What minimal API contract is needed before planner UI work, and how does it preserve complete occurrence provenance?
 
-Persistence, saved recipes, AI ingestion and fuzzy/semantic matching remain separate evidence-driven decisions, not prerequisites for M2.5.
+Persistence, accounts, pantry prediction, fuzzy/AI recipe interpretation and optimization remain separate evidence-driven decisions.
 
 ## Parallel mandatory work
 
-Continue without blocking deterministic M2 work unless new evidence invalidates accepted core assumptions:
+Continue without blocking deterministic M3 work unless new evidence invalidates accepted core assumptions:
 
 - **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
 - **#36** Kuper supported aggregator access investigation;
@@ -241,6 +235,12 @@ Continue without blocking deterministic M2 work unless new evidence invalidates 
 25. Recipe → Comparison composition delegates accepted Recipe and Comparison semantics and never bypasses production-access gating.
 26. Browser Recipe UI is a generated-contract client; Recipe scaling/merge/provenance/comparison semantics remain server-owned.
 27. Browser/E2E fixtures can prove UX behavior but never establish production retailer readiness.
+28. Multi-recipe aggregation distinguishes Recipe identity from occurrence identity.
+29. Repeating one Recipe under distinct aggregation occurrence IDs is valid and lineage remains unambiguous.
+30. Cross-Recipe automatic merge uses the same exact requirement + canonical-unit semantics as single-Recipe conversion.
+31. Aggregate ShoppingItem identity remains list+requirement+canonical-unit scoped and independent of amount/target servings.
+32. Multi-recipe provenance remains outside neutral Shopping Core types and is deeply immutable.
+33. Planner-specific semantics in M3 must compose accepted M2 aggregation rather than silently changing Recipe/Shopping merge rules.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,135 +31,131 @@ Accepted guarantees:
 - `UNKNOWN` availability stays uncertain;
 - incomplete baskets cannot expose misleading complete totals or hidden winners;
 - technical connectivity and production access remain independent;
-- production access scopes acquisition **before** runtime evidence loading;
-- blocked/pending/discovery retailers cannot enter evidence-source request scope;
+- production access scopes acquisition before runtime evidence loading;
 - evidence outside requested retailer scope is a contract violation;
 - ordinary CI remains retailer-network-free.
 
-**GO to M2 Recipes for deterministic product/core development.** This does not claim production retailer completeness.
+## M2 — Recipes — COMPLETE / ACCEPTED
 
-## M2 — Recipes — CURRENT
-
-Goal: make recipes a first-class deterministic source of shopping requirements and expose a usable Recipe-first product flow without weakening accepted Shopping Core invariants.
+Goal achieved: recipes are a first-class deterministic source of shopping requirements from one Recipe through responsive product UI and multi-Recipe aggregation.
 
 ### M2.1 — Recipe domain and Recipe → ShoppingList — COMPLETE / ACCEPTED
 
 Design: [`superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`](superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md)  
 Shipping evidence: [`superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md`](superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md)  
-Accepted squash merge: `423eb14f7c565bbe264257a92df89a6b42d0d158`.
+Accepted merge: `423eb14f7c565bbe264257a92df89a6b42d0d158`.
 
-Accepted result: immutable Recipe semantics, exact-safe serving scaling, canonical Shopping quantities, deterministic exact merge/order/ShoppingItem identities and ordered provenance outside Shopping Core.
+Result: immutable Recipe semantics, exact-safe serving scaling, canonical Shopping quantities, deterministic exact merge/order/ShoppingItem identities and ordered provenance outside Shopping Core.
 
 ### M2.2 — Stateless Recipe application/API boundary — COMPLETE / ACCEPTED
 
 Design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`](superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md)  
 Acceptance: [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md)  
-Accepted squash merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`.
+Accepted merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`.
 
-Accepted boundary:
+Boundary: `POST /api/v1/recipe-shopping-previews`.
 
-`POST /api/v1/recipe-shopping-previews`
-
-Accepted result: stateless server-owned transient identities, strict serving validation, self-contained Recipe provenance, OpenAPI/generated TypeScript contract and no persistence/retailer traffic.
+Result: stateless server-owned transient identities, strict serving validation, self-contained Recipe provenance, OpenAPI/generated TypeScript contract and no persistence/retailer traffic.
 
 ### M2.3 — Composed Recipe → Comparison flow — COMPLETE / ACCEPTED
 
 Design: [`superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md`](superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md)  
 Acceptance: [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md)  
-Accepted squash merge: `15a086d135f40277c655b39549c3e7a04c2e914e`.
+Accepted merge: `15a086d135f40277c655b39549c3e7a04c2e914e`.
 
-Accepted boundary:
+Boundary: `POST /api/v1/recipe-comparison-previews`.
 
-`POST /api/v1/recipe-comparison-previews`
-
-Accepted result: one stateless request composes accepted Recipe conversion with accepted comparison semantics while preserving ShoppingItem identity/order/requirement/canonical quantity and production-access gating.
+Result: one stateless request composes accepted Recipe conversion with accepted comparison semantics while preserving ShoppingItem identity/order/requirement/canonical quantity and production-access gating.
 
 ### M2.4 — Responsive Recipe UI — COMPLETE / ACCEPTED
 
 Design: [`superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md`](superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md)  
-Implementation plan: [`superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md`](superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md)  
 Shipping evidence: [`superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md`](superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md)  
 Acceptance: [`m2-4-responsive-recipe-ui-acceptance-2026-08-14.md`](m2-4-responsive-recipe-ui-acceptance-2026-08-14.md)  
-Accepted squash merge: `aba20c9cee263a683c0d4383ad840d7415851861`.
+Accepted merge: `aba20c9cee263a683c0d4383ad840d7415851861`.
 
-Accepted primary journey:
+Result: Recipe-first responsive homepage flow over generated contracts, canonical generated shopping output, truthful retailer comparison, fail-closed errors, desktop/mobile accessibility regression and preserved manual-list comparison.
 
-`Recipe title/servings + ingredient editing + locality → composed Recipe comparison endpoint → generated canonical shopping requirements → truthful retailer comparison`
+### M2.5 — Deterministic multi-recipe aggregation — COMPLETE / ACCEPTED
 
-Accepted result:
+Design: [`superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md`](superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md)  
+Acceptance: [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md)  
+Accepted merge: `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
 
-- Recipe-first responsive homepage experience;
-- manual list comparison remains a secondary path;
-- generated TypeScript contract is the only transport contract;
-- browser owns form state/preflight only and does not duplicate Recipe/comparison semantics;
-- canonical generated shopping requirements render before retailer results;
-- service failure is fail-closed with no fabricated result;
-- transient internal IDs are hidden;
-- desktop/mobile Playwright covers scaling, generated list, unavailable state, keyboard focus and horizontal-overflow safety;
-- deterministic retailer evidence remains E2E-only.
+Accepted flow:
+
+`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregate ShoppingList + occurrence-aware provenance`
+
+Accepted guarantees:
+
+- Recipe occurrence identity is distinct from Recipe identity;
+- the same Recipe may be included repeatedly under distinct occurrence IDs;
+- serving scaling and source-unit canonicalization remain delegated to accepted M2.1 conversion;
+- cross-Recipe merge remains exact normalized requirement + canonical unit only;
+- aggregate amounts are exact and order is first-compatible-occurrence deterministic;
+- aggregate ShoppingItem ID remains aggregate-list + requirement + canonical-unit scoped and independent of amount/target servings;
+- occurrence-aware provenance is ordered, complete and deeply immutable;
+- empty/duplicate occurrence sets and identity collisions fail closed;
+- accepted single-Recipe UUID semantics remain byte-for-byte stable after shared-helper extraction;
+- no API/UI/persistence/planner/provider/retailer scope was introduced.
 
 Acceptance proof:
 
-- reviewed exact PR head `fb069d64b96f0d989951e67fd62b793277453024`: 9/9 normal PR workflow groups SUCCESS;
-- read-only review `REVIEWED_READY / Looks good`; no unresolved P0/P1/P2; review threads empty;
-- squash merge `main=aba20c9cee263a683c0d4383ad840d7415851861`;
-- #103 closed `completed`;
+- reviewed exact head `a6e1095696ebfd67fafe7675a37b125ae02b3170`: 9/9 normal PR workflow groups SUCCESS;
+- review `REVIEWED_READY / Looks good`; no unresolved P0/P1/P2; review threads empty;
+- squash merge `main=0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`;
+- #106 closed `completed`;
 - **8/8 post-merge normal push workflows SUCCESS, 0 failures**.
 
-### M2.5 — Deterministic multi-recipe aggregation — NEXT
+### M2 exit decision
 
-Goal: provide the deterministic merge/provenance layer required by M3 Weekly Planning without prematurely introducing persistence, AI semantics or planner UI.
-
-Target flow:
-
-`several accepted Recipe inputs/conversions → one aggregated canonical ShoppingList + per-recipe/per-ingredient provenance`
-
-Recommended default direction:
-
-- remain stateless first;
-- aggregate accepted Recipe semantics rather than inventing a second Recipe model;
-- preserve exact normalized requirement + canonical unit as the only automatic merge key;
-- preserve deterministic input order and first compatible group occurrence;
-- derive aggregate ShoppingItem identities deterministically from aggregate-list identity + requirement + canonical unit;
-- retain complete lineage back to RecipeId + RecipeIngredientId outside neutral Shopping Core types;
-- reject duplicate/colliding Recipe or ingredient identities fail-closed;
-- do not add case folding, synonyms, fuzzy/semantic/AI equivalence;
-- do not require database persistence merely to aggregate multiple recipes;
-- define a stateless application/API boundary only after the pure aggregation semantics are accepted.
-
-Required design questions:
-
-1. Should aggregation consume Recipe domain objects directly or accepted `RecipeShoppingListConversion` outputs?
-2. What aggregate identity inputs make ShoppingItem IDs stable across target-serving changes while remaining list-scoped?
-3. What public provenance shape is useful for M3 without leaking internal maps?
-4. How should the aggregator represent the same source Recipe included twice intentionally versus an accidental duplicate identity?
-5. What maximum recipe/item bounds keep stateless API behavior predictable?
-6. Does M2.5 end at pure domain/application aggregation, or include the smallest API contract needed for M3 planner work?
-
-Exit gate:
-
-- pure deterministic aggregation behavior accepted with explicit RED→GREEN evidence;
-- provenance/order/identity invariants covered;
-- full API architecture/verification green;
-- any public contract generated from OpenAPI, not handwritten in web;
-- no persistence/fuzzy/AI scope expansion;
-- exact-head review/CI/merge/post-merge acceptance proof.
-
-### M2 exit direction
-
-After M2.5 acceptance, M2 has the complete deterministic foundation for M3:
+M2 has the complete deterministic foundation required by weekly planning:
 
 - one Recipe → canonical ShoppingList;
 - stateless Recipe application boundary;
 - Recipe → retailer comparison composition;
 - responsive Recipe-first UI;
-- multiple recipes → one canonical aggregate ShoppingList with lineage.
+- multiple Recipe occurrences → one canonical aggregate ShoppingList with unambiguous lineage.
 
-Then advance to **M3 Weekly Planning** rather than extending M2 with planner-specific UI/state.
+Decision: **advance to M3 Weekly Planning**.
+
+## M3 — Weekly Planning — CURRENT / DESIGN NEXT
+
+Goal: combine several meal occurrences into one coherent, reviewable weekly shopping requirement set while keeping planner semantics separate from accepted Recipe/Shopping aggregation rules.
+
+### Recommended M3.1 first slice
+
+Start with a **pure WeeklyPlan domain/application composition**, not persistence or UI.
+
+Target model direction:
+
+`WeeklyPlan identity + ordered meal occurrences + optional day/slot ownership + per-occurrence target servings → accepted M2.5 aggregation → reviewable weekly ShoppingList projection`
+
+Key design questions:
+
+1. Should the first WeeklyPlan aggregate model explicit days/meal slots immediately, or start with an ordered meal-occurrence list and add calendar placement separately?
+2. Planner occurrence identity should be distinct at the WeeklyPlan boundary while mapping deterministically to accepted `RecipeAggregationEntryId` internally.
+3. How are user-facing meal labels/day labels represented without contaminating Recipe or Shopping Core?
+4. Which constraints are true domain invariants: non-empty plan, max occurrences, duplicate planner occurrence IDs, optional repeated Recipe entries, ordering?
+5. Should the first slice remain stateless? **Default: yes** until saved weekly plans/history demonstrate persistence value.
+6. Pantry/exclusions must be a later explicit semantics layer because removing/subtracting requirements changes lineage and should not be hidden inside M2.5 aggregation.
+7. After pure WeeklyPlan semantics are accepted, define the smallest stateless API/OpenAPI contract, then responsive planner UI with RED-first desktop/mobile Playwright.
+
+Suggested M3 sequence:
+
+- **M3.1** WeeklyPlan domain + deterministic composition over M2.5;
+- **M3.2** stateless WeeklyPlan application/API boundary with complete occurrence provenance;
+- **M3.3** responsive weekly planner/review UI;
+- **M3.4** pantry/exclusion semantics as a dedicated deterministic layer;
+- persistence only when repeat-use evidence justifies saved weekly plans.
+
+M3 must not silently change M2.5 exact merge, identity or provenance rules.
 
 ## Parallel connectivity / operational work
 
-Continue without blocking deterministic M2 work unless evidence invalidates accepted core assumptions:
+Continue without blocking deterministic M3 work unless evidence invalidates accepted core assumptions:
 
 - **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
 - **#36** Kuper supported aggregator investigation;
@@ -167,19 +163,6 @@ Continue without blocking deterministic M2 work unless evidence invalidates acce
 - structured package semantics for additional providers only where source evidence proves them;
 - retailer-specific production-access/right-to-operate decisions before activation;
 - successful real **`v0.1.0-rc.3`** release event with final image promotion, SBOM/attestation and digest smoke evidence.
-
-## M3 — Weekly Planning
-
-Goal: combine several meals into one coherent shopping-requirement set and let the user review the resulting week before retailer comparison.
-
-Scope after M2.5:
-
-- weekly planner composition over accepted multi-recipe aggregation;
-- per-meal serving choices;
-- deterministic duplicate merging/unit conversion inherited from M2.5;
-- pantry/exclusion controls as an explicit new semantics layer;
-- shopping-list review before comparison;
-- persistence only if weekly-plan reuse/history becomes a demonstrated product requirement.
 
 ## M4 — Basket Optimization
 

--- a/docs/m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md
+++ b/docs/m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md
@@ -1,0 +1,138 @@
+# M2.5 Deterministic Multi-Recipe Aggregation — Acceptance Decision
+
+Date: 2026-08-14  
+Issue: #106  
+Implementation PR: #107  
+Accepted merge SHA: `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`  
+Decision: **COMPLETE / ACCEPTED**
+
+## Decision
+
+M2.5 is accepted as the deterministic multi-recipe aggregation foundation required by M3 Weekly Planning.
+
+Accepted flow:
+
+`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregate ShoppingList + occurrence-aware Recipe/ingredient provenance`
+
+M2.5 remains a pure Recipe-domain/core capability. It introduces no public API, planner UI, persistence, pantry semantics, retailer/provider behavior or fuzzy/AI interpretation.
+
+## Accepted model and behavior
+
+- `RecipeAggregationEntryId` identifies one occurrence of a Recipe independently from `RecipeId`.
+- `RecipeAggregationEntry` binds occurrence ID, accepted Recipe and target servings.
+- The same Recipe may be intentionally included more than once when occurrence IDs differ.
+- Duplicate occurrence IDs fail closed.
+- `RecipeShoppingListAggregator` delegates serving scaling and source-unit canonicalization to the accepted `RecipeShoppingListConverter` for every occurrence.
+- Per-occurrence intermediate ShoppingList IDs are deterministic and internal.
+- Cross-Recipe automatic merge remains exact normalized ShoppingRequirement + canonical QuantityUnit only.
+- Already-canonical scaled quantities are summed exactly with `BigDecimal.add`.
+- First compatible occurrence controls aggregate item order.
+- Aggregate ShoppingItem IDs reuse the accepted M2.1 list+requirement+canonical-unit derivation and remain independent of amount and target-serving changes.
+- `RecipeAggregationIngredientRef` adds occurrence identity around the accepted `RecipeIngredientRef`, so repeated inclusion of the same Recipe remains unambiguous.
+- Aggregate provenance preserves occurrence order and accepted converter lineage order and is deeply immutable.
+- Empty input, null entries, duplicate occurrence IDs, missing/empty converted provenance, null derived IDs and generated-ID collisions fail closed.
+- Shopping Core remains Recipe-free.
+
+## Compatibility proof
+
+Before extracting the shared M2.1 identity helper, a literal characterization fixture locked this accepted identity:
+
+- ShoppingListId: `4ea3a925-1d2a-4246-a970-7a82ffc96402`;
+- requirement: `Flour`;
+- canonical unit: `GRAM`;
+- ShoppingItem UUID: `3d737f10-a263-39b3-b90a-fe7868c035b9`.
+
+The fixture passed before and after extraction of package-private `RecipeShoppingMergeKey` and `RecipeShoppingItemIds.derive(...)`. Existing single-Recipe ShoppingItem IDs therefore remain byte-for-byte compatible.
+
+## TDD evidence
+
+Aggregation RED:
+
+`d337ec12a739e0c9cc20be8233a69de435cb72ee`
+
+- compilation failed on intentionally absent aggregation production types.
+
+Aggregation GREEN:
+
+`e447e8bfdbcc55ddef20f4d9445de1c5e4080474`
+
+- full API verification succeeded;
+- two independently converted Recipe occurrences merged into one exact canonical item with ordered occurrence-aware provenance.
+
+Hardening RED:
+
+`3c377bc331c4a2a2bb8c0c8af57da2d62536a31c`
+
+- eight aggregation tests executed;
+- exactly two intended failures: empty aggregation input and duplicate occurrence ID;
+- zero errors;
+- all other new aggregation invariants passed;
+- all ten existing converter tests passed.
+
+Hardening GREEN:
+
+`42b0a7c22141f770d58e9bbdca35a26f62b1d2ae`
+
+- only the two missing fail-closed checks were added;
+- full API/Maven verification succeeded.
+
+## Review and exact-head CI
+
+Final reviewed PR head:
+
+`a6e1095696ebfd67fafe7675a37b125ae02b3170`
+
+Review verdict: **REVIEWED_READY / Looks good**.
+
+Review covered:
+
+- M2.1 ShoppingItem-ID compatibility;
+- strict merge semantics;
+- repeated-Recipe occurrence lineage;
+- first-occurrence ordering;
+- identity stability;
+- deep provenance immutability;
+- fail-closed validation/collision paths;
+- dependency direction;
+- absence of API/UI/persistence/planner scope creep.
+
+No unresolved P0/P1/P2 finding remained and review threads were empty.
+
+All **9/9 normal PR workflow groups SUCCESS** on the exact reviewed head, including API/Maven verification, Contract, responsive Web/E2E regression, CodeQL Java + JS/TS, Dependency Review, Container Security, Retailer Bridge, Release Contract and Release Bundle.
+
+## Post-merge acceptance proof
+
+PR #107 was squash-merged using expected-head protection.
+
+Exact merged `main` SHA:
+
+`0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`
+
+Issue #106 closed with state reason `completed`.
+
+GitHub created exactly eight normal push-triggered workflows for this SHA. Final result:
+
+- API CI — SUCCESS;
+- Contract CI — SUCCESS;
+- Web CI / responsive E2E — SUCCESS;
+- CodeQL Java + JavaScript/TypeScript — SUCCESS;
+- Container Security CI — SUCCESS;
+- Retailer Bridge CI — SUCCESS;
+- Release Contract CI — SUCCESS;
+- Release Bundle CI — SUCCESS.
+
+At workflow-group level: **8/8 SUCCESS, 0 failures**.
+
+## M2 exit decision
+
+M2 deterministic Recipe foundations are now complete:
+
+1. one Recipe → canonical ShoppingList;
+2. stateless Recipe application/API boundary;
+3. Recipe → retailer comparison composition;
+4. responsive Recipe-first product UI;
+5. several Recipe occurrences → one canonical aggregate ShoppingList with complete occurrence-aware lineage.
+
+Decision: **advance to M3 Weekly Planning**.
+
+The next slice should design the smallest weekly-plan domain/application boundary over accepted M2.5 aggregation semantics. Planner-specific meal/day ownership, pantry/exclusions, API/UI and any persistence decision belong to M3 and must not modify accepted M2 merge/provenance rules implicitly.


### PR DESCRIPTION
## Summary

Synchronize canonical project documentation after accepted M2.5 implementation PR #107.

Acceptance evidence:
- final reviewed feature head `a6e1095696ebfd67fafe7675a37b125ae02b3170`;
- 9/9 normal PR workflow groups SUCCESS;
- read-only review `REVIEWED_READY / Looks good`, no unresolved P0/P1/P2, no review threads;
- squash merge `main=0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`;
- issue #106 closed `completed`;
- exactly 8 normal post-merge push workflows, **8/8 SUCCESS, 0 failures**.

Documentation changes:
- add dedicated M2.5 acceptance decision;
- mark M2.5 and M2 Recipes COMPLETE / ACCEPTED in PROJECT_STATE;
- advance current phase to **M3 Weekly Planning**;
- update ROADMAP with M3.1 pure WeeklyPlan domain/application composition as the next design target;
- update CHANGELOG with occurrence-aware aggregation, shared M2.1 identity compatibility proof and acceptance evidence.

No production code, OpenAPI, generated-client or web behavior changes.