### PR TITLE
docs(m3): finalize WeeklyPlan comparison acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - OpenAPI 3.1 and generated TypeScript expose `createWeeklyPlanShoppingPreview`, `WEEKLY_PLAN_SHOPPING_PREVIEWS_PATH` and synchronized request/response/problem types.
 - ArchUnit guards keep `weeklyplanpreview` out of provider, retailer, matching, basket, comparison and database layers and protect reverse dependency direction into accepted Recipe/Shopping/WeeklyPlan packages.
 - M3.2 design, implementation plan, shipping evidence and acceptance decision document request/composition/provenance/HTTP/contract/hardening RED→GREEN chains, reviewed head `250aedb85b675036ffcb20e96a67db1afc03167a`, squash merge `9682ad1230910fc268ca3cddd8601a3fad7b100e`, issue #112 closure and 8/8 successful post-merge `main` workflows.
+- Stateless M3.3 `POST /api/v1/weekly-plan-comparison-previews` composes provider-neutral locality plus the accepted M3.2 WeeklyPlan input into one accepted weekly shopping projection and retailer comparison without client-controlled server identities.
+- M3.3 preserves generated weekly ShoppingItem UUID, order, normalized requirement and canonical quantity unchanged into ComparisonPreview while returning M3.2 self-contained `occurrenceId + recipeId + recipeIngredientId` provenance unchanged.
+- Accepted ComparisonPreview remains authoritative for locality validation, canonical retailer visibility, production-access gating before acquisition, runtime evidence, matching, package/basket semantics and truthful complete/uncertain/incomplete/unavailable states.
+- M3.3 fails closed on cross-boundary cardinality, identity/order, requirement or canonical-quantity drift instead of silently adapting mismatched projections.
+- Whole-wrapper JSON binding failures use sanitized `INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW`; successfully bound M3.2 and comparison semantic failures retain their accepted problem contracts.
+- OpenAPI 3.1 and generated TypeScript expose `createWeeklyPlanComparisonPreview`, `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH` and synchronized composed request/response/problem types.
+- ArchUnit keeps `weeklyplancomparisonpreview` on accepted M3.2/ComparisonPreview application boundaries with only the finite Shopping `Quantity` / `QuantityUnit` bridge, rejecting direct planner-domain/provider/retailer/matching/basket/comparison-domain/database coupling.
+- M3.3 design, implementation plan, shipping evidence and acceptance decision document explicit RED→GREEN checkpoints, reviewed head `396445c333ea369bed6d428b33f38f37765eff20`, squash merge `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`, issue #115 closure and 8/8 successful post-merge `main` workflows.
 
 #### Product and shopping core
 
@@ -122,14 +130,15 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M2 Recipes is **COMPLETE / ACCEPTED**.
 - M3.1 WeeklyPlan domain + deterministic shopping composition is **COMPLETE / ACCEPTED** after final reviewed head `ec1af08cbaf373f79c54858e9654451cebc4f009`, squash merge `13e09c63959b050d431cc913597fc868aa408718`, issue #109 closure and 8/8 successful post-merge `main` workflows.
 - M3.2 stateless WeeklyPlan shopping-preview application/API boundary is **COMPLETE / ACCEPTED** after final reviewed head `250aedb85b675036ffcb20e96a67db1afc03167a`, squash merge `9682ad1230910fc268ca3cddd8601a3fad7b100e`, issue #112 closure and 8/8 successful post-merge `main` workflows.
-- The current deterministic target is **M3.3 WeeklyPlan → Comparison composition**; responsive Weekly Planning UI is M3.4, while persistence and pantry subtraction remain later explicit slices.
+- M3.3 WeeklyPlan → Comparison composition is **COMPLETE / ACCEPTED** after final reviewed head `396445c333ea369bed6d428b33f38f37765eff20`, squash merge `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`, issue #115 closure and 8/8 successful post-merge `main` workflows.
+- The current deterministic target is **M3.4 Responsive Weekly Planning UI**; persistence and pantry subtraction remain later explicit slices.
 - Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
 - Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`; M2.2 projects that provenance publicly as self-contained source ingredient IDs instead of modifying Shopping Core types.
 - Recipe lifecycle and the first Weekly Planning direction remain stateless by default; persistence stays deferred until reusable saved plans/history demonstrate product value.
 - Recipe → Comparison has an accepted primary product boundary at `/api/v1/recipe-comparison-previews`; M2.4 consumes it directly as the primary Recipe-first browser journey.
 - Multi-Recipe aggregation distinguishes Recipe identity from occurrence identity; repeated Recipe use is valid only through distinct occurrence IDs and does not weaken accepted exact merge semantics.
 - WeeklyPlan distinguishes planner occurrence identity from Recipe identity and keeps day metadata outside Recipe/Shopping merge and quantity semantics.
-- WeeklyPlan shopping preview remains locality/retailer-independent; retailer comparison is an explicit later composition concern rather than hidden planner behavior.
+- WeeklyPlan shopping preview remains locality/retailer-independent; retailer comparison is an explicit composition concern owned by M3.3 rather than hidden planner behavior.
 - Retailer onboarding remains transport-neutral and universal; a failed direct path changes acquisition mode rather than retailer scope.
 - `ObservedOffer` is the provider trust boundary and `OfferSnapshot` the immutable comparison record.
 - Observation time and provider-side update time remain distinct.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -21,9 +21,10 @@ Milestone status:
 - M2.4 Responsive Recipe UI — **COMPLETE / ACCEPTED** (#104 / #103);
 - M2.5 Deterministic multi-recipe aggregation — **COMPLETE / ACCEPTED** (#107 / #106);
 - M3.1 WeeklyPlan domain + deterministic shopping composition — **COMPLETE / ACCEPTED** (#110 / #109);
-- M3.2 Stateless WeeklyPlan shopping-preview application/API boundary — **COMPLETE / ACCEPTED** (#113 / #112).
+- M3.2 Stateless WeeklyPlan shopping-preview application/API boundary — **COMPLETE / ACCEPTED** (#113 / #112);
+- M3.3 WeeklyPlan → Comparison composition — **COMPLETE / ACCEPTED** (#116 / #115).
 
-Current focus: **design M3.3 WeeklyPlan → Comparison composition**.
+Current focus: **M3.4 — Responsive Weekly Planning UI**.
 
 ## Permanent connectivity rule
 
@@ -144,26 +145,67 @@ Post-merge proof on `main=9682ad1230910fc268ca3cddd8601a3fad7b100e`:
 - exactly 8 normal push workflows;
 - **8/8 SUCCESS, 0 failures**.
 
-## Next deterministic target — M3.3 WeeklyPlan → Comparison composition
+### M3.3 — WeeklyPlan → Comparison composition — COMPLETE / ACCEPTED
 
-M3.2 now supplies a truthful stateless weekly shopping projection. The next slice should compose it with the already accepted comparison application boundary without changing planner, Recipe, shopping or retailer semantics.
+Authoritative design: [`superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md`](superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md)  
+Acceptance: [`m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md`](m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md)  
+Accepted squash merge: `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`.
 
-Recommended flow:
+Accepted boundary:
 
-`explicit WeeklyPlan + locality → accepted M3.2 weekly shopping preview → canonical generated shopping requirements → accepted ComparisonPreview`
+`POST /api/v1/weekly-plan-comparison-previews`
 
-M3.3 design should preserve:
+Accepted flow:
 
-1. server-owned WeeklyPlan/occurrence/Recipe/ingredient identity from M3.2;
-2. exact Weekly ShoppingItem identity/order/requirement/canonical quantity across the composition boundary;
-3. self-contained planner/Recipe provenance from M3.2;
-4. existing comparison production-access gating before runtime evidence acquisition;
-5. no direct provider/retailer/matching/basket dependencies from the new composition adapter;
-6. locality only at the composition boundary rather than inside WeeklyPlan domain;
-7. sanitized wrapper failure semantics while preserving accepted nested planner/comparison errors where appropriate;
-8. ordinary CI with no live retailer traffic.
+`locality + accepted M3.2 WeeklyPlan input → accepted WeeklyPlanShoppingPreview → generated canonical ShoppingItems → accepted ComparisonPreview`
 
-Responsive Weekly Planning UI is **M3.4 after M3.3 acceptance**. Persistence/saved-plan history and pantry/exclusion subtraction remain separate evidence-driven slices.
+Accepted behavior:
+
+- M3.3 is stateless and introduces no client-controlled server identities;
+- accepted M3.2 remains authoritative for planner/Recipe validation, transient identities, weekly composition, ShoppingList/ShoppingItem identity and self-contained provenance;
+- generated weekly ShoppingItem identity, order, normalized requirement and canonical quantity cross the composition boundary unchanged;
+- accepted ComparisonPreview remains authoritative for locality, retailer visibility, production-access gating, runtime evidence, matching, basket/package semantics and truthful comparison states;
+- M3.2 public provenance is returned unchanged and never reinterpreted by comparison;
+- composition drift in cardinality, identity/order, requirement or canonical quantity fails closed;
+- whole-wrapper binding failures use sanitized `INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW`, while successfully bound planner/comparison semantic failures preserve their accepted problem vocabularies;
+- OpenAPI 3.1 and generated TypeScript client expose the composed contract;
+- architecture guards keep the adapter on accepted application boundaries and out of provider/retailer/matching/basket/comparison-domain/database internals;
+- no persistence, UI, pantry, retailer onboarding/activation, production-access policy change or live-retailer CI behavior was introduced.
+
+Final reviewed PR head `396445c333ea369bed6d428b33f38f37765eff20`:
+
+- **9/9 normal PR workflow groups SUCCESS**;
+- final read-only review: **Looks good**, no P0/P1/P2/P3;
+- review threads empty.
+
+Post-merge proof on `main=89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`:
+
+- issue #115 closed `completed`;
+- exactly 8 normal push workflows;
+- **8/8 SUCCESS, 0 failures**.
+
+## Next deterministic target — M3.4 Responsive Weekly Planning UI
+
+M3.3 now provides the accepted stateless product boundary needed by the planner UI. The next slice should build a responsive WeeklyPlan editing journey over that composed endpoint without duplicating planner, Recipe, shopping or comparison semantics in browser code.
+
+Recommended product flow:
+
+`edit ordered weekly meal occurrences + locality → POST /api/v1/weekly-plan-comparison-previews → canonical weekly shopping requirements + truthful retailer comparison`
+
+M3.4 should preserve:
+
+1. generated WeeklyPlan/occurrence/Recipe/ingredient/ShoppingList/ShoppingItem identities as server-owned implementation detail rather than editable browser state;
+2. explicit meal occurrence order, day and target servings without adding a fixed breakfast/lunch/dinner/snack taxonomy;
+3. accepted M3.3 as the primary WeeklyPlan comparison transport rather than browser-side composition of M3.2 + comparison;
+4. canonical weekly shopping requirements rendered before retailer comparison so aggregation remains inspectable;
+5. accepted comparison uncertainty/incomplete/unavailable states without fabricated winners or totals;
+6. generated OpenAPI/client types instead of duplicated frontend DTOs;
+7. manual-list and Recipe journeys unchanged and regression-covered;
+8. responsive desktop/mobile accessibility and deterministic Playwright coverage with no live retailer traffic.
+
+Pantry/exclusion subtraction and persistence/saved-plan history remain separate evidence-driven slices after the base planner flow.
 
 ## Magnit production state
 
@@ -217,6 +259,9 @@ Continue without blocking deterministic M3 work unless new evidence invalidates 
 24. Every public M3.2 shopping-item source resolves to one returned occurrence, Recipe and Recipe ingredient.
 25. M3.2 delegates Recipe validation/scaling semantics to accepted M2.2/M3.1 boundaries rather than creating a parallel planner algorithm.
 26. M3.2 remains locality/retailer-independent; comparison is an explicit composition concern.
+27. M3.3 is a stateless application composition adapter: planner projection remains owned by M3.2 and comparison behavior remains owned by accepted ComparisonPreview.
+28. M3.3 preserves generated ShoppingItem identity/order/requirement/canonical quantity and returns M3.2 self-contained planner provenance unchanged.
+29. M3.3 sanitizes whole-wrapper binding failures while preserving accepted planner/comparison semantic problem contracts after successful binding.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,51 +108,67 @@ Acceptance proof:
 - issue #112 closed `completed`;
 - **8/8 post-merge normal push workflows SUCCESS**.
 
-### M3.3 — WeeklyPlan → Comparison composition — NEXT
+### M3.3 — WeeklyPlan → Comparison composition — COMPLETE / ACCEPTED
 
-Goal: compose the accepted weekly shopping preview with the accepted retailer comparison boundary in one stateless request without changing planner, Recipe, Shopping or retailer semantics.
+Authoritative design: [`superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md`](superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md)  
+Acceptance: [`m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md`](m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md)  
+Accepted squash merge: `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`.
 
-Recommended target flow:
+Accepted boundary:
 
-`explicit WeeklyPlan + locality → accepted M3.2 weekly shopping projection → generated canonical shopping requirements → accepted ComparisonPreview`
+`POST /api/v1/weekly-plan-comparison-previews`
 
-Design defaults to validate:
+Accepted result:
 
-- request contains locality plus the accepted weekly-plan input shape and no server identities;
-- planner/Recipe identities and self-contained provenance are produced by accepted M3.2;
-- generated weekly ShoppingItem identity/order/requirement/canonical quantity are preserved unchanged into comparison input;
-- comparison production-access gating remains authoritative before runtime evidence acquisition;
-- no provider/retailer/matching/basket internals leak into the composition adapter;
-- wrapper binding failures are sanitized while nested accepted planner/comparison semantic problems remain explicit where appropriate;
-- ordinary CI performs no live retailer requests;
-- no UI/persistence/pantry scope.
+- one stateless request combines provider-neutral locality with the accepted M3.2 WeeklyPlan input and owns no server identities;
+- accepted M3.2 remains the only planner/Recipe shopping-preview authority and its self-contained provenance is returned unchanged;
+- generated weekly ShoppingItem UUID, order, normalized requirement and canonical quantity are preserved exactly into comparison;
+- accepted ComparisonPreview remains the only authority for locality validation, retailer visibility/readiness, production-access gating, runtime evidence, matching, basket/package semantics and truthful comparison projection;
+- fail-closed verification rejects cardinality, identity/order, requirement or quantity drift across the composition boundary;
+- whole-wrapper binding failures use sanitized `INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW`; successfully bound M3.2 and comparison semantic failures preserve their accepted contracts;
+- OpenAPI/generated client exposes `createWeeklyPlanComparisonPreview` and `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH`;
+- ArchUnit prevents direct planner-domain/provider/retailer/matching/basket/comparison-domain/database coupling and protects accepted boundary direction;
+- no persistence, UI, pantry, retailer activation or new acquisition behavior.
 
-Exit gate:
+Acceptance proof:
 
-- authoritative design approved;
-- application/contract TDD RED→GREEN;
-- OpenAPI/generated-client synchronization green;
-- architecture/full regression green;
-- exact-head 9/9 PR workflows + clean review;
-- squash merge + 8/8 post-merge acceptance proof.
+- final reviewed head `396445c333ea369bed6d428b33f38f37765eff20`: **9/9 PR workflow groups SUCCESS**;
+- read-only review **Looks good**, no P0/P1/P2/P3, no review threads;
+- squash merge `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`;
+- issue #115 closed `completed`;
+- **8/8 post-merge normal push workflows SUCCESS**.
 
-### M3.4 — Responsive Weekly Planning UI — AFTER M3.3
+### M3.4 — Responsive Weekly Planning UI — NEXT
 
 Goal: provide a Recipe/meal-by-day editor over the accepted composed WeeklyPlan→Comparison contract and expose canonical weekly shopping plus truthful retailer comparison.
 
 Expected scope:
 
+- consume generated `POST /api/v1/weekly-plan-comparison-previews` contract as the primary planner product boundary;
 - add/remove/reorder weekly meal occurrences;
-- choose day and target servings per occurrence;
+- choose day and target servings per occurrence without introducing a fixed meal-slot taxonomy;
 - edit explicit Recipe ingredients;
 - show canonical weekly shopping requirements before comparison;
+- render accepted complete/uncertain/incomplete/unavailable retailer states without browser-side business recomputation;
 - preserve manual-list and Recipe comparison journeys;
+- use generated API/client types rather than duplicated frontend DTOs;
 - desktop/mobile accessibility and Playwright RED-first coverage;
-- no business-semantic duplication in browser code.
+- deterministic E2E fixtures only; no live retailer traffic in ordinary browser acceptance.
+
+Exit gate:
+
+- authoritative UI/interaction design approved;
+- browser/service TDD RED→GREEN;
+- desktop/mobile accessibility, overflow, loading/error and critical-journey regression coverage green;
+- no browser duplication of WeeklyPlan/Recipe/shopping/comparison semantics;
+- exact-head 9/9 PR workflows + clean review;
+- squash merge + 8/8 post-merge acceptance proof.
 
 ### M3.5 — Pantry / exclusions semantics — AFTER BASE PLANNER FLOW
 
-Pantry/subtraction must be an explicit semantics layer with its own design and provenance rules. It must never silently mutate accepted M2.5/M3.1/M3.2 behavior.
+Pantry/subtraction must be an explicit semantics layer with its own design and provenance rules. It must never silently mutate accepted M2.5/M3.1/M3.2/M3.3 behavior.
 
 Persistence remains deferred until saved-plan reuse/history demonstrates product value.
 

--- a/docs/m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md
+++ b/docs/m3-3-weekly-plan-comparison-preview-acceptance-2026-08-14.md
@@ -1,0 +1,159 @@
+# M3.3 WeeklyPlan → Comparison Preview — Acceptance
+
+Date: 2026-08-14  
+Status: **COMPLETE / ACCEPTED**  
+Issue: #115  
+Implementation PR: #116
+
+Baseline before M3.3: `4f3c171311f25c7aa03acb54680a5d1924cdb691`  
+Final reviewed feature head: `396445c333ea369bed6d428b33f38f37765eff20`  
+Accepted implementation squash merge: `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`
+
+Authoritative design: [`superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md`](superpowers/specs/2026-08-14-m3-3-weekly-plan-comparison-preview-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview.md)  
+Shipping evidence: [`superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md`](superpowers/plans/2026-08-14-m3-3-weekly-plan-comparison-preview-shipping.md)
+
+## Accepted boundary
+
+`POST /api/v1/weekly-plan-comparison-previews`
+
+Accepted flow:
+
+`locality + accepted M3.2 WeeklyPlan input → accepted WeeklyPlanShoppingPreview → generated canonical ShoppingItems → accepted ComparisonPreview`
+
+M3.3 is a stateless composition adapter. It does not create a second WeeklyPlan/Recipe/shopping/comparison algorithm.
+
+## Accepted behavior
+
+- request contains provider-neutral locality plus the accepted M3.2 weekly-plan input shape and no client-controlled WeeklyPlan, meal-occurrence, Recipe, ingredient, ShoppingList or ShoppingItem identities;
+- `WeeklyPlanShoppingPreviewService` is invoked through its accepted application boundary and remains authoritative for planner/Recipe validation, server-owned transient identities, serving scaling, canonicalization, deterministic weekly aggregation, ShoppingList/ShoppingItem identity and self-contained planner provenance;
+- generated weekly ShoppingItems cross the composition boundary in the same order with the same UUID, normalized requirement and canonical quantity;
+- `ComparisonPreviewService` remains authoritative for locality validation/normalization, canonical retailer visibility, production-access gating before evidence acquisition, runtime evidence, matching, package/basket semantics, uncertainty/incompleteness and product-safe retailer projection;
+- the accepted M3.2 `WeeklyPlanShoppingPreview` is returned unchanged, so public `occurrenceId + recipeId + recipeIngredientId` lineage remains self-contained and comparison never reinterprets it;
+- cross-boundary cardinality, ShoppingItem identity/order, requirement and canonical-quantity drift fail closed as internal errors;
+- successfully bound planner semantic failures preserve `INVALID_WEEKLY_PLAN_SHOPPING_PREVIEW`;
+- successfully bound locality/comparison semantic failures preserve `INVALID_COMPARISON_PREVIEW`;
+- malformed/unreadable or binding failures anywhere in the composed JSON use sanitized `INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW` with one safe `$request` error and no parser/Jackson/internal exception detail;
+- OpenAPI 3.1 exposes operation `createWeeklyPlanComparisonPreview`; the generated TypeScript client exposes `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH` and synchronized request/response/problem types;
+- architecture guards keep the adapter on accepted application boundaries, permit only the finite canonical Shopping `Quantity` / `QuantityUnit` value bridge, prohibit direct WeeklyPlan/Recipe/provider/retailer/matching/basket/comparison-domain/database coupling and protect reverse dependency direction;
+- ordinary CI remains retailer-network-free; M3.3 introduces no provider adapter, retailer activation, production-access policy change, persistence, UI, pantry semantics or database migration.
+
+## TDD evidence
+
+### Application composition
+
+RED `3c1cdbdfb74e5ae407e010ab1adcfeba2ed18757`:
+
+- service/architecture tests existed before M3.3 production types;
+- API CI failed on intentionally absent M3.3 application types.
+
+GREEN `9a0d1b6fa34e28b584747185ca56cc754eefa775`:
+
+- minimal wrapper/service/configuration implemented;
+- full API Maven verification passed with **340 tests, 0 failures, 0 errors** (5 skipped), including Spring context, Modulith and PostgreSQL/Testcontainers coverage;
+- tests prove generated ShoppingItem identity/order/value preservation and fail-closed cardinality/identity/requirement/quantity drift handling.
+
+### HTTP / problem contract
+
+Initial RED `df30faf5dd428d2b58f79992caf38e5d0a0e8967` revealed a test-only JSON helper defect. The fixture was corrected before production HTTP code.
+
+Corrected RED `d7415a2d5ae49937a6a85df99ee97c14819144ed`:
+
+- API CI failed only because the intended M3.3 controller/advice types did not yet exist.
+
+GREEN `4f1c9d70e96950cab0aef8e8ee75554b826ec4a2`:
+
+- thin controller, controller-scoped advice and sanitized wrapper problem added;
+- exact-head API CI succeeded;
+- binding coverage includes malformed/empty/null JSON, unknown wrapper/nested fields, invalid day/unit enums and fractional JSON for integer serving fields.
+
+### OpenAPI / generated client
+
+RED `d181b15e9b14f3e0855e1eeb9781a7e7cb281c20`:
+
+- old generated-schema freshness remained green;
+- TypeScript failed exactly on the intentionally missing M3.3 path constant, path, operation, request, response and problem types.
+
+Test-only approved-name correction `a87dcc790240d5c903e780051228bb5e40287f51` aligned the RED test with schema name `WeeklyPlanComparisonPreview` before OpenAPI implementation.
+
+OpenAPI/client source checkpoint `b4085e47965cf7616aed83ab5c5eee676ff72fcb` intentionally left generated output stale; pinned `openapi-typescript 7.13.0` Contract CI then failed only generated freshness and supplied the authoritative generated diff.
+
+GREEN `cf4f0e7d2ed6b767b99966aaedbed8dba883a715`:
+
+- generated `schema.d.ts` synchronized from the pinned generator diff;
+- generated blob `a56ebd3b8d499915cb2ddfeab135ac0d82008509` matched the generator target shown by CI;
+- exact-head Contract CI passed generated freshness, TypeScript typecheck, Vitest and build;
+- exact-head API CI also passed.
+
+## Final PR acceptance proof
+
+Final reviewed PR #116 head:
+
+`396445c333ea369bed6d428b33f38f37765eff20`
+
+On that exact head all **9/9 normal PR workflow groups succeeded**:
+
+1. API CI — SUCCESS;
+2. Contract CI — SUCCESS;
+3. Web CI + responsive E2E — SUCCESS;
+4. CodeQL Java + JavaScript/TypeScript — SUCCESS;
+5. Dependency Review — SUCCESS;
+6. Container Security API + Web — SUCCESS;
+7. Retailer Bridge CI — SUCCESS;
+8. Release Contract CI — SUCCESS;
+9. Release Bundle CI — SUCCESS.
+
+Read-only review on the same exact head:
+
+- verdict: **Looks good**;
+- P0: none;
+- P1: none;
+- P2: none;
+- P3: none;
+- unresolved review threads: **0**;
+- review changed no repository files.
+
+## Merge and post-merge acceptance proof
+
+PR #116 was squash-merged with expected-head protection.
+
+Accepted implementation merge:
+
+`89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`
+
+Post-merge evidence on that exact `main` SHA:
+
+- exactly **8 normal push workflows** were created;
+- **8/8 SUCCESS**;
+- CodeQL Java and JavaScript/TypeScript both succeeded;
+- Container Security API and Web both succeeded;
+- issue #115 is closed with state reason `completed`.
+
+Therefore M3.3 implementation is accepted as:
+
+**implemented → tested → reviewed → merged → accepted**.
+
+## Non-goals preserved
+
+M3.3 does not add:
+
+- Responsive Weekly Planning UI;
+- persistence, saved plans or history;
+- pantry/exclusion subtraction;
+- nutrition/macros;
+- calendar dates, week numbers or time-zone semantics;
+- fixed meal-slot taxonomy;
+- fuzzy/synonym/AI ingredient equivalence;
+- retailer/provider onboarding or activation;
+- production-access policy changes;
+- matching/basket/ranking redesign;
+- precise-address input;
+- database changes.
+
+## Decision
+
+**M3.3 WeeklyPlan → Comparison composition is COMPLETE / ACCEPTED.**
+
+The next deterministic product slice is **M3.4 — Responsive Weekly Planning UI**, consuming the accepted composed endpoint while preserving manual-list and Recipe journeys. Pantry/exclusion semantics and persistence remain separate later slices.
+
+Canonical documentation synchronization is performed by the docs-only acceptance PR containing this document; its own exact-head review/CI and post-merge push proof are verified separately from implementation acceptance.


### PR DESCRIPTION
Canonical documentation acceptance for M3.3 after implementation PR #116 was reviewed, merged and accepted on `main=89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`.

## Evidence already accepted

- implementation final reviewed head: `396445c333ea369bed6d428b33f38f37765eff20`
- implementation PR #116: 9/9 normal PR workflow groups SUCCESS
- read-only review: Looks good; no P0/P1/P2/P3; 0 unresolved threads
- squash merge: `89b9ef2ca95d07a7e4c964fdef38a9af1c5c3a43`
- issue #115: closed `completed`
- exact implementation merge: exactly 8 normal push workflows, 8/8 SUCCESS

## Docs-only scope

- add dedicated M3.3 acceptance evidence;
- mark M3.3 COMPLETE / ACCEPTED in PROJECT_STATE and ROADMAP;
- record accepted M3.3 behavior/evidence in CHANGELOG;
- set M3.4 Responsive Weekly Planning UI as the next deterministic target;
- preserve all historical M3.1/M3.2 evidence and parallel retailer/ops work.

This PR contains no application/runtime/OpenAPI/client behavior changes.