### PR TITLE
M3.1: add WeeklyPlan domain and deterministic shopping composition

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/RecipeAggregationBoundary.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/RecipeAggregationBoundary.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntry;
+import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregation;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import java.util.List;
+
+@FunctionalInterface
+interface RecipeAggregationBoundary {
+    RecipeShoppingListAggregation aggregate(
+            List<RecipeAggregationEntry> entries,
+            ShoppingListId shoppingListId);
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrence.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrence.java
@@ -1,0 +1,19 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.Recipe;
+import io.github.trueruslan.zakupgotov.recipe.RecipeServings;
+import java.util.Objects;
+
+public record WeeklyMealOccurrence(
+        WeeklyMealOccurrenceId id,
+        WeeklyPlanDay day,
+        Recipe recipe,
+        RecipeServings targetServings) {
+
+    public WeeklyMealOccurrence {
+        id = Objects.requireNonNull(id, "id must not be null");
+        day = Objects.requireNonNull(day, "day must not be null");
+        recipe = Objects.requireNonNull(recipe, "recipe must not be null");
+        targetServings = Objects.requireNonNull(targetServings, "targetServings must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrenceId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrenceId.java
@@ -1,0 +1,10 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record WeeklyMealOccurrenceId(UUID value) {
+    public WeeklyMealOccurrenceId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlan.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlan.java
@@ -1,0 +1,27 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public record WeeklyPlan(
+        WeeklyPlanId id,
+        List<WeeklyMealOccurrence> occurrences) {
+
+    public WeeklyPlan {
+        id = Objects.requireNonNull(id, "id must not be null");
+        occurrences = Objects.requireNonNull(occurrences, "occurrences must not be null");
+        if (occurrences.isEmpty()) {
+            throw new IllegalArgumentException("occurrences must not be empty");
+        }
+
+        var seenIds = new HashSet<WeeklyMealOccurrenceId>();
+        for (var occurrence : occurrences) {
+            Objects.requireNonNull(occurrence, "occurrence must not be null");
+            if (!seenIds.add(occurrence.id())) {
+                throw new IllegalArgumentException("duplicate weekly meal occurrence id");
+            }
+        }
+        occurrences = List.copyOf(occurrences);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanDay.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanDay.java
@@ -1,0 +1,11 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+public enum WeeklyPlanDay {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanId.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanId.java
@@ -1,0 +1,10 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record WeeklyPlanId(UUID value) {
+    public WeeklyPlanId {
+        value = Objects.requireNonNull(value, "value must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIdentityDeriver.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIdentityDeriver.java
@@ -1,0 +1,12 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntryId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+
+interface WeeklyPlanIdentityDeriver {
+    ShoppingListId shoppingListId(WeeklyPlanId planId);
+
+    RecipeAggregationEntryId aggregationEntryId(
+            WeeklyPlanId planId,
+            WeeklyMealOccurrenceId occurrenceId);
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIds.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIds.java
@@ -1,0 +1,33 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntryId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+final class WeeklyPlanIds implements WeeklyPlanIdentityDeriver {
+
+    static final WeeklyPlanIds INSTANCE = new WeeklyPlanIds();
+
+    private static final String LIST_PREFIX = "zakup-gotov:weekly-plan-shopping-list:v1:";
+    private static final String ENTRY_PREFIX = "zakup-gotov:weekly-plan-aggregation-entry:v1:";
+
+    private WeeklyPlanIds() {}
+
+    @Override
+    public ShoppingListId shoppingListId(WeeklyPlanId planId) {
+        return new ShoppingListId(nameUuid(LIST_PREFIX + planId.value()));
+    }
+
+    @Override
+    public RecipeAggregationEntryId aggregationEntryId(
+            WeeklyPlanId planId,
+            WeeklyMealOccurrenceId occurrenceId) {
+        return new RecipeAggregationEntryId(
+                nameUuid(ENTRY_PREFIX + planId.value() + ":" + occurrenceId.value()));
+    }
+
+    private static UUID nameUuid(String payload) {
+        return UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIngredientRef.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIngredientRef.java
@@ -1,0 +1,14 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientRef;
+import java.util.Objects;
+
+public record WeeklyPlanIngredientRef(
+        WeeklyMealOccurrenceId occurrenceId,
+        RecipeIngredientRef recipeIngredient) {
+
+    public WeeklyPlanIngredientRef {
+        occurrenceId = Objects.requireNonNull(occurrenceId, "occurrenceId must not be null");
+        recipeIngredient = Objects.requireNonNull(recipeIngredient, "recipeIngredient must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java
@@ -1,0 +1,76 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntry;
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntryId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregation;
+import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregator;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class WeeklyPlanShoppingListComposer {
+
+    private final RecipeAggregationBoundary aggregationBoundary;
+    private final WeeklyPlanIdentityDeriver identityDeriver;
+
+    public WeeklyPlanShoppingListComposer() {
+        this(new RecipeShoppingListAggregator()::aggregate, WeeklyPlanIds.INSTANCE);
+    }
+
+    WeeklyPlanShoppingListComposer(
+            RecipeAggregationBoundary aggregationBoundary,
+            WeeklyPlanIdentityDeriver identityDeriver) {
+        this.aggregationBoundary = Objects.requireNonNull(
+                aggregationBoundary, "aggregationBoundary must not be null");
+        this.identityDeriver = Objects.requireNonNull(
+                identityDeriver, "identityDeriver must not be null");
+    }
+
+    public WeeklyPlanShoppingListComposition compose(WeeklyPlan plan) {
+        Objects.requireNonNull(plan, "plan must not be null");
+
+        var shoppingListId = Objects.requireNonNull(
+                identityDeriver.shoppingListId(plan.id()),
+                "derived shoppingListId must not be null");
+        var entries = new ArrayList<RecipeAggregationEntry>(plan.occurrences().size());
+        var occurrenceByEntryId = new LinkedHashMap<RecipeAggregationEntryId, WeeklyMealOccurrenceId>();
+
+        for (var occurrence : plan.occurrences()) {
+            var entryId = Objects.requireNonNull(
+                    identityDeriver.aggregationEntryId(plan.id(), occurrence.id()),
+                    "derived aggregation entry id must not be null");
+            if (occurrenceByEntryId.putIfAbsent(entryId, occurrence.id()) != null) {
+                throw new IllegalStateException("generated aggregation entry id collision");
+            }
+            entries.add(new RecipeAggregationEntry(entryId, occurrence.recipe(), occurrence.targetServings()));
+        }
+
+        var aggregation = Objects.requireNonNull(
+                aggregationBoundary.aggregate(List.copyOf(entries), shoppingListId),
+                "aggregation result must not be null");
+        return project(aggregation, occurrenceByEntryId);
+    }
+
+    private static WeeklyPlanShoppingListComposition project(
+            RecipeShoppingListAggregation aggregation,
+            Map<RecipeAggregationEntryId, WeeklyMealOccurrenceId> occurrenceByEntryId) {
+        var projected = new LinkedHashMap<io.github.trueruslan.zakupgotov.shopping.ShoppingItemId,
+                List<WeeklyPlanIngredientRef>>();
+
+        aggregation.provenance().forEach((itemId, refs) -> {
+            var itemRefs = new ArrayList<WeeklyPlanIngredientRef>(refs.size());
+            for (var ref : refs) {
+                var occurrenceId = occurrenceByEntryId.get(ref.entryId());
+                if (occurrenceId == null) {
+                    throw new IllegalStateException("unknown aggregation entry id in provenance");
+                }
+                itemRefs.add(new WeeklyPlanIngredientRef(occurrenceId, ref.ingredientRef()));
+            }
+            projected.put(itemId, List.copyOf(itemRefs));
+        });
+
+        return new WeeklyPlanShoppingListComposition(aggregation.shoppingList(), projected);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java
@@ -4,8 +4,10 @@ import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntry;
 import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntryId;
 import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregation;
 import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregator;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -56,10 +58,11 @@ public final class WeeklyPlanShoppingListComposer {
     private static WeeklyPlanShoppingListComposition project(
             RecipeShoppingListAggregation aggregation,
             Map<RecipeAggregationEntryId, WeeklyMealOccurrenceId> occurrenceByEntryId) {
-        var projected = new LinkedHashMap<io.github.trueruslan.zakupgotov.shopping.ShoppingItemId,
-                List<WeeklyPlanIngredientRef>>();
+        validateProvenanceStructure(aggregation);
 
-        aggregation.provenance().forEach((itemId, refs) -> {
+        var projected = new LinkedHashMap<ShoppingItemId, List<WeeklyPlanIngredientRef>>();
+        for (var item : aggregation.shoppingList().items()) {
+            var refs = aggregation.provenance().get(item.id());
             var itemRefs = new ArrayList<WeeklyPlanIngredientRef>(refs.size());
             for (var ref : refs) {
                 var occurrenceId = occurrenceByEntryId.get(ref.entryId());
@@ -68,9 +71,25 @@ public final class WeeklyPlanShoppingListComposer {
                 }
                 itemRefs.add(new WeeklyPlanIngredientRef(occurrenceId, ref.ingredientRef()));
             }
-            projected.put(itemId, List.copyOf(itemRefs));
-        });
+            projected.put(item.id(), List.copyOf(itemRefs));
+        }
 
         return new WeeklyPlanShoppingListComposition(aggregation.shoppingList(), projected);
+    }
+
+    private static void validateProvenanceStructure(RecipeShoppingListAggregation aggregation) {
+        var itemIds = new LinkedHashSet<ShoppingItemId>();
+        for (var item : aggregation.shoppingList().items()) {
+            itemIds.add(item.id());
+        }
+
+        if (!itemIds.equals(aggregation.provenance().keySet())) {
+            throw new IllegalStateException("shopping list and provenance keys must match exactly");
+        }
+        aggregation.provenance().forEach((itemId, refs) -> {
+            if (refs.isEmpty()) {
+                throw new IllegalStateException("aggregate provenance must not be empty for item " + itemId.value());
+            }
+        });
     }
 }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposition.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposition.java
@@ -1,0 +1,25 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record WeeklyPlanShoppingListComposition(
+        ShoppingList shoppingList,
+        Map<ShoppingItemId, List<WeeklyPlanIngredientRef>> provenance) {
+
+    public WeeklyPlanShoppingListComposition {
+        shoppingList = Objects.requireNonNull(shoppingList, "shoppingList must not be null");
+        provenance = Objects.requireNonNull(provenance, "provenance must not be null");
+
+        var copy = new LinkedHashMap<ShoppingItemId, List<WeeklyPlanIngredientRef>>();
+        provenance.forEach((itemId, refs) -> copy.put(
+                Objects.requireNonNull(itemId, "provenance itemId must not be null"),
+                List.copyOf(Objects.requireNonNull(refs, "provenance refs must not be null"))));
+        provenance = Collections.unmodifiableMap(copy);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanArchitectureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanArchitectureTest.java
@@ -1,0 +1,80 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class WeeklyPlanArchitectureTest {
+
+    private static final String ROOT = "io.github.trueruslan.zakupgotov.";
+    private static final String WEEKLY_PLAN = ROOT + "weeklyplan";
+
+    @Test
+    void weeklyPlanProductionBoundaryExists() {
+        var classes = productionClasses();
+
+        assertThat(classes.stream()
+                        .anyMatch(javaClass -> javaClass.getPackageName().equals(WEEKLY_PLAN)))
+                .as("M3.1 weeklyplan production package must exist")
+                .isTrue();
+    }
+
+    @Test
+    void weeklyPlanDependsOnlyOnRecipeAndShoppingProjectPackages() {
+        var classes = productionClasses();
+
+        var projectDependencies = classes.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(WEEKLY_PLAN))
+                .flatMap(javaClass -> javaClass.getDirectDependenciesFromSelf().stream())
+                .map(dependency -> dependency.getTargetClass())
+                .filter(target -> target.getName().startsWith(ROOT))
+                .filter(target -> !target.getPackageName().equals(WEEKLY_PLAN))
+                .map(target -> target.getPackageName())
+                .collect(Collectors.toSet());
+
+        assertThat(projectDependencies)
+                .allSatisfy(packageName -> assertThat(packageName)
+                        .matches(ROOT + "(recipe|shopping)(\\..*)?"));
+    }
+
+    @Test
+    void weeklyPlanDoesNotReachIntoDownstreamOrTransportPackages() {
+        var classes = productionClasses();
+
+        noClasses()
+                .that().resideInAPackage("..weeklyplan..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "..preview..",
+                        "..recipepreview..",
+                        "..recipecomparisonpreview..",
+                        "..provider..",
+                        "..retailer..",
+                        "..matching..",
+                        "..basket..",
+                        "..comparison..",
+                        "..database..",
+                        "org.springframework.web..")
+                .check(classes);
+    }
+
+    @Test
+    void acceptedRecipeAndShoppingPackagesRemainIndependentFromWeeklyPlan() {
+        var classes = productionClasses();
+
+        noClasses()
+                .that().resideInAnyPackage("..recipe..", "..shopping..")
+                .should().dependOnClassesThat().resideInAPackage("..weeklyplan..")
+                .check(classes);
+    }
+
+    private static JavaClasses productionClasses() {
+        return new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.github.trueruslan.zakupgotov");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerHardeningTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerHardeningTest.java
@@ -1,0 +1,217 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.recipe.Recipe;
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationEntryId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeAggregationIngredientRef;
+import io.github.trueruslan.zakupgotov.recipe.RecipeId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredient;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientRef;
+import io.github.trueruslan.zakupgotov.recipe.RecipeServings;
+import io.github.trueruslan.zakupgotov.recipe.RecipeShoppingListAggregation;
+import io.github.trueruslan.zakupgotov.recipe.RecipeTitle;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class WeeklyPlanShoppingListComposerHardeningTest {
+
+    private static final WeeklyPlanId PLAN_ID =
+            new WeeklyPlanId(UUID.fromString("88000000-0000-0000-0000-000000000001"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_A =
+            new WeeklyMealOccurrenceId(UUID.fromString("89000000-0000-0000-0000-000000000001"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_B =
+            new WeeklyMealOccurrenceId(UUID.fromString("89000000-0000-0000-0000-000000000002"));
+    private static final ShoppingListId LIST_ID =
+            new ShoppingListId(UUID.fromString("8a000000-0000-0000-0000-000000000001"));
+    private static final ShoppingItemId ITEM_A =
+            new ShoppingItemId(UUID.fromString("8b000000-0000-0000-0000-000000000001"));
+    private static final ShoppingItemId ITEM_B =
+            new ShoppingItemId(UUID.fromString("8b000000-0000-0000-0000-000000000002"));
+
+    @Test
+    void rejectsFinalShoppingItemWithoutProvenance() {
+        var composer = composerReturning((entries, listId) ->
+                new RecipeShoppingListAggregation(listWith(ITEM_A), Map.of()));
+
+        assertThatThrownBy(() -> composer.compose(singleOccurrencePlan()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsOrphanProvenanceKey() {
+        var composer = composerReturning((entries, listId) -> {
+            var ref = validRef(entries.getFirst().id());
+            return new RecipeShoppingListAggregation(listWith(ITEM_A), Map.of(ITEM_B, List.of(ref)));
+        });
+
+        assertThatThrownBy(() -> composer.compose(singleOccurrencePlan()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsEmptyAggregateProvenanceList() {
+        var composer = composerReturning((entries, listId) ->
+                new RecipeShoppingListAggregation(listWith(ITEM_A), Map.of(ITEM_A, List.of())));
+
+        assertThatThrownBy(() -> composer.compose(singleOccurrencePlan()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsUnknownInternalAggregationEntryInProvenance() {
+        var unknown = new RecipeAggregationEntryId(
+                UUID.fromString("8c000000-0000-0000-0000-000000000099"));
+        var composer = composerReturning((entries, listId) -> new RecipeShoppingListAggregation(
+                listWith(ITEM_A), Map.of(ITEM_A, List.of(validRef(unknown)))));
+
+        assertThatThrownBy(() -> composer.compose(singleOccurrencePlan()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsGeneratedInternalAggregationIdCollision() {
+        var collision = new RecipeAggregationEntryId(
+                UUID.fromString("8c000000-0000-0000-0000-000000000001"));
+        var identity = new WeeklyPlanIdentityDeriver() {
+            @Override
+            public ShoppingListId shoppingListId(WeeklyPlanId planId) {
+                return LIST_ID;
+            }
+
+            @Override
+            public RecipeAggregationEntryId aggregationEntryId(
+                    WeeklyPlanId planId, WeeklyMealOccurrenceId occurrenceId) {
+                return collision;
+            }
+        };
+        RecipeAggregationBoundary unused = (entries, listId) -> {
+            throw new AssertionError("aggregation must not be invoked after identity collision");
+        };
+        var composer = new WeeklyPlanShoppingListComposer(unused, identity);
+
+        assertThatThrownBy(() -> composer.compose(twoOccurrencePlan()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsNullDerivedShoppingListIdAndNullPlan() {
+        var identity = new WeeklyPlanIdentityDeriver() {
+            @Override
+            public ShoppingListId shoppingListId(WeeklyPlanId planId) {
+                return null;
+            }
+
+            @Override
+            public RecipeAggregationEntryId aggregationEntryId(
+                    WeeklyPlanId planId, WeeklyMealOccurrenceId occurrenceId) {
+                throw new AssertionError("entry id must not be requested");
+            }
+        };
+        var composer = new WeeklyPlanShoppingListComposer(
+                (entries, listId) -> { throw new AssertionError("must not aggregate"); }, identity);
+
+        assertThatThrownBy(() -> composer.compose(singleOccurrencePlan()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyPlanShoppingListComposer().compose(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void plannerProvenanceIsDeeplyImmutableAndReturnsExactAggregateShoppingList() {
+        var capturedList = listWith(ITEM_A);
+        RecipeAggregationBoundary boundary = (entries, listId) -> new RecipeShoppingListAggregation(
+                capturedList,
+                Map.of(ITEM_A, List.of(validRef(entries.getFirst().id()))));
+        var composer = new WeeklyPlanShoppingListComposer(boundary, fixedIdentity());
+
+        var result = composer.compose(singleOccurrencePlan());
+
+        assertThat(result.shoppingList()).isSameAs(capturedList);
+        assertThatThrownBy(() -> result.provenance().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.provenance().get(ITEM_A).clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private static WeeklyPlanShoppingListComposer composerReturning(RecipeAggregationBoundary boundary) {
+        return new WeeklyPlanShoppingListComposer(boundary, fixedIdentity());
+    }
+
+    private static WeeklyPlanIdentityDeriver fixedIdentity() {
+        return new WeeklyPlanIdentityDeriver() {
+            @Override
+            public ShoppingListId shoppingListId(WeeklyPlanId planId) {
+                return LIST_ID;
+            }
+
+            @Override
+            public RecipeAggregationEntryId aggregationEntryId(
+                    WeeklyPlanId planId, WeeklyMealOccurrenceId occurrenceId) {
+                var suffix = occurrenceId.equals(OCCURRENCE_A) ? 1 : 2;
+                return new RecipeAggregationEntryId(UUID.fromString(
+                        "8c000000-0000-0000-0000-%012d".formatted(suffix)));
+            }
+        };
+    }
+
+    private static RecipeAggregationIngredientRef validRef(RecipeAggregationEntryId entryId) {
+        var recipe = recipe("8d000000-0000-0000-0000-000000000001");
+        return new RecipeAggregationIngredientRef(
+                entryId,
+                new RecipeIngredientRef(recipe.id(), recipe.ingredients().getFirst().id()));
+    }
+
+    private static ShoppingList listWith(ShoppingItemId itemId) {
+        var list = new ShoppingList(LIST_ID);
+        list.add(new ShoppingItem(
+                itemId,
+                new ShoppingRequirement("Milk"),
+                new Quantity(new BigDecimal("100"), QuantityUnit.MILLILITER)));
+        return list;
+    }
+
+    private static WeeklyPlan singleOccurrencePlan() {
+        return new WeeklyPlan(
+                PLAN_ID,
+                List.of(new WeeklyMealOccurrence(
+                        OCCURRENCE_A,
+                        WeeklyPlanDay.MONDAY,
+                        recipe("8d000000-0000-0000-0000-000000000011"),
+                        new RecipeServings(1))));
+    }
+
+    private static WeeklyPlan twoOccurrencePlan() {
+        var recipe = recipe("8d000000-0000-0000-0000-000000000021");
+        return new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipe, new RecipeServings(1)),
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_B, WeeklyPlanDay.TUESDAY, recipe, new RecipeServings(1))));
+    }
+
+    private static Recipe recipe(String id) {
+        return new Recipe(
+                new RecipeId(UUID.fromString(id)),
+                new RecipeTitle("Test recipe"),
+                new RecipeServings(1),
+                List.of(new RecipeIngredient(
+                        new RecipeIngredientId(UUID.fromString("8e000000-0000-0000-0000-000000000001")),
+                        new ShoppingRequirement("Milk"),
+                        new Quantity(new BigDecimal("100"), QuantityUnit.MILLILITER))));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerTest.java
@@ -1,0 +1,214 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.recipe.Recipe;
+import io.github.trueruslan.zakupgotov.recipe.RecipeId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredient;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientRef;
+import io.github.trueruslan.zakupgotov.recipe.RecipeServings;
+import io.github.trueruslan.zakupgotov.recipe.RecipeTitle;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class WeeklyPlanShoppingListComposerTest {
+
+    private static final WeeklyPlanId PLAN_ID =
+            new WeeklyPlanId(UUID.fromString("84000000-0000-0000-0000-000000000001"));
+    private static final WeeklyPlanId OTHER_PLAN_ID =
+            new WeeklyPlanId(UUID.fromString("84000000-0000-0000-0000-000000000002"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_A =
+            new WeeklyMealOccurrenceId(UUID.fromString("85000000-0000-0000-0000-000000000001"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_B =
+            new WeeklyMealOccurrenceId(UUID.fromString("85000000-0000-0000-0000-000000000002"));
+
+    private final WeeklyPlanShoppingListComposer composer = new WeeklyPlanShoppingListComposer();
+
+    @Test
+    void composesCompatibleWeeklyOccurrencesThroughAcceptedM2Aggregation() {
+        var milkA = ingredient(
+                "86000000-0000-0000-0000-000000000001",
+                "Milk",
+                "0.5",
+                QuantityUnit.LITER);
+        var milkB = ingredient(
+                "86000000-0000-0000-0000-000000000002",
+                "Milk",
+                "250",
+                QuantityUnit.MILLILITER);
+        var recipeA = recipe("87000000-0000-0000-0000-000000000001", 2, milkA);
+        var recipeB = recipe("87000000-0000-0000-0000-000000000002", 1, milkB);
+        var plan = new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        occurrence(OCCURRENCE_A, WeeklyPlanDay.TUESDAY, recipeA, 4),
+                        occurrence(OCCURRENCE_B, WeeklyPlanDay.MONDAY, recipeB, 2)));
+
+        var result = composer.compose(plan);
+
+        assertThat(result.shoppingList().items()).singleElement().satisfies(item -> {
+            assertThat(item.requirement()).isEqualTo(new ShoppingRequirement("Milk"));
+            assertThat(item.quantity())
+                    .isEqualTo(new Quantity(new BigDecimal("1500"), QuantityUnit.MILLILITER));
+            assertThat(result.provenance().get(item.id())).containsExactly(
+                    new WeeklyPlanIngredientRef(
+                            OCCURRENCE_A,
+                            new RecipeIngredientRef(recipeA.id(), milkA.id())),
+                    new WeeklyPlanIngredientRef(
+                            OCCURRENCE_B,
+                            new RecipeIngredientRef(recipeB.id(), milkB.id())));
+        });
+    }
+
+    @Test
+    void repeatedRecipeOccurrencesRemainDistinctInPlannerProvenance() {
+        var milk = ingredient(
+                "86000000-0000-0000-0000-000000000011",
+                "Milk",
+                "500",
+                QuantityUnit.MILLILITER);
+        var sharedRecipe = recipe("87000000-0000-0000-0000-000000000011", 1, milk);
+        var source = new RecipeIngredientRef(sharedRecipe.id(), milk.id());
+        var plan = new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        occurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, sharedRecipe, 1),
+                        occurrence(OCCURRENCE_B, WeeklyPlanDay.FRIDAY, sharedRecipe, 2)));
+
+        var result = composer.compose(plan);
+        var item = result.shoppingList().items().getFirst();
+
+        assertThat(item.quantity().amount()).isEqualByComparingTo("1500");
+        assertThat(result.provenance().get(item.id())).containsExactly(
+                new WeeklyPlanIngredientRef(OCCURRENCE_A, source),
+                new WeeklyPlanIngredientRef(OCCURRENCE_B, source));
+    }
+
+    @Test
+    void preservesExplicitOccurrenceOrderRatherThanSortingByDay() {
+        var flour = ingredient(
+                "86000000-0000-0000-0000-000000000021",
+                "Flour",
+                "100",
+                QuantityUnit.GRAM);
+        var milk = ingredient(
+                "86000000-0000-0000-0000-000000000022",
+                "Milk",
+                "100",
+                QuantityUnit.MILLILITER);
+        var tuesdayRecipe = recipe("87000000-0000-0000-0000-000000000021", 1, flour);
+        var mondayRecipe = recipe("87000000-0000-0000-0000-000000000022", 1, milk);
+        var plan = new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        occurrence(OCCURRENCE_A, WeeklyPlanDay.TUESDAY, tuesdayRecipe, 1),
+                        occurrence(OCCURRENCE_B, WeeklyPlanDay.MONDAY, mondayRecipe, 1)));
+
+        var keys = composer.compose(plan).shoppingList().items().stream()
+                .map(item -> item.requirement().text())
+                .toList();
+
+        assertThat(keys).containsExactly("Flour", "Milk");
+    }
+
+    @Test
+    void itemIdentityIsStableAcrossServingAndDayChangesButScopedToWeeklyPlan() {
+        var milk = ingredient(
+                "86000000-0000-0000-0000-000000000031",
+                "Milk",
+                "100",
+                QuantityUnit.MILLILITER);
+        var recipe = recipe("87000000-0000-0000-0000-000000000031", 1, milk);
+
+        var base = composer.compose(new WeeklyPlan(
+                PLAN_ID,
+                List.of(occurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipe, 1))));
+        var changed = composer.compose(new WeeklyPlan(
+                PLAN_ID,
+                List.of(occurrence(OCCURRENCE_A, WeeklyPlanDay.SUNDAY, recipe, 3))));
+        var otherPlan = composer.compose(new WeeklyPlan(
+                OTHER_PLAN_ID,
+                List.of(occurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipe, 1))));
+
+        var baseItem = base.shoppingList().items().getFirst();
+        var changedItem = changed.shoppingList().items().getFirst();
+        var otherItem = otherPlan.shoppingList().items().getFirst();
+
+        assertThat(changedItem.id()).isEqualTo(baseItem.id());
+        assertThat(changedItem.quantity().amount()).isEqualByComparingTo("300");
+        assertThat(baseItem.quantity().amount()).isEqualByComparingTo("100");
+        assertThat(otherPlan.shoppingList().id()).isNotEqualTo(base.shoppingList().id());
+        assertThat(otherItem.id()).isNotEqualTo(baseItem.id());
+    }
+
+    @Test
+    void reorderingOccurrencesCanChangeOutputOrderWithoutChangingMergeKeyIdentities() {
+        var flour = ingredient(
+                "86000000-0000-0000-0000-000000000041",
+                "Flour",
+                "100",
+                QuantityUnit.GRAM);
+        var milk = ingredient(
+                "86000000-0000-0000-0000-000000000042",
+                "Milk",
+                "100",
+                QuantityUnit.MILLILITER);
+        var recipeA = recipe("87000000-0000-0000-0000-000000000041", 1, flour);
+        var recipeB = recipe("87000000-0000-0000-0000-000000000042", 1, milk);
+
+        var first = composer.compose(new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        occurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipeA, 1),
+                        occurrence(OCCURRENCE_B, WeeklyPlanDay.TUESDAY, recipeB, 1))));
+        var reversed = composer.compose(new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        occurrence(OCCURRENCE_B, WeeklyPlanDay.TUESDAY, recipeB, 1),
+                        occurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipeA, 1))));
+
+        assertThat(first.shoppingList().items()).extracting(item -> item.requirement().text())
+                .containsExactly("Flour", "Milk");
+        assertThat(reversed.shoppingList().items()).extracting(item -> item.requirement().text())
+                .containsExactly("Milk", "Flour");
+
+        var firstIdsByRequirement = first.shoppingList().items().stream()
+                .collect(java.util.stream.Collectors.toMap(item -> item.requirement().text(), item -> item.id()));
+        var reversedIdsByRequirement = reversed.shoppingList().items().stream()
+                .collect(java.util.stream.Collectors.toMap(item -> item.requirement().text(), item -> item.id()));
+        assertThat(reversedIdsByRequirement).isEqualTo(firstIdsByRequirement);
+    }
+
+    private static WeeklyMealOccurrence occurrence(
+            WeeklyMealOccurrenceId id,
+            WeeklyPlanDay day,
+            Recipe recipe,
+            int servings) {
+        return new WeeklyMealOccurrence(id, day, recipe, new RecipeServings(servings));
+    }
+
+    private static Recipe recipe(String id, int servings, RecipeIngredient... ingredients) {
+        return new Recipe(
+                new RecipeId(UUID.fromString(id)),
+                new RecipeTitle("Test recipe"),
+                new RecipeServings(servings),
+                List.of(ingredients));
+    }
+
+    private static RecipeIngredient ingredient(
+            String id,
+            String requirement,
+            String amount,
+            QuantityUnit unit) {
+        return new RecipeIngredient(
+                new RecipeIngredientId(UUID.fromString(id)),
+                new ShoppingRequirement(requirement),
+                new Quantity(new BigDecimal(amount), unit));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanTest.java
@@ -1,0 +1,148 @@
+package io.github.trueruslan.zakupgotov.weeklyplan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.recipe.Recipe;
+import io.github.trueruslan.zakupgotov.recipe.RecipeId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredient;
+import io.github.trueruslan.zakupgotov.recipe.RecipeIngredientId;
+import io.github.trueruslan.zakupgotov.recipe.RecipeServings;
+import io.github.trueruslan.zakupgotov.recipe.RecipeTitle;
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class WeeklyPlanTest {
+
+    private static final WeeklyPlanId PLAN_ID =
+            new WeeklyPlanId(UUID.fromString("81000000-0000-0000-0000-000000000001"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_A =
+            new WeeklyMealOccurrenceId(UUID.fromString("82000000-0000-0000-0000-000000000001"));
+    private static final WeeklyMealOccurrenceId OCCURRENCE_B =
+            new WeeklyMealOccurrenceId(UUID.fromString("82000000-0000-0000-0000-000000000002"));
+
+    @Test
+    void preservesExplicitOrderAcrossDaysAndAllowsMultipleMealsOnOneDay() {
+        var recipeA = recipe("83000000-0000-0000-0000-000000000001");
+        var recipeB = recipe("83000000-0000-0000-0000-000000000002");
+        var tuesday = new WeeklyMealOccurrence(
+                OCCURRENCE_A, WeeklyPlanDay.TUESDAY, recipeA, new RecipeServings(2));
+        var monday = new WeeklyMealOccurrence(
+                OCCURRENCE_B, WeeklyPlanDay.MONDAY, recipeB, new RecipeServings(4));
+
+        var plan = new WeeklyPlan(PLAN_ID, List.of(tuesday, monday));
+
+        assertThat(plan.id()).isEqualTo(PLAN_ID);
+        assertThat(plan.occurrences()).containsExactly(tuesday, monday);
+
+        var sameDayPlan = new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_A, WeeklyPlanDay.WEDNESDAY, recipeA, new RecipeServings(1)),
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_B, WeeklyPlanDay.WEDNESDAY, recipeB, new RecipeServings(1))));
+        assertThat(sameDayPlan.occurrences()).hasSize(2);
+    }
+
+    @Test
+    void allowsSameRecipeMoreThanOnceWhenOccurrenceIdsDiffer() {
+        var sharedRecipe = recipe("83000000-0000-0000-0000-000000000011");
+
+        var plan = new WeeklyPlan(
+                PLAN_ID,
+                List.of(
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_A, WeeklyPlanDay.MONDAY, sharedRecipe, new RecipeServings(1)),
+                        new WeeklyMealOccurrence(
+                                OCCURRENCE_B, WeeklyPlanDay.FRIDAY, sharedRecipe, new RecipeServings(3))));
+
+        assertThat(plan.occurrences()).extracting(occurrence -> occurrence.recipe().id())
+                .containsExactly(sharedRecipe.id(), sharedRecipe.id());
+    }
+
+    @Test
+    void defensivelyCopiesOccurrencesAndExposesImmutableOrder() {
+        var mutable = new ArrayList<WeeklyMealOccurrence>();
+        mutable.add(new WeeklyMealOccurrence(
+                OCCURRENCE_A,
+                WeeklyPlanDay.THURSDAY,
+                recipe("83000000-0000-0000-0000-000000000021"),
+                new RecipeServings(2)));
+
+        var plan = new WeeklyPlan(PLAN_ID, mutable);
+        mutable.add(new WeeklyMealOccurrence(
+                OCCURRENCE_B,
+                WeeklyPlanDay.SATURDAY,
+                recipe("83000000-0000-0000-0000-000000000022"),
+                new RecipeServings(2)));
+
+        assertThat(plan.occurrences()).hasSize(1);
+        assertThatThrownBy(() -> plan.occurrences().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsMissingOrEmptyPlanStateAndDuplicateOccurrenceIdentity() {
+        var occurrence = new WeeklyMealOccurrence(
+                OCCURRENCE_A,
+                WeeklyPlanDay.MONDAY,
+                recipe("83000000-0000-0000-0000-000000000031"),
+                new RecipeServings(1));
+
+        assertThatThrownBy(() -> new WeeklyPlan(null, List.of(occurrence)))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyPlan(PLAN_ID, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyPlan(PLAN_ID, List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new WeeklyPlan(PLAN_ID, java.util.Arrays.asList(occurrence, null)))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyPlan(PLAN_ID, List.of(occurrence, occurrence)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void occurrenceRejectsMissingFieldsAndRecipeServingsRejectsNonPositiveCounts() {
+        var recipe = recipe("83000000-0000-0000-0000-000000000041");
+        var servings = new RecipeServings(1);
+
+        assertThatThrownBy(() -> new WeeklyMealOccurrence(null, WeeklyPlanDay.MONDAY, recipe, servings))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyMealOccurrence(OCCURRENCE_A, null, recipe, servings))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyMealOccurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, null, servings))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyMealOccurrence(OCCURRENCE_A, WeeklyPlanDay.MONDAY, recipe, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new RecipeServings(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RecipeServings(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void identifierValueObjectsRejectNullUuids() {
+        assertThatThrownBy(() -> new WeeklyPlanId(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new WeeklyMealOccurrenceId(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private static Recipe recipe(String id) {
+        return new Recipe(
+                new RecipeId(UUID.fromString(id)),
+                new RecipeTitle("Test recipe"),
+                new RecipeServings(2),
+                List.of(new RecipeIngredient(
+                        new RecipeIngredientId(UUID.randomUUID()),
+                        new ShoppingRequirement("Milk"),
+                        new Quantity(new BigDecimal("500"), QuantityUnit.MILLILITER))));
+    }
+}

--- a/docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md
+++ b/docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md
@@ -1,0 +1,144 @@
+# M3.1 WeeklyPlan Domain + Deterministic Shopping Composition — Shipping Evidence
+
+Date: 2026-08-14  
+Issue: #109  
+PR: #110  
+Status: **IMPLEMENTED / TESTED / SHIPPING — acceptance pending**
+
+Authoritative design: `docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md`  
+Implementation plan: `docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md`
+
+## Delivered scope
+
+M3.1 introduces the first pure Weekly Planning domain/application boundary:
+
+`ordered WeeklyPlan meal occurrences → deterministic M2.5 aggregation entries → one canonical weekly ShoppingList + WeeklyMealOccurrence provenance`
+
+Delivered behavior:
+
+- immutable `WeeklyPlanId`, `WeeklyMealOccurrenceId`, `WeeklyPlanDay`, `WeeklyMealOccurrence` and `WeeklyPlan`;
+- ordered non-empty meal occurrences across Monday through Sunday;
+- multiple occurrences may share one day;
+- the same Recipe may be used more than once through distinct occurrence IDs;
+- each occurrence owns an accepted positive `RecipeServings` target;
+- there is deliberately no BREAKFAST/LUNCH/DINNER/SNACK slot vocabulary;
+- caller occurrence order is preserved and is not re-sorted by day;
+- deterministic weekly ShoppingList identity derives from WeeklyPlanId;
+- deterministic internal M2.5 aggregation-entry identity derives from WeeklyPlanId + WeeklyMealOccurrenceId;
+- `WeeklyPlanShoppingListComposer` invokes the accepted `RecipeShoppingListAggregator` exactly once;
+- M2.5 remains authoritative for serving scaling, source-unit canonicalization, exact merge keys, canonical sums, first-compatible output order and final ShoppingItem IDs;
+- planner output preserves the exact M2.5 ShoppingList instance and projects lineage to `WeeklyMealOccurrenceId + RecipeIngredientRef`;
+- internal `RecipeAggregationEntryId` does not escape the planner result;
+- day and serving changes do not perturb ShoppingItem identity when WeeklyPlanId + normalized requirement + canonical unit remain unchanged;
+- reordering occurrences may change output group order but not IDs for unchanged merge keys in the same plan;
+- invalid planner identity/provenance states fail closed;
+- planner provenance maps and nested lineage lists are deep immutable;
+- no persistence, HTTP/OpenAPI/generated client, web UI, pantry/exclusions, nutrition, provider/retailer, comparison or AI/fuzzy behavior was introduced.
+
+## Explicit TDD evidence
+
+### WeeklyPlan domain
+
+RED head `4fc807aef66a2d861f3707477186ce29c3d7a022`:
+
+- test-only `WeeklyPlanTest` was added before production types;
+- API CI reached `testCompile` and failed only on intentionally absent `WeeklyPlanId`, `WeeklyMealOccurrenceId`, `WeeklyMealOccurrence`, `WeeklyPlanDay` and `WeeklyPlan` symbols;
+- there was no infrastructure or unrelated regression failure.
+
+GREEN head `f9f8f4372dab7c15aa4e5c08fc1f0d841ca3be04`:
+
+- minimal five-type WeeklyPlan domain implementation added;
+- full API/Maven verification SUCCESS;
+- domain tests prove multi-day/multi-meal construction, repeated Recipe use, explicit order, defensive-copy immutability and fail-closed null/empty/duplicate identity behavior.
+
+### WeeklyPlan → ShoppingList composition
+
+RED head `3faa4c8a93ee725082264751079a23fbd43f28b4`:
+
+- test-only `WeeklyPlanShoppingListComposerTest` was added before composer/result/identity types;
+- API CI failed at `testCompile` on intentionally absent `WeeklyPlanShoppingListComposer` and `WeeklyPlanIngredientRef` plus downstream type-inference cascades caused by those absent result types;
+- already-accepted WeeklyPlan domain types compiled.
+
+GREEN head `5b2cf92f9f3c1caa071a953f977fb09fce090697`:
+
+- composer, planner provenance/result types and package-private aggregation/identity seams were added;
+- full API/Maven verification SUCCESS;
+- two weekly occurrences contributing `0.5 LITER` and `250 MILLILITER`, with independent target-serving scaling, produce one exact `Milk 1500 MILLILITER` final item through accepted M2.5;
+- repeated use of the same Recipe remains distinct through WeeklyMealOccurrence provenance;
+- caller order remains authoritative rather than day sorting;
+- ShoppingItem identity is stable across day/serving changes and scoped by WeeklyPlanId;
+- reordering occurrences can reorder output groups without changing unchanged merge-key IDs.
+
+### Fail-closed provenance hardening
+
+RED head `a2aeb7e9fdb45b646cb0d19407acca1291bf6cf1`:
+
+- hardening suite added seven invariant tests;
+- full Maven run: **315 tests, exactly 3 failures, 0 errors, 5 skipped**;
+- the only failures were the intended missing protections:
+  1. final ShoppingItem without provenance;
+  2. orphan provenance ShoppingItemId;
+  3. empty provenance lineage list;
+- existing tests already passed for unknown internal aggregation entry identity, generated internal-ID collision, null derived ShoppingListId/null plan and deep immutability/exact ShoppingList preservation;
+- all M3.1 happy-path/domain tests and all existing Recipe/M2.5 regressions remained green.
+
+GREEN head `25677c697292f63649579720e02aefd666093322`:
+
+- only exact ShoppingList/provenance key-set validation and non-empty lineage validation were added;
+- projection now iterates final ShoppingList order after structural validation;
+- full API/Maven verification SUCCESS.
+
+## Deterministic identity boundary
+
+Default package-private `WeeklyPlanIds` uses UTF-8 `UUID.nameUUIDFromBytes` over versioned payloads:
+
+```text
+zakup-gotov:weekly-plan-shopping-list:v1:<weeklyPlanId>
+zakup-gotov:weekly-plan-aggregation-entry:v1:<weeklyPlanId>:<weeklyMealOccurrenceId>
+```
+
+Final ShoppingItem IDs are not reimplemented in `weeklyplan`; M2.5 derives them from the resulting weekly ShoppingListId + accepted normalized requirement + canonical unit semantics.
+
+## Architecture / scope evidence
+
+Architecture checkpoint head `f3874d21b3569964a20d5b1bfb17c07ac250a821` adds `WeeklyPlanArchitectureTest` using the repository's existing ArchUnit test stack.
+
+The guard proves:
+
+- `weeklyplan` production package exists;
+- project-level dependencies from `weeklyplan` are limited to `recipe` and `shopping`;
+- `weeklyplan` does not reach into preview, recipe-preview/composition adapters, provider, retailer, matching, basket, comparison, database or Spring Web packages;
+- accepted `recipe` and `shopping` packages remain independent from `weeklyplan`.
+
+Full API/Maven/Testcontainers/Modulith/ArchUnit verification on `f3874d21b3569964a20d5b1bfb17c07ac250a821` — SUCCESS.
+
+No production changes were made to OpenAPI, generated TypeScript client, web, database, retailer bridge, provider acquisition or comparison layers.
+
+## Repository-wide shipping gate
+
+This document creates a new final PR head. Earlier green workflow runs are implementation evidence only and are not reused as acceptance proof.
+
+Before merge, the exact final head must have all nine normal PR workflow groups SUCCESS:
+
+- API CI;
+- Contract CI;
+- Web CI including responsive E2E;
+- CodeQL Java + JavaScript/TypeScript;
+- Dependency Review;
+- Container Security CI;
+- Retailer Bridge CI;
+- Release Contract CI;
+- Release Bundle CI.
+
+A read-only final review must also report no unresolved P0/P1/P2 findings and no unresolved review threads.
+
+## Remaining acceptance gates
+
+M3.1 is **not ACCEPTED** until:
+
+1. all nine normal PR workflow groups succeed on one exact final head;
+2. final read-only review is clean;
+3. PR #110 is made ready and squash-merged using exact-head protection;
+4. issue #109 closes as completed through the merged PR;
+5. all normal push-triggered workflows succeed on the merged `main` SHA;
+6. only then a separate canonical docs-only acceptance PR marks M3.1 `COMPLETE / ACCEPTED` and advances current focus to **M3.2 stateless WeeklyPlan application/API boundary**.

--- a/docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md
+++ b/docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md
@@ -1,0 +1,279 @@
+# M3.1 WeeklyPlan Domain + Deterministic Shopping Composition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce an immutable WeeklyPlan domain and a deterministic planner-to-shopping composer that delegates all Recipe scaling/canonicalization/merge/ShoppingItem identity behavior to accepted M2.5 multi-recipe aggregation while projecting complete lineage back to WeeklyPlan meal occurrences.
+
+**Architecture:** Add a new inward-facing `weeklyplan` package. `WeeklyPlan` owns planner identity, day metadata, ordered meal occurrences and target servings. `WeeklyPlanShoppingListComposer` deterministically maps occurrences to accepted `RecipeAggregationEntry` inputs, invokes M2.5 exactly once through a narrow package-private boundary, and projects aggregation provenance to planner provenance. Deterministic WeeklyPlan ShoppingList/aggregation-entry UUID derivation lives behind a package-private identity seam so collision/failure behavior can be tested without modifying accepted Recipe code.
+
+**Tech Stack:** Java 25, JUnit 5, AssertJ, Spring Modulith verification, Maven/Testcontainers repository baseline.
+
+## Global Constraints
+
+- M3.1 is pure domain/application work: no REST/OpenAPI/generated client/web/persistence/database/provider/retailer/comparison changes.
+- `weeklyplan` may depend only on accepted `recipe`, the finite `shopping` value/aggregate types required by its result, and JDK classes.
+- `recipe` and `shopping` must not depend on `weeklyplan`.
+- WeeklyPlan day metadata never participates in Recipe merge keys, quantity arithmetic or final ShoppingItem identity.
+- No breakfast/lunch/dinner/snack slot vocabulary.
+- Same Recipe may appear repeatedly under distinct `WeeklyMealOccurrenceId` values.
+- WeeklyPlan occurrence order is explicit caller order and is never auto-sorted by day.
+- M2.5 remains authoritative for serving scaling, source-unit canonicalization, exact cross-Recipe merge, first-compatible ordering and final ShoppingItem IDs.
+- Planner provenance contains `WeeklyMealOccurrenceId + RecipeIngredientRef`; internal `RecipeAggregationEntryId` does not escape the composer.
+- All public outputs are deeply immutable and invalid identity/provenance states fail closed.
+
+---
+
+### Task 1: Lock WeeklyPlan domain contract with RED tests
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanTest.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanId.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrenceId.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanDay.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyMealOccurrence.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlan.java`
+
+**Public interfaces:**
+
+```java
+public record WeeklyPlanId(UUID value) {}
+public record WeeklyMealOccurrenceId(UUID value) {}
+public enum WeeklyPlanDay {
+    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+}
+public record WeeklyMealOccurrence(
+    WeeklyMealOccurrenceId id,
+    WeeklyPlanDay day,
+    Recipe recipe,
+    RecipeServings targetServings) {}
+public record WeeklyPlan(
+    WeeklyPlanId id,
+    List<WeeklyMealOccurrence> occurrences) {}
+```
+
+- [ ] **Step 1: Add RED domain tests only**
+
+Cover:
+- valid multi-day plan;
+- multiple occurrences on one day;
+- same Recipe object/RecipeId repeated under distinct occurrence IDs;
+- exact caller occurrence order preservation;
+- defensive copy/immutable occurrence list;
+- null WeeklyPlanId;
+- null/empty occurrence list;
+- null occurrence;
+- duplicate `WeeklyMealOccurrenceId`;
+- null occurrence ID/day/Recipe/target servings;
+- non-positive target servings through accepted `RecipeServings` construction.
+
+- [ ] **Step 2: Run API CI and preserve expected RED**
+
+Expected failure: compilation errors for intentionally absent `weeklyplan` production types, not infrastructure failures or unrelated regressions.
+
+- [ ] **Step 3: Implement minimal domain types**
+
+Use `Objects.requireNonNull`, `List.copyOf`, a `HashSet` duplicate-occurrence check and existing `RecipeServings` validation. Do not add dates, labels, slots, persistence fields or helper behavior not required by tests/spec.
+
+- [ ] **Step 4: Run API verification GREEN**
+
+Require all new domain tests and existing Recipe/M2.5 tests to pass.
+
+### Task 2: Define deterministic planner identity seam and composition result
+
+**Files:**
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIngredientRef.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposition.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIdentityDeriver.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanIds.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/RecipeAggregationBoundary.java`
+- Create later in GREEN: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java`
+- Create RED tests: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerTest.java`
+
+**Public result:**
+
+```java
+public record WeeklyPlanIngredientRef(
+    WeeklyMealOccurrenceId occurrenceId,
+    RecipeIngredientRef recipeIngredient) {}
+
+public record WeeklyPlanShoppingListComposition(
+    ShoppingList shoppingList,
+    Map<ShoppingItemId, List<WeeklyPlanIngredientRef>> provenance) {}
+```
+
+**Package-private seams:**
+
+```java
+interface RecipeAggregationBoundary {
+    RecipeShoppingListAggregation aggregate(
+        List<RecipeAggregationEntry> entries,
+        ShoppingListId shoppingListId);
+}
+
+interface WeeklyPlanIdentityDeriver {
+    ShoppingListId shoppingListId(WeeklyPlanId planId);
+    RecipeAggregationEntryId aggregationEntryId(
+        WeeklyPlanId planId,
+        WeeklyMealOccurrenceId occurrenceId);
+}
+```
+
+Default `WeeklyPlanIds` derivation uses UTF-8 `UUID.nameUUIDFromBytes` over exactly:
+
+```text
+zakup-gotov:weekly-plan-shopping-list:v1:<weeklyPlanId>
+zakup-gotov:weekly-plan-aggregation-entry:v1:<weeklyPlanId>:<weeklyMealOccurrenceId>
+```
+
+- [ ] **Step 1: Add composition RED for one accepted M2.5 merge path**
+
+Construct two WeeklyPlan occurrences contributing compatible `Milk` quantities through different recipes/days and target servings. Require one canonical final item with exact M2.5 quantity and planner provenance ordered by occurrence.
+
+- [ ] **Step 2: Add repeated-Recipe and ordering RED**
+
+Require:
+- same Recipe used twice is distinguishable via two WeeklyMealOccurrenceIds in provenance;
+- first compatible WeeklyPlan occurrence determines final group order;
+- day value does not sort/reorder aggregation input.
+
+- [ ] **Step 3: Add deterministic identity RED**
+
+For same WeeklyPlanId + requirement + canonical unit:
+- target-serving changes preserve ShoppingItem ID;
+- day-only changes preserve ShoppingItem ID and quantity;
+- occurrence reordering preserves IDs for unchanged merge keys while output order may change;
+- changing WeeklyPlanId changes final ShoppingListId and ShoppingItem IDs.
+
+- [ ] **Step 4: Run focused API CI and preserve RED**
+
+Expected failure is absence of composer/result/identity seam production types.
+
+- [ ] **Step 5: Implement minimal result types, identity seam and composer**
+
+Default composer constructor:
+
+```java
+public WeeklyPlanShoppingListComposer() {
+    this(new RecipeShoppingListAggregator()::aggregate, WeeklyPlanIds.INSTANCE);
+}
+```
+
+Package-private constructor accepts `RecipeAggregationBoundary` and `WeeklyPlanIdentityDeriver` for invariant/collision tests.
+
+Composition algorithm:
+1. reject null plan;
+2. derive one weekly ShoppingListId;
+3. derive one unique internal `RecipeAggregationEntryId` per occurrence and retain `entryId -> occurrenceId` in insertion order;
+4. fail closed if two distinct occurrences derive the same internal ID or any derived ID is null;
+5. build ordered `RecipeAggregationEntry` list using occurrence Recipe + target servings;
+6. invoke `RecipeAggregationBoundary.aggregate(...)` exactly once;
+7. validate aggregate ShoppingList/provenance key completeness;
+8. translate every `RecipeAggregationIngredientRef` through the internal map into `WeeklyPlanIngredientRef` without modifying `RecipeIngredientRef`;
+9. preserve aggregate provenance order and return exact aggregate ShoppingList;
+10. do not read/use day for aggregation semantics.
+
+- [ ] **Step 6: Run focused composer + M2.5 regression GREEN**
+
+### Task 3: Fail-closed provenance, collision and immutability hardening
+
+**Files:**
+- Modify: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposerTest.java`
+- Modify as needed: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposer.java`
+- Modify as needed: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanShoppingListComposition.java`
+
+- [ ] **Step 1: Add hardening RED tests**
+
+Inject seams to require fail-closed behavior for:
+- null plan;
+- null derived ShoppingListId;
+- two different occurrences deriving the same `RecipeAggregationEntryId`;
+- aggregate result with missing provenance for a final ShoppingItem;
+- aggregate provenance with an orphan ShoppingItemId;
+- empty aggregate provenance list;
+- aggregate provenance containing unknown internal `RecipeAggregationEntryId`;
+- null aggregate result / null lineage values if reachable through injected boundary;
+- returned planner provenance map and nested lists are immutable.
+
+- [ ] **Step 2: Run API CI and confirm failures are only intended hardening gaps**
+
+Existing happy-path composer/domain/M2.5 tests must remain green.
+
+- [ ] **Step 3: Implement only missing validation/defensive-copy behavior**
+
+No fallback, silent skipping, logging-driven recovery or semantic repair. Invalid aggregate evidence is an internal invariant failure (`IllegalStateException`); invalid caller input remains `NullPointerException`/`IllegalArgumentException` consistent with existing domain style.
+
+- [ ] **Step 4: Re-run focused + full API verification GREEN**
+
+### Task 4: Architecture boundary regression
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/weeklyplan/WeeklyPlanArchitectureTest.java` if a direct package dependency assertion can be expressed with existing test dependencies.
+- Always rely on existing: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/ApplicationArchitectureTest.java`
+
+- [ ] **Step 1: Inspect available architecture-test primitives before adding a dependency**
+
+Do not add ArchUnit or another library solely for M3.1 if it is not already present. Prefer existing Spring Modulith `ApplicationModules.verify()` plus a small source/class dependency guard using existing repository facilities.
+
+- [ ] **Step 2: Add the smallest guard that proves scope**
+
+Require weeklyplan production code to avoid dependencies on:
+`preview`, `recipepreview`, `recipecomparisonpreview`, `provider`, `retailer`, `matching`, `basket`, `comparison`, `database` and HTTP/controller packages; verify existing `recipe`/`shopping` code has no dependency on `weeklyplan`.
+
+- [ ] **Step 3: Full Maven/Testcontainers/Modulith GREEN**
+
+No changes to Spring runtime wiring, database schema, OpenAPI or web are expected.
+
+### Task 5: Shipping evidence and exact-head acceptance gate
+
+**Files:**
+- Update: `CHANGELOG.md`
+- Create: `docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md`
+- Update `docs/PROJECT_STATE.md` only to **M3.1 IMPLEMENTED / TESTED / SHIPPING — acceptance pending** before merge if needed for current-state accuracy; do not mark ACCEPTED pre-merge.
+- Update `docs/ROADMAP.md` only conservatively; M3.2 is not active until M3.1 post-merge acceptance.
+
+- [ ] **Step 1: Record explicit RED→GREEN commit evidence**
+
+Shipping memo must identify domain RED/GREEN, composition RED/GREEN and hardening RED/GREEN heads and what each failure/proof established.
+
+- [ ] **Step 2: Exact-head full PR CI**
+
+Require all nine normal PR workflow groups SUCCESS on one final head:
+- API CI;
+- Contract CI;
+- Web CI / responsive E2E;
+- CodeQL;
+- Dependency Review;
+- Container Security CI;
+- Retailer Bridge CI;
+- Release Contract CI;
+- Release Bundle CI.
+
+- [ ] **Step 3: Read-only final review**
+
+Review:
+- WeeklyPlan invariants;
+- day-vs-order semantics;
+- repeated Recipe occurrence behavior;
+- deterministic list/entry identities;
+- exact M2.5 delegation;
+- planner provenance completeness/order/immutability;
+- collision/failure paths;
+- dependency direction and scope containment.
+
+Block unresolved P0/P1/P2 and clear all review threads.
+
+- [ ] **Step 4: Squash merge with exact-head protection**
+
+Issue #109 may become merged/closed only through the PR once the exact reviewed head is green.
+
+- [ ] **Step 5: Post-merge acceptance**
+
+Require exactly the normal push workflows on merged `main` to finish green. Only then mark M3.1 `COMPLETE / ACCEPTED` in a separate canonical docs-only acceptance PR and advance current focus to **M3.2 stateless WeeklyPlan application/API boundary**.
+
+## Plan Self-Review
+
+- Spec coverage: WeeklyPlan identity/day/order, repeated Recipe occurrences, per-occurrence servings, M2.5 delegation, deterministic IDs, provenance projection, immutability, fail-closed behavior, architecture and shipping gates are mapped to concrete tasks.
+- Placeholder scan: no TODO/TBD or undecided semantics remain.
+- Type consistency: WeeklyMealOccurrence uses accepted `Recipe` and `RecipeServings`; planner provenance wraps accepted `RecipeIngredientRef`; Shopping result reuses accepted `ShoppingList`/`ShoppingItemId`.
+- Scope containment: no persistence, API, UI, pantry, retailer, comparison, nutrition or AI work is included.
+- Testability: package-private aggregation/identity seams allow malformed provenance and deterministic-ID collision tests without modifying accepted M2.5 production behavior.

--- a/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
+++ b/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
@@ -1,7 +1,7 @@
 # M3.1 — WeeklyPlan Domain + Deterministic Shopping Composition
 
 Date: 2026-08-14  
-Status: DESIGN APPROVED; WRITTEN SPEC AWAITING USER REVIEW  
+Status: AUTHORITATIVE DESIGN — approved for implementation by the user  
 Issue: #109  
 Baseline: `main=7d7df863e8b9218b018f343e46dd7fd7c03396f1`
 
@@ -181,6 +181,8 @@ Final ShoppingItem identity remains entirely owned by M2.5:
 
 Therefore amount, target servings, Recipe occurrence day and occurrence position do not participate directly in ShoppingItem identity.
 
+Reordering occurrences may change final ShoppingItem order because M2.5 uses first-compatible-occurrence ordering, but it does not change ShoppingItem IDs for unchanged merge keys under the same WeeklyPlanId.
+
 ## Provenance
 
 ### Planner provenance type
@@ -190,7 +192,9 @@ Therefore amount, target servings, Recipe occurrence day and occurrence position
 - `WeeklyMealOccurrenceId occurrenceId`;
 - accepted `RecipeIngredientRef recipeIngredient`.
 
-No `RecipeAggregationEntryId` is exposed in the final planner result. `WeeklyPlanDay` is intentionally not duplicated in provenance: callers resolve planner metadata through `occurrenceId` against the same WeeklyPlan, while the provenance value stays a minimal stable lineage reference.
+No `RecipeAggregationEntryId` is exposed in the final planner result.
+
+`WeeklyPlanDay` is intentionally not duplicated into provenance. The occurrence ID resolves to exactly one occurrence in the same WeeklyPlan, and that occurrence owns the day. Planner provenance therefore remains minimal and non-redundant.
 
 ### Projection invariants
 
@@ -215,9 +219,9 @@ The composer sends aggregation entries to M2.5 in exactly that order.
 
 M2.5 remains authoritative for final ShoppingItem order: first compatible normalized requirement + canonical unit occurrence wins the group position.
 
-`WeeklyPlanDay` is not an implicit sort key. Reordering occurrences may therefore change final ShoppingItem order when first compatible occurrences move, but it must not change ShoppingItem identity for unchanged `WeeklyPlanId + normalized requirement + canonical unit` merge keys.
+`WeeklyPlanDay` is not an implicit sort key.
 
-This separation is intentional: the planner records calendar placement; shopping aggregation remains deterministic over explicit planner order.
+This separation is intentional: the planner records calendar placement; shopping aggregation remains deterministic over explicit planner order. Reordering the WeeklyPlan may reorder output groups without changing their deterministic identities.
 
 ## Error handling
 
@@ -279,7 +283,7 @@ Must prove:
 - repeated use of the same Recipe remains unambiguous in provenance;
 - same plan identity + requirement + unit yields stable ShoppingItem ID across target-serving changes;
 - changing only day does not alter ShoppingItem ID or quantity;
-- reordering occurrences can change final item order but not identity for unchanged merge keys;
+- reordering occurrences may change final item order but does not change IDs for unchanged merge keys under the same WeeklyPlanId;
 - changing WeeklyPlanId changes the derived ShoppingList scope and therefore final ShoppingItem IDs;
 - generated internal aggregation-ID collision fails closed through the package-private derivation seam;
 - provenance is deeply immutable;

--- a/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
+++ b/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
@@ -1,0 +1,320 @@
+# M3.1 — WeeklyPlan Domain + Deterministic Shopping Composition
+
+Date: 2026-08-14  
+Status: APPROVED FOR IMPLEMENTATION PLANNING  
+Issue: #109  
+Baseline: `main=7d7df863e8b9218b018f343e46dd7fd7c03396f1`
+
+## Goal
+
+Introduce the first Weekly Planning domain boundary without weakening or duplicating accepted M2 Recipe and multi-recipe aggregation semantics.
+
+A user must be able to express an ordered week of meal occurrences, choose the target servings for each occurrence, and deterministically compose the whole week into one canonical ShoppingList while retaining lineage back to the specific weekly occurrence and Recipe ingredient that caused each shopping requirement.
+
+M3.1 is a pure domain/application slice. It does not expose a public API or UI.
+
+## User and success criteria
+
+Primary user: a person planning several meals for a week before comparing retailer baskets.
+
+M3.1 succeeds when:
+
+1. a weekly plan can contain one or more ordered meal occurrences across Monday through Sunday;
+2. the same Recipe can be included more than once through distinct occurrence identities;
+3. each occurrence can choose its own positive target serving count;
+4. composing the plan delegates all Recipe scaling, canonicalization, merge and final ShoppingItem identity semantics to accepted M2.5 behavior;
+5. every final ShoppingItem has complete ordered provenance back to `WeeklyMealOccurrenceId + RecipeIngredientRef`;
+6. changing only occurrence day or target servings does not change final ShoppingItem identity when `WeeklyPlanId + normalized requirement + canonical unit` are unchanged;
+7. invalid or ambiguous planner identity/provenance states fail closed;
+8. no persistence, transport, web, retailer or comparison semantics are introduced.
+
+## Approved product model
+
+### WeeklyPlan
+
+`WeeklyPlan` is an immutable aggregate with:
+
+- `WeeklyPlanId id`;
+- ordered non-empty `List<WeeklyMealOccurrence> occurrences`.
+
+Rules:
+
+- `id` is required;
+- occurrences are required, non-null and non-empty;
+- no occurrence may be null;
+- `WeeklyMealOccurrenceId` must be unique inside one plan;
+- two occurrences may reference the same `RecipeId` intentionally;
+- two or more occurrences may share the same day;
+- occurrence order is explicit user order and is not automatically re-sorted by day.
+
+### WeeklyPlanDay
+
+`WeeklyPlanDay` is a finite planner-domain enum:
+
+`MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY`.
+
+The day is planner metadata. It does not participate in Recipe merge keys, ShoppingItem identity or quantity arithmetic.
+
+### WeeklyMealOccurrence
+
+Immutable value with:
+
+- `WeeklyMealOccurrenceId id`;
+- `WeeklyPlanDay day`;
+- `Recipe recipe`;
+- `int targetServings`.
+
+Rules:
+
+- all fields are required;
+- `targetServings > 0`;
+- Recipe base-serving validation remains owned by the accepted Recipe aggregate;
+- no fixed `BREAKFAST / LUNCH / DINNER / SNACK` slot exists in M3.1;
+- identical Recipe + day + servings is still valid when occurrence IDs differ.
+
+## Why no fixed meal slots
+
+Three approaches were considered:
+
+1. **Approved: required day + ordered occurrence, no fixed slot.**
+   - Expresses a real weekly plan.
+   - Supports arbitrary numbers of meals per day.
+   - Avoids premature breakfast/lunch/dinner assumptions.
+   - Keeps the first M3 slice small.
+
+2. Ordered Recipe list without day.
+   - Simpler, but does not yet model a week and would immediately require another planner-domain migration.
+
+3. Day + fixed meal slot vocabulary.
+   - More structured, but over-constrains users and introduces conflict/ordering semantics not yet required by evidence.
+
+The approved model preserves day information while keeping slot semantics deferred.
+
+## Package and dependency boundary
+
+New production package:
+
+`io.github.trueruslan.zakupgotov.weeklyplan`
+
+Allowed inward dependencies:
+
+- `recipe`;
+- `shopping` only for canonical ShoppingList/ShoppingItem value types exposed by the composition result.
+
+The `weeklyplan` package owns planner-specific types and composition. Existing `recipe` and `shopping` packages must not depend on `weeklyplan`.
+
+The accepted `recipe` package remains the owner of M2.5 aggregation semantics.
+
+No dependency on provider, retailer, matching, basket, comparison, database, HTTP or web layers is allowed.
+
+## Deterministic composition
+
+### Public application operation
+
+`WeeklyPlanShoppingListComposer.compose(WeeklyPlan plan)`
+
+returns immutable:
+
+`WeeklyPlanShoppingListComposition`
+
+containing:
+
+- canonical `ShoppingList shoppingList`;
+- ordered deep-immutable `Map<ShoppingItemId, List<WeeklyPlanIngredientRef>> provenance`.
+
+### Composition flow
+
+For each occurrence in plan order:
+
+1. derive one internal `RecipeAggregationEntryId` from `WeeklyPlanId + WeeklyMealOccurrenceId`;
+2. create a `RecipeAggregationEntry` with the occurrence Recipe and target servings;
+3. retain an internal one-to-one mapping from derived aggregation entry ID to WeeklyMealOccurrenceId;
+4. derive the final aggregate `ShoppingListId` from `WeeklyPlanId`;
+5. call the accepted `RecipeShoppingListAggregator` exactly once with the ordered aggregation entries and derived ShoppingListId;
+6. project M2.5 provenance from `RecipeAggregationEntryId + RecipeIngredientRef` into `WeeklyMealOccurrenceId + RecipeIngredientRef`;
+7. return the exact ShoppingList produced by M2.5 plus the projected planner provenance.
+
+The composer does not rescale quantities, canonicalize units, merge requirements or re-derive final ShoppingItem IDs itself.
+
+## Deterministic identity rules
+
+### Weekly plan ShoppingList identity
+
+The final `ShoppingListId` is deterministically derived from `WeeklyPlanId` with a versioned namespaced payload.
+
+Logical payload:
+
+`zakup-gotov:weekly-plan-shopping-list:v1:<weeklyPlanId>`
+
+Properties:
+
+- same WeeklyPlanId -> same ShoppingListId;
+- day/order/servings/content changes do not directly alter ShoppingListId;
+- a different WeeklyPlanId produces a different list identity under ordinary deterministic UUID behavior.
+
+### Internal aggregation-entry identity
+
+Each internal `RecipeAggregationEntryId` is deterministically derived from:
+
+`WeeklyPlanId + WeeklyMealOccurrenceId`
+
+with a versioned namespaced payload.
+
+Logical payload:
+
+`zakup-gotov:weekly-plan-aggregation-entry:v1:<weeklyPlanId>:<weeklyMealOccurrenceId>`
+
+Properties:
+
+- the same occurrence identity in another WeeklyPlan is plan-scoped and produces a different internal aggregation identity;
+- changing day, Recipe content or target servings does not alter the internal entry identity;
+- duplicate WeeklyMealOccurrenceId is rejected by WeeklyPlan before composition;
+- any impossible generated-ID collision across distinct occurrences must fail closed rather than overwrite the internal mapping.
+
+The concrete UUID derivation must use the repository's deterministic UUID approach and be isolated behind a package-private seam so collision behavior can be tested without changing the public model.
+
+### Final ShoppingItem identity
+
+Final ShoppingItem identity remains entirely owned by M2.5:
+
+`derived weekly ShoppingListId + normalized requirement + canonical unit`
+
+Therefore amount, target servings, Recipe occurrence day and occurrence position do not participate directly in ShoppingItem identity.
+
+## Provenance
+
+### Planner provenance type
+
+`WeeklyPlanIngredientRef` contains:
+
+- `WeeklyMealOccurrenceId occurrenceId`;
+- accepted `RecipeIngredientRef recipeIngredient`.
+
+No `RecipeAggregationEntryId` is exposed in the final planner result.
+
+### Projection invariants
+
+For every ShoppingItem in the composed ShoppingList:
+
+- provenance entry exists;
+- provenance list is non-empty;
+- every internal aggregation entry ID resolves to exactly one WeeklyMealOccurrenceId in the same plan;
+- projected RecipeIngredientRef is preserved exactly from M2.5;
+- source order from M2.5 is preserved;
+- no provenance key exists for a ShoppingItem absent from the final list;
+- no final ShoppingItem exists without provenance;
+- maps and nested lists are defensively copied and immutable.
+
+Unknown internal aggregation IDs, missing provenance or impossible cardinality/key drift fail closed as internal invariant violations.
+
+## Ordering semantics
+
+WeeklyPlan preserves explicit occurrence input order.
+
+The composer sends aggregation entries to M2.5 in exactly that order.
+
+M2.5 remains authoritative for final ShoppingItem order: first compatible normalized requirement + canonical unit occurrence wins the group position.
+
+`WeeklyPlanDay` is not an implicit sort key.
+
+This separation is intentional: the planner records calendar placement; shopping aggregation remains deterministic over explicit planner order.
+
+## Error handling
+
+Construction fails fast for:
+
+- missing WeeklyPlanId;
+- missing/null/empty occurrence list;
+- null occurrence;
+- duplicate WeeklyMealOccurrenceId;
+- missing occurrence ID/day/Recipe;
+- non-positive target servings.
+
+Composition fails closed for:
+
+- missing plan;
+- deterministic internal ID collision;
+- accepted M2.5 aggregation failure;
+- missing, orphan or empty aggregate provenance;
+- unknown aggregation-entry identity during planner provenance projection;
+- ShoppingList/provenance key drift.
+
+These are domain/application invariant failures. M3.1 does not introduce a public HTTP problem vocabulary.
+
+## Immutability and thread safety
+
+All new public domain/result types are immutable.
+
+- constructor inputs are defensively copied where applicable;
+- returned collections are unmodifiable;
+- nested provenance lists are immutable;
+- composer keeps no mutable shared state;
+- deterministic ID derivation is stateless.
+
+The composer is safe for concurrent reuse assuming the accepted stateless M2.5 aggregator remains so.
+
+## Tests and acceptance criteria
+
+### WeeklyPlan domain tests
+
+Must prove:
+
+- valid multi-day plan construction;
+- multiple occurrences on one day;
+- same Recipe used multiple times through distinct occurrence IDs;
+- explicit occurrence order preservation;
+- rejection of null/missing/empty state;
+- rejection of duplicate occurrence IDs;
+- rejection of non-positive target servings.
+
+### Composition tests
+
+Must prove:
+
+- two compatible requirements across different weekly occurrences merge through M2.5;
+- incompatible requirement/unit combinations remain separate exactly as M2.5 dictates;
+- final quantities match accepted M2.5 canonical arithmetic;
+- final item order follows first compatible occurrence in WeeklyPlan input order;
+- provenance resolves to occurrence ID + exact RecipeIngredientRef;
+- repeated use of the same Recipe remains unambiguous in provenance;
+- same plan identity + requirement + unit yields stable ShoppingItem ID across target-serving changes;
+- changing only day does not alter ShoppingItem ID or quantity;
+- changing WeeklyPlanId changes the derived ShoppingList scope and therefore final ShoppingItem IDs;
+- generated internal aggregation-ID collision fails closed through the package-private derivation seam;
+- provenance is deeply immutable;
+- null plan and provenance drift fail closed.
+
+### Architecture/full verification
+
+Before acceptance:
+
+- focused M3.1 tests GREEN;
+- existing M2.1/M2.5 identity and aggregation regression tests GREEN;
+- full Maven/Testcontainers/Modulith verification GREEN;
+- architecture guard confirms `weeklyplan -> recipe/shopping` only and prevents reverse/downstream coupling;
+- exact-head PR workflow groups GREEN;
+- independent read-only review has no unresolved P0/P1/P2;
+- squash merge is protected by exact head SHA;
+- normal post-merge push workflows on `main` are all GREEN before M3.1 is marked COMPLETE / ACCEPTED.
+
+## Non-goals
+
+M3.1 explicitly does not add:
+
+- persistence or database schema;
+- saved/reusable plan history;
+- REST/OpenAPI/generated TypeScript contracts;
+- weekly planner web UI;
+- breakfast/lunch/dinner/snack slots;
+- timestamps, calendar dates, week-number/time-zone semantics;
+- pantry inventory or exclusion/subtraction semantics;
+- nutrition/macros/calories;
+- Recipe search/catalog/import;
+- AI, fuzzy, synonym or semantic ingredient equivalence;
+- retailer/provider acquisition;
+- comparison orchestration;
+- optimization or multi-store checkout logic.
+
+## Follow-on direction
+
+After M3.1 acceptance, the next evidence-driven slice should be a stateless WeeklyPlan application/API boundary that owns transient planner identities and exposes the accepted weekly composition result without persistence. A responsive Weekly Planning UI follows only after that contract is accepted.

--- a/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
+++ b/docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md
@@ -1,7 +1,7 @@
 # M3.1 — WeeklyPlan Domain + Deterministic Shopping Composition
 
 Date: 2026-08-14  
-Status: APPROVED FOR IMPLEMENTATION PLANNING  
+Status: DESIGN APPROVED; WRITTEN SPEC AWAITING USER REVIEW  
 Issue: #109  
 Baseline: `main=7d7df863e8b9218b018f343e46dd7fd7c03396f1`
 
@@ -190,7 +190,7 @@ Therefore amount, target servings, Recipe occurrence day and occurrence position
 - `WeeklyMealOccurrenceId occurrenceId`;
 - accepted `RecipeIngredientRef recipeIngredient`.
 
-No `RecipeAggregationEntryId` is exposed in the final planner result.
+No `RecipeAggregationEntryId` is exposed in the final planner result. `WeeklyPlanDay` is intentionally not duplicated in provenance: callers resolve planner metadata through `occurrenceId` against the same WeeklyPlan, while the provenance value stays a minimal stable lineage reference.
 
 ### Projection invariants
 
@@ -215,7 +215,7 @@ The composer sends aggregation entries to M2.5 in exactly that order.
 
 M2.5 remains authoritative for final ShoppingItem order: first compatible normalized requirement + canonical unit occurrence wins the group position.
 
-`WeeklyPlanDay` is not an implicit sort key.
+`WeeklyPlanDay` is not an implicit sort key. Reordering occurrences may therefore change final ShoppingItem order when first compatible occurrences move, but it must not change ShoppingItem identity for unchanged `WeeklyPlanId + normalized requirement + canonical unit` merge keys.
 
 This separation is intentional: the planner records calendar placement; shopping aggregation remains deterministic over explicit planner order.
 
@@ -279,6 +279,7 @@ Must prove:
 - repeated use of the same Recipe remains unambiguous in provenance;
 - same plan identity + requirement + unit yields stable ShoppingItem ID across target-serving changes;
 - changing only day does not alter ShoppingItem ID or quantity;
+- reordering occurrences can change final item order but not identity for unchanged merge keys;
 - changing WeeklyPlanId changes the derived ShoppingList scope and therefore final ShoppingItem IDs;
 - generated internal aggregation-ID collision fails closed through the package-private derivation seam;
 - provenance is deeply immutable;


### PR DESCRIPTION
## Summary

Implements #109 using the approved M3.1 authoritative design and implementation plan.

Scope:
- immutable WeeklyPlan domain with ordered day-bound meal occurrences;
- no fixed breakfast/lunch/dinner/snack slots;
- deterministic mapping to accepted M2.5 aggregation;
- weekly ShoppingList identity scoped to WeeklyPlanId;
- internal aggregation-entry identity scoped to WeeklyPlanId + WeeklyMealOccurrenceId;
- planner provenance = WeeklyMealOccurrenceId + accepted RecipeIngredientRef;
- exact M2.5 merge/order/quantity/ShoppingItem identity semantics remain authoritative;
- fail-closed identity/provenance invariants;
- no persistence, REST/OpenAPI, web UI, pantry, provider/retailer or comparison scope.

Authoritative design: `docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md`

Current checkpoint: **DESIGN/PLAN APPROVED — implementation starting with RED tests.**