### PR TITLE
docs(m3): finalize WeeklyPlan domain acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Deep-immutable ordered multi-Recipe provenance plus fail-closed empty input, duplicate occurrence identity, missing provenance and generated-ID collision behavior.
 - M2.5 design, implementation plan, shipping evidence and acceptance decision documenting explicit RED→GREEN checkpoints, reviewed head `a6e1095696ebfd67fafe7675a37b125ae02b3170`, squash merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0` and 8/8 successful post-merge `main` workflows.
 
+#### Weekly planning
+
+- M3.1 immutable `WeeklyPlan` domain with stable plan/meal-occurrence identities, required Monday-through-Sunday metadata, positive per-occurrence target servings and explicit caller ordering.
+- Weekly plans allow multiple meals on the same day and repeated use of one Recipe through distinct `WeeklyMealOccurrenceId` values without imposing premature breakfast/lunch/dinner/snack slots.
+- Deterministic WeeklyPlan-scoped ShoppingList identity and internal M2.5 aggregation-entry identity use versioned namespaced UUID payloads based on `WeeklyPlanId` and `WeeklyMealOccurrenceId`.
+- `WeeklyPlanShoppingListComposer` delegates Recipe scaling, canonicalization, exact cross-Recipe merge, canonical arithmetic, final ordering and ShoppingItem identity to the accepted M2.5 aggregator rather than duplicating those semantics.
+- Planner provenance projects accepted M2.5 lineage to ordered `WeeklyMealOccurrenceId + RecipeIngredientRef` while internal `RecipeAggregationEntryId` remains hidden.
+- Fail-closed WeeklyPlan composition rejects deterministic internal-ID collisions, missing/orphan/empty ShoppingItem provenance and unknown aggregation-entry lineage.
+- ArchUnit guards constrain `weeklyplan` production dependencies to accepted `recipe`/`shopping` packages and protect reverse dependency direction.
+- M3.1 design, implementation plan, shipping evidence and acceptance decision document domain/composition/hardening RED→GREEN chains, reviewed head `ec1af08cbaf373f79c54858e9654451cebc4f009`, squash merge `13e09c63959b050d431cc913597fc868aa408718` and 8/8 successful post-merge `main` workflows.
+
 #### Product and shopping core
 
 - Canonical eight-retailer registry with independent technical-connectivity and production-access states.
@@ -92,7 +103,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 
 ### Changed
 
-- Project phase advanced from M0 Product & Integration Discovery to M1 Shopping Core, then to M2 Recipes, and after accepted M2.5 to **M3 Weekly Planning**.
+- Project phase advanced from M0 Product & Integration Discovery to M1 Shopping Core, then M2 Recipes, and now **M3 Weekly Planning**.
 - M1 Shopping Core is **COMPLETE / ACCEPTED** on the post-merge pre-acquisition-gate baseline `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 - The M1→M2 decision is **GO for deterministic product/core development**; it does not claim every retailer is production-ready.
 - M2.1 `Recipe → explicit ingredients → canonical quantities → ShoppingList` is **COMPLETE / ACCEPTED** after squash merge `423eb14f7c565bbe264257a92df89a6b42d0d158` and 8/8 successful post-merge `main` workflows.
@@ -100,12 +111,15 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M2.3 composed Recipe → Comparison boundary is **COMPLETE / ACCEPTED** after final reviewed head `b6575f03b668f8bbaacd5b2897c4fb9301d94cdf`, squash merge `15a086d135f40277c655b39549c3e7a04c2e914e`, issue #100 closure and 8/8 successful post-merge `main` workflows.
 - M2.4 responsive Recipe UI is **COMPLETE / ACCEPTED** after final reviewed head `fb069d64b96f0d989951e67fd62b793277453024`, squash merge `aba20c9cee263a683c0d4383ad840d7415851861`, issue #103 closure and 8/8 successful post-merge `main` workflows.
 - M2.5 deterministic multi-Recipe aggregation is **COMPLETE / ACCEPTED** after final reviewed head `a6e1095696ebfd67fafe7675a37b125ae02b3170`, squash merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`, issue #106 closure and 8/8 successful post-merge `main` workflows.
-- M2 Recipes is **COMPLETE / ACCEPTED**; the deterministic roadmap now advances to **M3 Weekly Planning**, beginning with planner-specific domain/application semantics over accepted M2.5 aggregation.
+- M2 Recipes is **COMPLETE / ACCEPTED**.
+- M3.1 WeeklyPlan domain + deterministic shopping composition is **COMPLETE / ACCEPTED** after final reviewed head `ec1af08cbaf373f79c54858e9654451cebc4f009`, squash merge `13e09c63959b050d431cc913597fc868aa408718`, issue #109 closure and 8/8 successful post-merge `main` workflows.
+- The current deterministic target is **M3.2 stateless WeeklyPlan application/API boundary**; persistence, pantry subtraction, comparison orchestration and planner UI remain later explicit slices.
 - Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
 - Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`; M2.2 projects that provenance publicly as self-contained source ingredient IDs instead of modifying Shopping Core types.
 - Recipe lifecycle and the first Weekly Planning direction remain stateless by default; persistence stays deferred until reusable saved plans/history demonstrate product value.
 - Recipe → Comparison has an accepted primary product boundary at `/api/v1/recipe-comparison-previews`; M2.4 consumes it directly as the primary Recipe-first browser journey.
 - Multi-Recipe aggregation distinguishes Recipe identity from occurrence identity; repeated Recipe use is valid only through distinct occurrence IDs and does not weaken accepted exact merge semantics.
+- WeeklyPlan distinguishes planner occurrence identity from Recipe identity and keeps day metadata outside Recipe/Shopping merge and quantity semantics.
 - Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
 - `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.
@@ -136,6 +150,8 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - Shared Recipe ShoppingItem-ID extraction preserves the accepted literal single-Recipe UUID fixture instead of silently changing historical IDs.
 - Multi-Recipe aggregation rejects an empty occurrence set and duplicate aggregation occurrence IDs instead of producing an empty/ambiguous aggregate.
 - Multi-Recipe aggregation rejects generated final ShoppingItem-ID collisions across different merge keys and missing/empty converted provenance instead of silently overwriting lineage.
+- WeeklyPlan rejects missing/empty occurrence state and duplicate meal-occurrence identity rather than producing an ambiguous planner aggregate.
+- WeeklyPlan composition rejects missing/orphan/empty ShoppingItem provenance, unknown internal aggregation lineage and deterministic internal aggregation-ID collisions rather than repairing or silently dropping evidence.
 - Provider offer validation rejects provenance/context mismatches before comparison logic.
 - Precise addresses are excluded from default string representations and provider routing.
 - Snapshot freshness rejects provider timestamps after observation time.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -4,20 +4,25 @@ Updated: 2026-08-14
 
 ## Project
 
-**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is to turn recipes, meal plans or a manual grocery list into a location-aware comparison of complete retailer baskets while preserving price/availability evidence, package semantics, provenance, freshness and uncertainty.
+**Zakup Gotov** is a recipe-to-cart grocery comparison product. The target experience is to turn recipes, weekly meal plans or a manual grocery list into a location-aware comparison of complete retailer baskets while preserving price/availability evidence, package semantics, provenance, freshness and uncertainty.
 
 Repository: `True-Ruslan/zakup-gotov`  
 Visibility: Public  
-Current phase: **M3 — Weekly Planning**  
-M0 status: **technical discovery COMPLETE**  
-M1 status: **Shopping Core COMPLETE / ACCEPTED**  
-M2 status: **Recipes COMPLETE / ACCEPTED**  
-M2.1 status: **Recipe domain + Recipe → ShoppingList COMPLETE / ACCEPTED (#94 / #93)**  
-M2.2 status: **Recipe application/API boundary COMPLETE / ACCEPTED (#97 / #96)**  
-M2.3 status: **Recipe → Comparison composition COMPLETE / ACCEPTED (#101 / #100)**  
-M2.4 status: **Responsive Recipe UI COMPLETE / ACCEPTED (#104 / #103)**  
-M2.5 status: **Deterministic multi-recipe aggregation COMPLETE / ACCEPTED (#107 / #106)**  
-Current focus: **design the first M3 Weekly Planning domain/application slice over accepted M2.5 aggregation semantics**
+Current phase: **M3 — Weekly Planning**
+
+Milestone status:
+
+- M0 Product & Integration Discovery — **COMPLETE**;
+- M1 Shopping Core — **COMPLETE / ACCEPTED**;
+- M2 Recipes — **COMPLETE / ACCEPTED**;
+- M2.1 Recipe domain + Recipe → ShoppingList — **COMPLETE / ACCEPTED** (#94 / #93);
+- M2.2 Recipe application/API boundary — **COMPLETE / ACCEPTED** (#97 / #96);
+- M2.3 Recipe → Comparison composition — **COMPLETE / ACCEPTED** (#101 / #100);
+- M2.4 Responsive Recipe UI — **COMPLETE / ACCEPTED** (#104 / #103);
+- M2.5 Deterministic multi-recipe aggregation — **COMPLETE / ACCEPTED** (#107 / #106);
+- M3.1 WeeklyPlan domain + deterministic shopping composition — **COMPLETE / ACCEPTED** (#110 / #109).
+
+Current focus: **design M3.2 stateless WeeklyPlan application/API boundary**.
 
 ## Permanent connectivity rule
 
@@ -31,13 +36,7 @@ Technical feasibility, production-access readiness and deterministic product/cor
 
 ### M0 — Product & Integration Discovery — COMPLETE
 
-Accepted evidence established:
-
-- Perekrestok and Pyaterochka browser-bridge acquisition paths;
-- Magnit public-web acquisition path;
-- at least two acquisition modes;
-- deterministic sanitized fixtures/E2E and finite guarded probes;
-- provider-neutral retailer architecture.
+Accepted evidence established Perekrestok/Pyaterochka browser-bridge acquisition, Magnit public-web technical feasibility, at least two acquisition modes, deterministic sanitized fixtures/E2E and provider-neutral retailer architecture.
 
 M0 proves technical feasibility only. It does not establish blanket permission for recurring production acquisition.
 
@@ -46,20 +45,81 @@ M0 proves technical feasibility only. It does not establish blanket permission f
 Acceptance: [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md).  
 Accepted final hardening baseline: `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 
-Accepted capabilities:
+Accepted core includes canonical retailer registry/readiness, shopping requirements and canonical quantities, location/fulfillment provenance, immutable offer/freshness evidence, deterministic matching, whole-package basket calculation, truthful complete/uncertain/incomplete/unavailable comparison states, pre-acquisition production-access gating, stateless comparison preview API and responsive manual-list journey.
 
-- canonical eight-retailer registry with independent technical-coverage and production-access states;
-- shopping requirements, canonical quantities and shopping-list identity;
-- provider/path orchestration and provider-neutral location/fulfillment context;
-- immutable offer snapshots with explicit observation/provider freshness and `UNKNOWN` availability;
-- deterministic exact/normalized matching with explicit matched/ambiguous/unmatched states;
-- whole-package single-store basket calculation with complete/uncertain/incomplete states;
-- truthful retailer comparison/readiness projection;
-- structured package evidence and Magnit package/location technical research;
-- pre-acquisition production-access gate that scopes retailer evidence before a source can run;
-- stateless `POST /api/v1/comparison-previews` and responsive manual-list web journey.
+### M2 — Recipes — COMPLETE / ACCEPTED
 
-M1 guarantees that unavailable retailers stay visible, ambiguity remains explicit, incomplete baskets do not expose misleading complete totals, and production preview evidence never falls back to deterministic fixtures.
+M2 established deterministic Recipe semantics from domain through responsive Recipe-first product flow.
+
+Accepted baselines:
+
+- M2.1 Recipe domain/conversion — merge `423eb14f7c565bbe264257a92df89a6b42d0d158`;
+- M2.2 `POST /api/v1/recipe-shopping-previews` — acceptance [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md), merge `8f0c1d8d31cfc1673656780a7989512d38788aff`;
+- M2.3 `POST /api/v1/recipe-comparison-previews` — acceptance [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md), merge `15a086d135f40277c655b39549c3e7a04c2e914e`;
+- M2.4 responsive Recipe-first UI — acceptance [`m2-4-responsive-recipe-ui-acceptance-2026-08-14.md`](m2-4-responsive-recipe-ui-acceptance-2026-08-14.md), merge `aba20c9cee263a683c0d4383ad840d7415851861`;
+- M2.5 deterministic multi-recipe aggregation — acceptance [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md), merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
+
+M2 guarantees that Recipe scaling/canonicalization is deterministic, automatic merge remains exact normalized requirement + canonical unit only, ShoppingItem identity is deterministic/list-scoped, Recipe/multi-Recipe provenance remains outside neutral Shopping Core and no fuzzy/AI equivalence is introduced implicitly.
+
+### M3.1 — WeeklyPlan domain + deterministic shopping composition — COMPLETE / ACCEPTED
+
+Authoritative design: [`superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md`](superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md`](superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md`](superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md)  
+Acceptance: [`m3-1-weekly-plan-acceptance-2026-08-14.md`](m3-1-weekly-plan-acceptance-2026-08-14.md)  
+Accepted squash merge: `13e09c63959b050d431cc913597fc868aa408718`.
+
+Accepted flow:
+
+`ordered WeeklyPlan meal occurrences + target servings → accepted M2.5 aggregation → one canonical weekly ShoppingList + WeeklyMealOccurrence/RecipeIngredient provenance`
+
+Accepted behavior:
+
+- immutable WeeklyPlan identity + ordered non-empty meal occurrences;
+- required Monday-through-Sunday day metadata, with no fixed breakfast/lunch/dinner/snack slots;
+- multiple occurrences may share a day;
+- the same Recipe may appear multiple times under distinct WeeklyMealOccurrenceIds;
+- caller occurrence order is explicit and never auto-sorted by day;
+- weekly ShoppingList identity derives deterministically from WeeklyPlanId;
+- internal aggregation-entry identity derives deterministically from WeeklyPlanId + WeeklyMealOccurrenceId;
+- accepted M2.5 remains authoritative for scaling, canonicalization, cross-Recipe exact merge, final ordering and ShoppingItem identity;
+- planner provenance projects to WeeklyMealOccurrenceId + exact RecipeIngredientRef and hides internal RecipeAggregationEntryId;
+- key drift, empty lineage, unknown internal identity and generated-ID collisions fail closed;
+- weeklyplan may depend only on accepted recipe/shopping project packages; reverse dependency is prohibited;
+- no persistence, API/OpenAPI, web UI, pantry/exclusions, provider/retailer or comparison behavior was introduced.
+
+Final reviewed PR head `ec1af08cbaf373f79c54858e9654451cebc4f009`:
+
+- **9/9 normal PR workflow groups SUCCESS**;
+- final read-only review: **Looks good**, no P0/P1/P2/P3;
+- review threads empty.
+
+Post-merge proof on `main=13e09c63959b050d431cc913597fc868aa408718`:
+
+- issue #109 closed `completed`;
+- exactly 8 normal push workflows;
+- **8/8 SUCCESS, 0 failures**.
+
+## Next deterministic target — M3.2 stateless WeeklyPlan application/API boundary
+
+M3.1 accepted planner-domain semantics. The next slice should expose those semantics without introducing persistence or UI prematurely.
+
+Recommended flow:
+
+`explicit WeeklyPlan request → server-owned transient WeeklyPlan/occurrence/Recipe/ingredient identities → accepted M3.1 composition → self-contained weekly ShoppingList + planner/Recipe provenance`
+
+M3.2 design should decide:
+
+1. public request shape for ordered meal occurrences and days;
+2. bounded recipe/ingredient/occurrence counts for predictable stateless execution;
+3. server-owned transient identity generation and collision handling;
+4. self-contained response shape that exposes planner occurrence/day/Recipe ingredient lineage without leaking internal aggregation IDs;
+5. sanitized validation/problem vocabulary;
+6. whether locality/comparison remains a later composition slice rather than part of the first WeeklyPlan API — default direction: keep M3.2 planner-only;
+7. OpenAPI 3.1 + generated TypeScript contract requirements;
+8. architecture guard preventing provider/retailer/comparison/database coupling.
+
+Persistence, saved-plan history, pantry/exclusion subtraction, retailer comparison orchestration and Weekly Planning UI remain separate follow-on slices unless M3.2 design evidence requires otherwise.
 
 ## Magnit production state
 
@@ -72,135 +132,14 @@ Current product state:
 - comparison status: **`UNAVAILABLE`**;
 - public reason: **`PRODUCTION_ACCESS_BLOCKED`**.
 
-`BLOCKED` is a Zakup Gotov operating policy because an affirmative right to operate the intended recurring production catalog-acquisition/reuse model has not been established. It is not a legal adjudication. No production Spring/HTTP Magnit acquisition is activated.
-
-## M2 — Recipes — COMPLETE / ACCEPTED
-
-M2 established deterministic Recipe semantics, exposed them through stateless application/API composition, shipped a responsive Recipe-first user journey and completed the multi-recipe aggregation foundation required by M3.
-
-### M2.1 — Recipe domain + Recipe → ShoppingList — COMPLETE / ACCEPTED
-
-Design: [`superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`](superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md)  
-Shipping evidence: [`superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md`](superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md)  
-Accepted squash merge: `423eb14f7c565bbe264257a92df89a6b42d0d158`.
-
-Accepted behavior:
-
-- immutable Recipe aggregate with stable Recipe/ingredient identities;
-- normalized title, positive integer servings and ordered explicit ingredients;
-- deterministic Recipe → ShoppingList conversion;
-- exact-safe serving scaling and canonical unit handling;
-- exact merge only by normalized requirement + canonical unit;
-- deterministic list-scoped ShoppingItem identity;
-- ordered per-ingredient provenance kept outside Shopping Core;
-- no fuzzy/synonym/AI equivalence.
-
-Post-merge acceptance: 8/8 normal push workflows SUCCESS.
-
-### M2.2 — Stateless Recipe application/API boundary — COMPLETE / ACCEPTED
-
-Authoritative design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`](superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md)  
-Acceptance: [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md)  
-Accepted squash merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`.
-
-Accepted boundary: `POST /api/v1/recipe-shopping-previews`.
-
-Accepted behavior includes server-owned transient identities, strict serving validation, accepted M2.1 scaling/merge/identity semantics, self-contained ingredient provenance, sanitized request problems and generated OpenAPI/TypeScript contracts without persistence or retailer traffic.
-
-Post-merge acceptance: 8/8 normal push workflows SUCCESS.
-
-### M2.3 — Recipe → Comparison composition — COMPLETE / ACCEPTED
-
-Authoritative design: [`superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md`](superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md)  
-Acceptance: [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md)  
-Accepted squash merge: `15a086d135f40277c655b39549c3e7a04c2e914e`.
-
-Accepted boundary: `POST /api/v1/recipe-comparison-previews`.
-
-Accepted journey:
-
-`Recipe input + locality → accepted RecipeShoppingPreview → canonical generated Shopping items → accepted ComparisonPreview`
-
-Generated ShoppingItem identity/order/requirement/canonical quantity remain stable across the composition boundary, Recipe provenance remains self-contained and production-access gating remains authoritative before runtime evidence acquisition.
-
-Post-merge acceptance: 8/8 normal push workflows SUCCESS.
-
-### M2.4 — Responsive Recipe UI — COMPLETE / ACCEPTED
-
-Authoritative design: [`superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md`](superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md)  
-Implementation plan: [`superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md`](superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui.md)  
-Shipping evidence: [`superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md`](superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md)  
-Acceptance: [`m2-4-responsive-recipe-ui-acceptance-2026-08-14.md`](m2-4-responsive-recipe-ui-acceptance-2026-08-14.md)  
-Accepted squash merge: `aba20c9cee263a683c0d4383ad840d7415851861`.
-
-Accepted primary web journey:
-
-`Recipe title/servings + ingredient editing + locality → composed Recipe comparison endpoint → canonical generated shopping requirements → truthful retailer comparison`
-
-The browser remains a generated-contract client, internal IDs stay hidden, failure is fail-closed, manual list comparison remains available and desktop/mobile Playwright covers scaling, generated-list output, unavailable state, keyboard focus and horizontal-overflow safety.
-
-Post-merge acceptance: 8/8 normal push workflows SUCCESS.
-
-### M2.5 — Deterministic multi-recipe aggregation — COMPLETE / ACCEPTED
-
-Authoritative design: [`superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md`](superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md)  
-Implementation plan: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md)  
-Shipping evidence: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md)  
-Acceptance: [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md)  
-Accepted squash merge: `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
-
-Accepted flow:
-
-`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregate ShoppingList + occurrence-aware provenance`
-
-Accepted behavior:
-
-- occurrence identity is separate from Recipe identity so the same Recipe may appear multiple times;
-- accepted `RecipeShoppingListConverter` remains authoritative for serving scaling and source-unit canonicalization;
-- automatic cross-Recipe merge remains exact normalized requirement + canonical unit only;
-- canonical amounts are summed exactly and first compatible occurrence controls ordering;
-- aggregate ShoppingItem IDs reuse accepted M2.1 list+requirement+unit derivation and stay independent of amount/serving changes;
-- provenance preserves aggregation occurrence + accepted RecipeIngredientRef lineage and is deeply immutable;
-- empty/duplicate occurrence sets, missing provenance and generated-ID collisions fail closed;
-- no API, web, persistence, planner, provider or retailer behavior was added.
-
-Compatibility proof locked accepted M2.1 ShoppingItem UUID `3d737f10-a263-39b3-b90a-fe7868c035b9` before shared-helper extraction and preserved it afterwards.
-
-Final reviewed PR head `a6e1095696ebfd67fafe7675a37b125ae02b3170`: 9/9 normal PR workflow groups SUCCESS; review `REVIEWED_READY / Looks good`; no unresolved P0/P1/P2; review threads empty.
-
-Post-merge proof on exact `main=0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`:
-
-- issue #106 closed `completed`;
-- exactly 8 normal push workflow runs;
-- **8/8 SUCCESS; 0 failures**;
-- API, Contract, Web/E2E, CodeQL Java + JavaScript/TypeScript, Container Security, Retailer Bridge, Release Contract and Release Bundle all passed.
-
-## M3 — Weekly Planning — CURRENT / DESIGN NEXT
-
-M2 has supplied the deterministic aggregation primitive. M3 may now add planner-specific semantics without changing accepted Recipe/Shopping merge behavior implicitly.
-
-Recommended first design slice:
-
-`WeeklyPlan identity + ordered meal/day occurrences + per-occurrence target servings → accepted M2.5 aggregation → reviewable weekly ShoppingList projection`
-
-Design questions to resolve before implementation:
-
-1. What is the smallest WeeklyPlan aggregate: ordered meals only, or explicit day/slot ownership from the start?
-2. Should M3 reuse `RecipeAggregationEntryId` as an internal bridge while exposing planner-specific occurrence identity publicly?
-3. How are day/meal labels represented without contaminating Recipe or Shopping Core?
-4. Which planner invariants are deterministic domain rules versus UI-only organization?
-5. Should the first M3 slice remain stateless, with persistence deferred until saved weekly plans demonstrate value? Default direction: yes.
-6. Pantry/exclusions should be a separate explicit semantics layer after the base weekly-plan composition is accepted; they must not silently alter M2.5 provenance.
-7. What minimal API contract is needed before planner UI work, and how does it preserve complete occurrence provenance?
-
-Persistence, accounts, pantry prediction, fuzzy/AI recipe interpretation and optimization remain separate evidence-driven decisions.
+`BLOCKED` is a Zakup Gotov operating policy because affirmative right to operate the intended recurring production catalog-acquisition/reuse model has not been established. It is not a legal adjudication. No production Spring/HTTP Magnit acquisition is activated.
 
 ## Parallel mandatory work
 
 Continue without blocking deterministic M3 work unless new evidence invalidates accepted core assumptions:
 
 - **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
-- **#36** Kuper supported aggregator access investigation;
+- **#36** Kuper supported aggregator investigation;
 - Chizhik, Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
 - retailer-specific structured package semantics only where source evidence proves them;
 - retailer-specific production-access decisions before activation;
@@ -213,34 +152,23 @@ Continue without blocking deterministic M3 work unless new evidence invalidates 
 3. Technical connectivity and production-access readiness are independent.
 4. Precise addresses are sensitive and redacted by default.
 5. Provider/acquisition/fulfillment identifiers remain internal.
-6. `UNKNOWN` availability is never coerced.
-7. Observation time is not misrepresented as provider freshness.
-8. Matching ambiguity never becomes a hidden winner.
-9. Package quantity is explicit structured evidence and is never guessed from presentation text.
-10. Mass, volume and count are not interchangeable.
-11. Incomplete baskets never expose misleading complete-basket totals.
-12. Production-access policy scopes acquisition before source invocation.
-13. Evidence outside requested retailer scope is a contract violation.
-14. Ordinary CI/browser acceptance makes no live retailer requests.
-15. Production preview evidence does not fall back to deterministic fixtures.
-16. Universal retailer connectivity remains mandatory.
-17. Public technical accessibility is never treated as production authorization by itself.
-18. Recipe semantics reuse Shopping Core quantity/requirement normalization instead of duplicating it.
-19. Recipe provenance remains outside Shopping Core types.
-20. Recipe exact-safe merging never introduces fuzzy/AI equivalence implicitly.
-21. Recipe application requests own no server identities; transient IDs are generated at the application boundary.
-22. Public Recipe provenance is self-contained and every source ingredient ID resolves inside the same response.
-23. Fractional ingredient quantities remain valid; serving counts remain positive JSON integers.
-24. Recipe → Comparison composition preserves generated ShoppingItem identity, order, requirement and canonical quantity across the application boundary.
-25. Recipe → Comparison composition delegates accepted Recipe and Comparison semantics and never bypasses production-access gating.
-26. Browser Recipe UI is a generated-contract client; Recipe scaling/merge/provenance/comparison semantics remain server-owned.
-27. Browser/E2E fixtures can prove UX behavior but never establish production retailer readiness.
-28. Multi-recipe aggregation distinguishes Recipe identity from occurrence identity.
-29. Repeating one Recipe under distinct aggregation occurrence IDs is valid and lineage remains unambiguous.
-30. Cross-Recipe automatic merge uses the same exact requirement + canonical-unit semantics as single-Recipe conversion.
-31. Aggregate ShoppingItem identity remains list+requirement+canonical-unit scoped and independent of amount/target servings.
-32. Multi-recipe provenance remains outside neutral Shopping Core types and is deeply immutable.
-33. Planner-specific semantics in M3 must compose accepted M2 aggregation rather than silently changing Recipe/Shopping merge rules.
+6. `UNKNOWN` availability is never coerced and observation time is not misrepresented as provider freshness.
+7. Matching ambiguity never becomes a hidden winner.
+8. Package quantity is explicit structured evidence; mass, volume and count are not interchangeable.
+9. Incomplete baskets never expose misleading complete-basket totals.
+10. Production-access policy scopes acquisition before source invocation; out-of-scope evidence is a contract violation.
+11. Ordinary CI/browser acceptance makes no live retailer requests and production preview never falls back to deterministic fixtures.
+12. Universal retailer connectivity remains mandatory; public technical accessibility alone is never production authorization.
+13. Recipe semantics reuse Shopping Core requirement/quantity normalization.
+14. Recipe and planner provenance remain outside neutral Shopping Core types.
+15. Recipe and cross-Recipe automatic merge remain exact requirement + canonical-unit semantics; no fuzzy/AI equivalence is implicit.
+16. Multi-recipe aggregation distinguishes Recipe identity from occurrence identity and supports repeated Recipe use without ambiguous lineage.
+17. ShoppingItem identity remains list + normalized requirement + canonical unit scoped and independent of amount/target servings.
+18. WeeklyPlan day metadata never changes Recipe/Shopping merge or quantity semantics.
+19. WeeklyPlan occurrence identity is distinct from Recipe identity; repeated Recipe meals are valid under distinct occurrence IDs.
+20. WeeklyPlan composition delegates accepted M2.5 semantics and never duplicates serving/canonicalization/merge logic.
+21. Planner provenance exposes WeeklyMealOccurrenceId + RecipeIngredientRef and hides internal aggregation IDs.
+22. Planner composition fails closed on identity/provenance drift.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,142 +16,124 @@ Deterministic product/core progress does not imply that every retailer is produc
 
 Decision: **GO to M1** — [`superpowers/specs/2026-08-12-m0-to-m1-go-decision.md`](superpowers/specs/2026-08-12-m0-to-m1-go-decision.md).
 
-Exit evidence: accepted Perekrestok/Pyaterochka browser-bridge paths, Magnit public-web path, two acquisition modes, deterministic sanitized verification and retailer-neutral architecture.
+Accepted evidence: Perekrestok/Pyaterochka browser-bridge paths, Magnit public-web technical feasibility, two acquisition modes, deterministic sanitized verification and retailer-neutral architecture.
 
 ## M1 — Shopping Core — COMPLETE / ACCEPTED
 
 Acceptance: [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md).  
 Accepted final hardening baseline: `779d0b219a13e0bf82263a1e655fb732553ed5fe`.
 
-Accepted guarantees:
-
-- all eight canonical retailers remain explicit;
-- complete / uncertain / incomplete / unavailable states are distinct;
-- unmatched, ambiguous, package-unknown and unit-mismatch paths fail safely;
-- `UNKNOWN` availability stays uncertain;
-- incomplete baskets cannot expose misleading complete totals or hidden winners;
-- technical connectivity and production access remain independent;
-- production access scopes acquisition before runtime evidence loading;
-- evidence outside requested retailer scope is a contract violation;
-- ordinary CI remains retailer-network-free.
+Accepted guarantees include canonical retailer visibility/readiness, deterministic Shopping quantities/identity, provider/location provenance, freshness/availability evidence, exact/normalized product matching, whole-package basket semantics, truthful incomplete/uncertain states, pre-acquisition production-access gating and stateless comparison preview + responsive manual-list flow.
 
 ## M2 — Recipes — COMPLETE / ACCEPTED
 
-Goal achieved: recipes are a first-class deterministic source of shopping requirements from one Recipe through responsive product UI and multi-Recipe aggregation.
+Goal achieved: recipes are a deterministic first-class source of shopping requirements, including single-Recipe conversion, stateless Recipe APIs, Recipe→Comparison composition, responsive Recipe-first UI and occurrence-aware multi-Recipe aggregation.
 
-### M2.1 — Recipe domain and Recipe → ShoppingList — COMPLETE / ACCEPTED
+Accepted slices:
 
-Design: [`superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md`](superpowers/specs/2026-08-13-m2-1-recipe-domain-design.md)  
-Shipping evidence: [`superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md`](superpowers/plans/2026-08-13-m2-1-recipe-domain-shipping.md)  
-Accepted merge: `423eb14f7c565bbe264257a92df89a6b42d0d158`.
+- **M2.1 Recipe domain + Recipe → ShoppingList** — merge `423eb14f7c565bbe264257a92df89a6b42d0d158`;
+- **M2.2 stateless Recipe shopping preview API** — acceptance [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md), merge `8f0c1d8d31cfc1673656780a7989512d38788aff`;
+- **M2.3 composed Recipe → Comparison flow** — acceptance [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md), merge `15a086d135f40277c655b39549c3e7a04c2e914e`;
+- **M2.4 responsive Recipe UI** — acceptance [`m2-4-responsive-recipe-ui-acceptance-2026-08-14.md`](m2-4-responsive-recipe-ui-acceptance-2026-08-14.md), merge `aba20c9cee263a683c0d4383ad840d7415851861`;
+- **M2.5 deterministic multi-Recipe aggregation** — acceptance [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md), merge `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
 
-Result: immutable Recipe semantics, exact-safe serving scaling, canonical Shopping quantities, deterministic exact merge/order/ShoppingItem identities and ordered provenance outside Shopping Core.
+M2 permanent direction: exact normalized requirement + canonical unit remains the only implicit Recipe merge rule; no fuzzy/synonym/AI equivalence is introduced silently.
 
-### M2.2 — Stateless Recipe application/API boundary — COMPLETE / ACCEPTED
+## M3 — Weekly Planning — CURRENT
 
-Design: [`superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md`](superpowers/specs/2026-08-13-m2-2-recipe-shopping-preview-design-v2.md)  
-Acceptance: [`m2-2-recipe-shopping-preview-acceptance-2026-08-14.md`](m2-2-recipe-shopping-preview-acceptance-2026-08-14.md)  
-Accepted merge: `8f0c1d8d31cfc1673656780a7989512d38788aff`.
+Goal: combine several meals into one coherent weekly plan and review its resulting shopping requirements before retailer comparison.
 
-Boundary: `POST /api/v1/recipe-shopping-previews`.
+### M3.1 — WeeklyPlan domain + deterministic shopping composition — COMPLETE / ACCEPTED
 
-Result: stateless server-owned transient identities, strict serving validation, self-contained Recipe provenance, OpenAPI/generated TypeScript contract and no persistence/retailer traffic.
+Authoritative design: [`superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md`](superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md`](superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md`](superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md)  
+Acceptance: [`m3-1-weekly-plan-acceptance-2026-08-14.md`](m3-1-weekly-plan-acceptance-2026-08-14.md)  
+Accepted squash merge: `13e09c63959b050d431cc913597fc868aa408718`.
 
-### M2.3 — Composed Recipe → Comparison flow — COMPLETE / ACCEPTED
+Accepted result:
 
-Design: [`superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md`](superpowers/specs/2026-08-14-m2-3-recipe-comparison-preview-design.md)  
-Acceptance: [`m2-3-recipe-comparison-preview-acceptance-2026-08-14.md`](m2-3-recipe-comparison-preview-acceptance-2026-08-14.md)  
-Accepted merge: `15a086d135f40277c655b39549c3e7a04c2e914e`.
-
-Boundary: `POST /api/v1/recipe-comparison-previews`.
-
-Result: one stateless request composes accepted Recipe conversion with accepted comparison semantics while preserving ShoppingItem identity/order/requirement/canonical quantity and production-access gating.
-
-### M2.4 — Responsive Recipe UI — COMPLETE / ACCEPTED
-
-Design: [`superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md`](superpowers/specs/2026-08-14-m2-4-responsive-recipe-ui-design.md)  
-Shipping evidence: [`superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md`](superpowers/plans/2026-08-14-m2-4-responsive-recipe-ui-shipping.md)  
-Acceptance: [`m2-4-responsive-recipe-ui-acceptance-2026-08-14.md`](m2-4-responsive-recipe-ui-acceptance-2026-08-14.md)  
-Accepted merge: `aba20c9cee263a683c0d4383ad840d7415851861`.
-
-Result: Recipe-first responsive homepage flow over generated contracts, canonical generated shopping output, truthful retailer comparison, fail-closed errors, desktop/mobile accessibility regression and preserved manual-list comparison.
-
-### M2.5 — Deterministic multi-recipe aggregation — COMPLETE / ACCEPTED
-
-Design: [`superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md`](superpowers/specs/2026-08-14-m2-5-multi-recipe-aggregation-design.md)  
-Implementation plan: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation.md)  
-Shipping evidence: [`superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md`](superpowers/plans/2026-08-14-m2-5-multi-recipe-aggregation-shipping.md)  
-Acceptance: [`m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md`](m2-5-multi-recipe-aggregation-acceptance-2026-08-14.md)  
-Accepted merge: `0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`.
-
-Accepted flow:
-
-`ordered Recipe occurrences + target servings → accepted per-recipe conversion → one canonical aggregate ShoppingList + occurrence-aware provenance`
-
-Accepted guarantees:
-
-- Recipe occurrence identity is distinct from Recipe identity;
-- the same Recipe may be included repeatedly under distinct occurrence IDs;
-- serving scaling and source-unit canonicalization remain delegated to accepted M2.1 conversion;
-- cross-Recipe merge remains exact normalized requirement + canonical unit only;
-- aggregate amounts are exact and order is first-compatible-occurrence deterministic;
-- aggregate ShoppingItem ID remains aggregate-list + requirement + canonical-unit scoped and independent of amount/target servings;
-- occurrence-aware provenance is ordered, complete and deeply immutable;
-- empty/duplicate occurrence sets and identity collisions fail closed;
-- accepted single-Recipe UUID semantics remain byte-for-byte stable after shared-helper extraction;
-- no API/UI/persistence/planner/provider/retailer scope was introduced.
+- immutable WeeklyPlan + ordered WeeklyMealOccurrence model;
+- required Monday-through-Sunday metadata without fixed meal-slot taxonomy;
+- repeated use of one Recipe through distinct planner occurrence IDs;
+- explicit caller occurrence order rather than implicit day sorting;
+- per-occurrence target servings through accepted RecipeServings;
+- deterministic WeeklyPlan-scoped ShoppingList and internal aggregation-entry identity;
+- composition delegates accepted M2.5 scaling/canonicalization/exact merge/order/final ShoppingItem identity;
+- planner provenance projects to WeeklyMealOccurrenceId + RecipeIngredientRef;
+- internal RecipeAggregationEntryId remains hidden;
+- identity/provenance drift fails closed;
+- architecture guards keep weeklyplan dependent inward only on recipe/shopping;
+- no persistence, API, UI, pantry, retailer/provider or comparison scope.
 
 Acceptance proof:
 
-- reviewed exact head `a6e1095696ebfd67fafe7675a37b125ae02b3170`: 9/9 normal PR workflow groups SUCCESS;
-- review `REVIEWED_READY / Looks good`; no unresolved P0/P1/P2; review threads empty;
-- squash merge `main=0854fc5bf76ad2976986537d6b4f5f3b8ebd18f0`;
-- #106 closed `completed`;
-- **8/8 post-merge normal push workflows SUCCESS, 0 failures**.
+- final reviewed head `ec1af08cbaf373f79c54858e9654451cebc4f009`: **9/9 PR workflow groups SUCCESS**;
+- read-only review **Looks good**, no P0/P1/P2/P3, no review threads;
+- squash merge `13e09c63959b050d431cc913597fc868aa408718`;
+- issue #109 closed `completed`;
+- **8/8 post-merge normal push workflows SUCCESS**.
 
-### M2 exit decision
+### M3.2 — Stateless WeeklyPlan application/API boundary — NEXT
 
-M2 has the complete deterministic foundation required by weekly planning:
+Goal: expose accepted M3.1 planner semantics through one self-contained stateless contract without prematurely introducing persistence or UI.
 
-- one Recipe → canonical ShoppingList;
-- stateless Recipe application boundary;
-- Recipe → retailer comparison composition;
-- responsive Recipe-first UI;
-- multiple Recipe occurrences → one canonical aggregate ShoppingList with unambiguous lineage.
+Recommended target flow:
 
-Decision: **advance to M3 Weekly Planning**.
+`explicit weekly-plan request → server-owned transient planner/Recipe/ingredient identities → accepted M3.1 composition → self-contained weekly ShoppingList + planner/Recipe provenance`
 
-## M3 — Weekly Planning — CURRENT / DESIGN NEXT
+Design defaults to validate:
 
-Goal: combine several meal occurrences into one coherent, reviewable weekly shopping requirement set while keeping planner semantics separate from accepted Recipe/Shopping aggregation rules.
+- request owns planner content, not server IDs;
+- server generates transient WeeklyPlanId, WeeklyMealOccurrenceIds, RecipeIds, RecipeIngredientIds and weekly ShoppingList identity through accepted boundaries;
+- ordered occurrences include required day, Recipe title/base servings, target servings and explicit ingredients;
+- bounded occurrence/ingredient counts keep stateless execution predictable;
+- M3.1 remains authoritative for planner composition and M2.5 remains authoritative for Recipe aggregation;
+- response is self-contained: every ShoppingItem lineage resolves to one returned weekly occurrence + one returned Recipe ingredient;
+- internal RecipeAggregationEntryId and provider/retailer identifiers never appear publicly;
+- semantic/unreadable request errors use a sanitized planner-specific Problem Detail contract;
+- OpenAPI 3.1 remains source of truth and generated TypeScript client is regenerated/verified;
+- controller/application adapter remains independent from provider, retailer, matching, basket, comparison and database;
+- ordinary CI makes no live retailer request.
 
-### Recommended M3.1 first slice
+Explicit M3.2 non-goals:
 
-Start with a **pure WeeklyPlan domain/application composition**, not persistence or UI.
+- persistence/saved plans/history;
+- pantry/exclusion subtraction;
+- retailer comparison orchestration;
+- responsive planner UI;
+- calendar dates/week numbers/time zones;
+- breakfast/lunch/dinner slot taxonomy;
+- nutrition/macros;
+- fuzzy/AI ingredient semantics.
 
-Target model direction:
+Exit gate:
 
-`WeeklyPlan identity + ordered meal occurrences + optional day/slot ownership + per-occurrence target servings → accepted M2.5 aggregation → reviewable weekly ShoppingList projection`
+- authoritative design approved;
+- contract/application TDD RED→GREEN;
+- OpenAPI/generated-client synchronization green;
+- architecture/full API regression green;
+- exact-head 9/9 PR workflows + clean review;
+- squash merge + 8/8 post-merge acceptance proof.
 
-Key design questions:
+### M3.3 — Responsive Weekly Planning UI — AFTER M3.2
 
-1. Should the first WeeklyPlan aggregate model explicit days/meal slots immediately, or start with an ordered meal-occurrence list and add calendar placement separately?
-2. Planner occurrence identity should be distinct at the WeeklyPlan boundary while mapping deterministically to accepted `RecipeAggregationEntryId` internally.
-3. How are user-facing meal labels/day labels represented without contaminating Recipe or Shopping Core?
-4. Which constraints are true domain invariants: non-empty plan, max occurrences, duplicate planner occurrence IDs, optional repeated Recipe entries, ordering?
-5. Should the first slice remain stateless? **Default: yes** until saved weekly plans/history demonstrate persistence value.
-6. Pantry/exclusions must be a later explicit semantics layer because removing/subtracting requirements changes lineage and should not be hidden inside M2.5 aggregation.
-7. After pure WeeklyPlan semantics are accepted, define the smallest stateless API/OpenAPI contract, then responsive planner UI with RED-first desktop/mobile Playwright.
+Goal: provide a Recipe/meal-by-day editor over the accepted M3.2 generated contract, show canonical weekly shopping requirements and preserve manual/Recipe comparison journeys.
 
-Suggested M3 sequence:
+Expected scope:
 
-- **M3.1** WeeklyPlan domain + deterministic composition over M2.5;
-- **M3.2** stateless WeeklyPlan application/API boundary with complete occurrence provenance;
-- **M3.3** responsive weekly planner/review UI;
-- **M3.4** pantry/exclusion semantics as a dedicated deterministic layer;
-- persistence only when repeat-use evidence justifies saved weekly plans.
+- add/remove/reorder weekly meal occurrences;
+- choose day and target servings per occurrence;
+- edit explicit Recipe ingredients;
+- show weekly canonical shopping projection and validation/error states;
+- desktop/mobile accessibility and Playwright RED-first coverage;
+- no business-semantic duplication in browser code.
 
-M3 must not silently change M2.5 exact merge, identity or provenance rules.
+### M3.4 — Pantry / exclusions semantics — AFTER BASE PLANNER FLOW
+
+Pantry/subtraction must be an explicit semantics layer with its own design and provenance rules. It must never silently mutate accepted M2.5/M3.1 aggregation behavior.
+
+Persistence remains deferred until saved-plan reuse/history demonstrates product value.
 
 ## Parallel connectivity / operational work
 
@@ -160,7 +142,7 @@ Continue without blocking deterministic M3 work unless evidence invalidates acce
 - **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
 - **#36** Kuper supported aggregator investigation;
 - Chizhik, Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
-- structured package semantics for additional providers only where source evidence proves them;
+- structured package semantics only where source evidence proves them;
 - retailer-specific production-access/right-to-operate decisions before activation;
 - successful real **`v0.1.0-rc.3`** release event with final image promotion, SBOM/attestation and digest smoke evidence.
 
@@ -176,7 +158,7 @@ Goal: reliable repeat use with privacy-aware accounts/preferences, analytics abs
 
 ## M6 — Native Mobile
 
-Goal: Android/iOS clients using the shared API vocabulary and generated client contracts after the web/core product is stable.
+Goal: Android/iOS clients using shared API vocabulary/generated contracts after web/core stability.
 
 ## Guiding rule
 

--- a/docs/m3-1-weekly-plan-acceptance-2026-08-14.md
+++ b/docs/m3-1-weekly-plan-acceptance-2026-08-14.md
@@ -1,0 +1,108 @@
+# M3.1 WeeklyPlan Domain + Deterministic Shopping Composition — Acceptance
+
+Date: 2026-08-14  
+Issue: #109  
+Implementation PR: #110  
+Status: **COMPLETE / ACCEPTED**
+
+Authoritative design: `docs/superpowers/specs/2026-08-14-m3-1-weekly-plan-domain-design.md`  
+Implementation plan: `docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain.md`  
+Shipping evidence: `docs/superpowers/plans/2026-08-14-m3-1-weekly-plan-domain-shipping.md`
+
+## Decision
+
+**ACCEPT M3.1** and advance the deterministic roadmap to **M3.2 — stateless WeeklyPlan application/API boundary**.
+
+M3.1 provides the first accepted Weekly Planning domain/application foundation without introducing persistence, transport or UI scope.
+
+Accepted flow:
+
+`ordered WeeklyPlan meal occurrences + per-occurrence target servings → accepted M2.5 aggregation → one canonical weekly ShoppingList + occurrence-aware Recipe ingredient provenance`
+
+## Accepted behavior
+
+- immutable WeeklyPlan identity and ordered non-empty meal occurrence model;
+- Monday-through-Sunday planner metadata with no premature fixed breakfast/lunch/dinner/snack slots;
+- multiple occurrences may share one day;
+- the same Recipe may intentionally occur multiple times through distinct WeeklyMealOccurrenceIds;
+- each occurrence owns its own accepted positive RecipeServings target;
+- occurrence order remains explicit caller/user order and is never implicitly sorted by day;
+- weekly ShoppingList identity derives deterministically from WeeklyPlanId;
+- internal RecipeAggregationEntry identity derives deterministically from WeeklyPlanId + WeeklyMealOccurrenceId;
+- accepted M2.5 remains authoritative for Recipe scaling, source-unit canonicalization, exact-safe merge, quantity sum, first-compatible output ordering and final ShoppingItem identity;
+- day, target servings and occurrence position do not directly enter final ShoppingItem identity;
+- reordering occurrences may change output group order while unchanged merge-key IDs remain stable inside one plan;
+- planner provenance projects to WeeklyMealOccurrenceId + exact accepted RecipeIngredientRef and never exposes internal RecipeAggregationEntryId;
+- ShoppingList/provenance key drift, empty lineage, unknown internal occurrence mapping, deterministic internal-ID collision and missing inputs fail closed;
+- planner provenance map/nested lists are defensive, ordered and immutable;
+- weeklyplan project dependencies are limited to accepted recipe/shopping packages and JDK classes;
+- recipe/shopping remain independent from weeklyplan;
+- no persistence/database schema, REST/OpenAPI/generated client, web UI, pantry/exclusions, nutrition, AI/fuzzy semantics, provider/retailer acquisition or comparison orchestration was introduced.
+
+## TDD / verification evidence
+
+### WeeklyPlan domain
+
+- RED `4fc807aef66a2d861f3707477186ce29c3d7a022`: testCompile failed only on intentionally absent WeeklyPlan production types.
+- GREEN `f9f8f4372dab7c15aa4e5c08fc1f0d841ca3be04`: minimal domain model added; full API/Maven verify SUCCESS.
+
+### WeeklyPlan composition
+
+- RED `3faa4c8a93ee725082264751079a23fbd43f28b4`: testCompile failed on intentionally absent composer/provenance result types.
+- GREEN `5b2cf92f9f3c1caa071a953f977fb09fce090697`: deterministic M2.5 composition and planner provenance implemented; full API/Maven verify SUCCESS.
+
+### Fail-closed hardening
+
+- RED `a2aeb7e9fdb45b646cb0d19407acca1291bf6cf1`: full Maven run had exactly 3 intended failures / 0 errors for missing final-item provenance, orphan provenance key and empty lineage; all other M3.1/M2 regressions remained green.
+- GREEN `25677c697292f63649579720e02aefd666093322`: exact ShoppingList/provenance key validation and non-empty lineage enforcement added; full API/Maven verify SUCCESS.
+
+### Architecture
+
+- checkpoint `f3874d21b3569964a20d5b1bfb17c07ac250a821`: ArchUnit boundary tests plus full Maven/Testcontainers/Modulith verification SUCCESS.
+
+## Final PR gate
+
+Final reviewed feature head:
+
+`ec1af08cbaf373f79c54858e9654451cebc4f009`
+
+Evidence on that exact head:
+
+- API CI — SUCCESS;
+- Contract CI — SUCCESS;
+- Web CI + responsive E2E — SUCCESS;
+- CodeQL Java + JavaScript/TypeScript — SUCCESS;
+- Dependency Review — SUCCESS;
+- Container Security API + Web — SUCCESS;
+- Retailer Bridge CI — SUCCESS;
+- Release Contract CI — SUCCESS;
+- Release Bundle CI — SUCCESS.
+
+Result: **9/9 normal PR workflow groups SUCCESS**.
+
+Read-only final review: **Looks good**; no P0/P1/P2/P3 findings; review threads empty.
+
+## Merge / post-merge proof
+
+PR #110 was squash-merged with exact-head protection.
+
+Accepted main implementation SHA:
+
+`13e09c63959b050d431cc913597fc868aa408718`
+
+Post-merge evidence:
+
+- issue #109 closed with reason `completed`;
+- exactly 8 normal push-triggered workflow runs exist for the accepted main SHA;
+- no run remained in progress and no run concluded failure/cancelled/null;
+- therefore **8/8 normal push workflow groups SUCCESS**.
+
+## Next deterministic target
+
+Advance to **M3.2 — stateless WeeklyPlan application/API boundary**.
+
+Recommended M3.2 direction:
+
+`explicit weekly-plan request + locality-independent planner data → server-owned transient WeeklyPlan/occurrence/Recipe/ingredient identities → accepted M3.1 WeeklyPlan composition → self-contained weekly ShoppingList + planner/recipe provenance`
+
+M3.2 should remain stateless and contract-first. Persistence, saved plans/history, pantry subtraction, comparison orchestration and Weekly Planning UI remain separate follow-on slices unless the approved M3.2 design explicitly introduces the minimum needed boundary.


### PR DESCRIPTION
## Summary

Synchronize canonical project documentation after accepted M3.1 implementation PR #110.

Acceptance evidence:
- final reviewed feature head `ec1af08cbaf373f79c54858e9654451cebc4f009`;
- 9/9 normal PR workflow groups SUCCESS;
- read-only review `Looks good`, no P0/P1/P2/P3 findings, no review threads;
- squash merge `main=13e09c63959b050d431cc913597fc868aa408718`;
- issue #109 closed `completed`;
- exactly 8 normal post-merge push workflows, 8/8 SUCCESS.

Documentation changes:
- add dedicated M3.1 acceptance decision;
- mark M3.1 COMPLETE / ACCEPTED in PROJECT_STATE;
- advance current focus to M3.2 stateless WeeklyPlan application/API boundary;
- update ROADMAP with M3.2/M3.3/M3.4 sequencing;
- record WeeklyPlan domain/composition/identity/provenance and acceptance evidence in CHANGELOG.

No production code, OpenAPI/generated-client, web, database or retailer behavior changes.