### PR TITLE
M3.4: add responsive Weekly Planning UI

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,11 +1,39 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
+function weeklyForm(page: Page): Locator {
+  return page.locator("section[aria-labelledby='weekly-plan-comparison']");
+}
+
 function recipeForm(page: Page): Locator {
   return page.locator("section[aria-labelledby='recipe-comparison']");
 }
 
 function manualForm(page: Page): Locator {
   return page.locator("section[aria-labelledby='comparison-preview']");
+}
+
+async function fillWeeklyPlan(page: Page, locality = "Москва") {
+  const form = weeklyForm(page);
+  await form.getByRole("textbox", { name: "Населённый пункт", exact: true }).fill(locality);
+
+  const first = form.getByRole("group", { name: "Блюдо 1", exact: true });
+  await first.getByRole("combobox", { name: "День", exact: true }).selectOption("MONDAY");
+  await first.getByRole("spinbutton", { name: "Нужно порций", exact: true }).fill("4");
+  await first.getByRole("textbox", { name: "Название рецепта", exact: true }).fill("Каша");
+  await first.getByRole("spinbutton", { name: "Порций в рецепте", exact: true }).fill("2");
+  await first.getByRole("textbox", { name: "Ингредиент", exact: true }).fill("Молоко");
+  await first.getByRole("spinbutton", { name: "Количество", exact: true }).fill("0.5");
+  await first.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
+
+  await form.getByRole("button", { name: "Добавить блюдо" }).click();
+  const second = form.getByRole("group", { name: "Блюдо 2", exact: true });
+  await second.getByRole("combobox", { name: "День", exact: true }).selectOption("SUNDAY");
+  await second.getByRole("spinbutton", { name: "Нужно порций", exact: true }).fill("4");
+  await second.getByRole("textbox", { name: "Название рецепта", exact: true }).fill("Омлет");
+  await second.getByRole("spinbutton", { name: "Порций в рецепте", exact: true }).fill("2");
+  await second.getByRole("textbox", { name: "Ингредиент", exact: true }).fill("Яйца");
+  await second.getByRole("spinbutton", { name: "Количество", exact: true }).fill("5");
+  await second.getByRole("combobox", { name: "Единица", exact: true }).selectOption("PIECE");
 }
 
 async function fillRecipeForm(page: Page, locality = "Москва") {
@@ -17,7 +45,6 @@ async function fillRecipeForm(page: Page, locality = "Москва") {
   await form.getByRole("textbox", { name: "Ингредиент", exact: true }).fill("Молоко");
   await form.getByRole("spinbutton", { name: "Количество", exact: true }).fill("0.5");
   await form.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
-
   await form.getByRole("button", { name: "Добавить ингредиент" }).click();
   await form.getByRole("textbox", { name: "Ингредиент", exact: true }).nth(1).fill("Яйца");
   await form.getByRole("spinbutton", { name: "Количество", exact: true }).nth(1).fill("5");
@@ -30,7 +57,6 @@ async function fillManualComparisonForm(page: Page) {
   await form.getByRole("textbox", { name: "Товар", exact: true }).fill("Молоко");
   await form.getByRole("spinbutton", { name: "Количество", exact: true }).fill("2");
   await form.getByRole("combobox", { name: "Единица", exact: true }).selectOption("LITER");
-
   await form.getByRole("button", { name: "Добавить товар" }).click();
   await form.getByRole("textbox", { name: "Товар", exact: true }).nth(1).fill("Яйца");
   await form.getByRole("spinbutton", { name: "Количество", exact: true }).nth(1).fill("10");
@@ -38,23 +64,12 @@ async function fillManualComparisonForm(page: Page) {
 }
 
 async function expectSafeComparisonResult(page: Page) {
-  await expect(page.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeVisible();
-  const retailerList = page.getByRole("list", { name: "Сравнение магазинов" });
+  await expect(page.getByRole("heading", { level: 2, name: "Результат для Москва" }).last()).toBeVisible();
+  const retailerList = page.getByRole("list", { name: "Сравнение магазинов" }).last();
   await expect(retailerList.locator(":scope > li")).toHaveCount(8);
-
-  for (const name of [
-    "Пятёрочка",
-    "Перекрёсток",
-    "Чижик",
-    "Магнит",
-    "Лента",
-    "ВкусВилл",
-    "Ozon Fresh",
-    "Самокат",
-  ]) {
-    await expect(page.getByRole("heading", { level: 3, name })).toBeVisible();
+  for (const name of ["Пятёрочка", "Перекрёсток", "Чижик", "Магнит", "Лента", "ВкусВилл", "Ozon Fresh", "Самокат"]) {
+    await expect(retailerList.getByRole("heading", { level: 3, name })).toBeVisible();
   }
-
   const body = await page.locator("body").innerText();
   expect(body).not.toContain("sourceProviderId");
   expect(body).not.toContain("acquisitionMode");
@@ -63,92 +78,93 @@ async function expectSafeComparisonResult(page: Page) {
   expect(body).not.toMatch(/самый дешёвый|лучший выбор|рекомендуем/i);
 }
 
-test("runs the desktop Recipe → shopping list → retailer comparison journey", async ({ page }) => {
+test("runs desktop WeeklyPlan → weekly shopping → retailer comparison", async ({ page }) => {
   await page.goto("/");
+  await expect(page.getByText(/M3 · Weekly Planning/i)).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Собрать неделю" })).toBeVisible();
 
-  await expect(page.getByRole("heading", { level: 1, name: "Закуп готов" })).toBeVisible();
-  await expect(page.getByText(/M2 · Recipes/i)).toBeVisible();
-  await expect(page.getByRole("heading", { level: 2, name: "Сравнить рецепт" })).toBeVisible();
+  await fillWeeklyPlan(page);
+  await weeklyForm(page).getByRole("button", { name: "Сравнить план" }).click();
 
-  await fillRecipeForm(page);
-  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
-
-  await expect(page.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeVisible();
-  const shoppingList = page.getByRole("list", { name: "Покупки из рецепта" });
-  await expect(shoppingList.getByText("Молоко", { exact: true })).toBeVisible();
-  await expect(shoppingList.getByText("1000 MILLILITER", { exact: true })).toBeVisible();
-  await expect(shoppingList.getByText("Яйца", { exact: true })).toBeVisible();
-  await expect(shoppingList.getByText("10 PIECE", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Покупки на неделю" })).toBeVisible();
+  const shopping = page.getByRole("list", { name: "Покупки на неделю" });
+  await expect(shopping.getByText("Молоко", { exact: true })).toBeVisible();
+  await expect(shopping.getByText("1000 MILLILITER", { exact: true })).toBeVisible();
+  await expect(shopping.getByText("Яйца", { exact: true })).toBeVisible();
+  await expect(shopping.getByText("10 PIECE", { exact: true })).toBeVisible();
   await expectSafeComparisonResult(page);
 
-  const overflowsHorizontally = await page.evaluate(
-    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
-  );
-  expect(overflowsHorizontally).toBe(false);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false);
 });
 
-test("Recipe journey remains usable without horizontal overflow on mobile", async ({ page }) => {
+test("keeps explicit occurrence order independent from day metadata", async ({ page }) => {
+  await page.goto("/");
+  await fillWeeklyPlan(page);
+  const form = weeklyForm(page);
+  await form.getByRole("button", { name: "Переместить блюдо 2 выше" }).click();
+  const first = form.getByRole("group", { name: "Блюдо 1", exact: true });
+  await expect(first.getByRole("textbox", { name: "Название рецепта", exact: true })).toHaveValue("Омлет");
+  await expect(first.getByRole("combobox", { name: "День", exact: true })).toHaveValue("SUNDAY");
+});
+
+test("WeeklyPlan journey remains usable without horizontal overflow on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
-
-  await fillRecipeForm(page);
-  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
-
-  await expect(page.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeVisible();
-  await expect(page.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeVisible();
-  const dimensions = await page.evaluate(() => ({
-    scrollWidth: document.documentElement.scrollWidth,
-    clientWidth: document.documentElement.clientWidth,
-  }));
+  await fillWeeklyPlan(page);
+  await weeklyForm(page).getByRole("button", { name: "Сравнить план" }).click();
+  await expect(page.getByRole("heading", { level: 2, name: "Покупки на неделю" })).toBeVisible();
+  const dimensions = await page.evaluate(() => ({ scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth }));
   expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
 });
 
-test("Recipe journey shows one accessible error and no fabricated results when the API is unavailable", async ({ page }) => {
+test("WeeklyPlan journey fails closed when API is unavailable", async ({ page }) => {
   await page.goto("/");
+  await fillWeeklyPlan(page, "Недоступно");
+  await weeklyForm(page).getByRole("button", { name: "Сравнить план" }).click();
+  await expect(page.getByRole("alert").filter({ hasText: "Не удалось сравнить недельный план" })).toHaveCount(1);
+  await expect(page.getByRole("list", { name: "Покупки на неделю" })).toHaveCount(0);
+});
 
+test("WeeklyPlan form exposes a visible keyboard focus path", async ({ page }) => {
+  await page.goto("/");
+  const locality = weeklyForm(page).getByRole("textbox", { name: "Населённый пункт", exact: true });
+  await page.keyboard.press("Tab");
+  await expect(locality).toBeFocused();
+  const visible = await locality.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    return (style.outlineStyle !== "none" && style.outlineWidth !== "0px") || style.boxShadow !== "none";
+  });
+  expect(visible).toBe(true);
+});
+
+test("preserves Recipe → shopping list → retailer comparison as a secondary journey", async ({ page }) => {
+  await page.goto("/");
+  await fillRecipeForm(page);
+  await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
+  await expect(page.getByRole("heading", { level: 2, name: "Список покупок из рецепта" })).toBeVisible();
+  const shoppingList = page.getByRole("list", { name: "Покупки из рецепта" });
+  await expect(shoppingList.getByText("1000 MILLILITER", { exact: true })).toBeVisible();
+  await expect(shoppingList.getByText("10 PIECE", { exact: true })).toBeVisible();
+});
+
+test("Recipe unavailable state remains fail-closed", async ({ page }) => {
+  await page.goto("/");
   await fillRecipeForm(page, "Недоступно");
   await recipeForm(page).getByRole("button", { name: "Сравнить рецепт" }).click();
-
-  const serviceAlert = page.getByRole("alert").filter({
-    hasText: "Не удалось сравнить рецепт. Основной сервис временно недоступен.",
-  });
-  await expect(serviceAlert).toHaveCount(1);
-  await expect(page.getByRole("list", { name: "Покупки из рецепта" })).toHaveCount(0);
-  await expect(page.getByRole("list", { name: "Сравнение магазинов" })).toHaveCount(0);
+  await expect(page.getByRole("alert").filter({ hasText: "Не удалось сравнить рецепт" })).toHaveCount(1);
 });
 
-test("Recipe form has a visible keyboard focus path", async ({ page }) => {
+test("preserves deterministic manual comparison as a secondary path", async ({ page }) => {
   await page.goto("/");
-
-  const title = recipeForm(page).getByRole("textbox", { name: "Название рецепта", exact: true });
-  await page.keyboard.press("Tab");
-  await expect(title).toBeFocused();
-
-  const focusIsVisible = await title.evaluate((element) => {
-    const style = window.getComputedStyle(element);
-    return (
-      (style.outlineStyle !== "none" && style.outlineWidth !== "0px") ||
-      style.boxShadow !== "none"
-    );
-  });
-  expect(focusIsVisible).toBe(true);
-});
-
-test("preserves the deterministic manual comparison journey as a secondary path", async ({ page }) => {
-  await page.goto("/");
-
-  await expect(page.getByRole("heading", { level: 2, name: "Сравнить корзину" })).toBeVisible();
   await fillManualComparisonForm(page);
   await manualForm(page).getByRole("button", { name: "Сравнить корзину" }).click();
-
   await expectSafeComparisonResult(page);
   await expect(page.getByText("Корзина рассчитана")).toHaveCount(1);
   await expect(page.getByText("Есть неопределённость")).toHaveCount(1);
   await expect(page.getByText("Корзина неполная")).toHaveCount(4);
   await expect(page.getByText("Сравнение пока недоступно")).toHaveCount(2);
-
-  const magnit = page.getByRole("article", { name: "Магнит" });
+  const magnit = page.getByRole("article", { name: "Магнит" }).last();
   await expect(magnit.getByText("Неизвестен размер упаковки", { exact: true })).toHaveCount(1);
-  const lenta = page.getByRole("article", { name: "Лента" });
+  const lenta = page.getByRole("article", { name: "Лента" }).last();
   await expect(lenta.getByText("Товар не найден", { exact: true })).toHaveCount(1);
 });

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -19,12 +19,8 @@ function normalizeText(value) {
 }
 
 function canonicalQuantity(quantity) {
-  if (quantity.unit === "KILOGRAM") {
-    return { amount: quantity.amount * 1000, unit: "GRAM" };
-  }
-  if (quantity.unit === "LITER") {
-    return { amount: quantity.amount * 1000, unit: "MILLILITER" };
-  }
+  if (quantity.unit === "KILOGRAM") return { amount: quantity.amount * 1000, unit: "GRAM" };
+  if (quantity.unit === "LITER") return { amount: quantity.amount * 1000, unit: "MILLILITER" };
   return { amount: quantity.amount, unit: quantity.unit };
 }
 
@@ -40,11 +36,7 @@ function readJson(request) {
       }
     });
     request.on("end", () => {
-      try {
-        resolve(JSON.parse(body));
-      } catch (error) {
-        reject(error);
-      }
+      try { resolve(JSON.parse(body)); } catch (error) { reject(error); }
     });
     request.on("error", reject);
   });
@@ -56,27 +48,19 @@ function writeJson(response, status, payload) {
 }
 
 function requestedItem(item) {
-  return {
-    id: item.id,
-    requirement: item.requirement,
-    quantity: canonicalQuantity(item.quantity),
-  };
+  return { id: item.id, requirement: item.requirement, quantity: canonicalQuantity(item.quantity) };
 }
 
 function selection(item, productName, packageQuantity, packagePrice) {
   const requested = canonicalQuantity(item.quantity);
-  const packageCount =
-    requested.unit === packageQuantity.unit
-      ? Math.max(1, Math.ceil(requested.amount / packageQuantity.amount))
-      : 1;
+  const packageCount = requested.unit === packageQuantity.unit
+    ? Math.max(1, Math.ceil(requested.amount / packageQuantity.amount))
+    : 1;
   return {
     productName,
     packageQuantity,
     packageCount,
-    coveredQuantity: {
-      amount: packageQuantity.amount * packageCount,
-      unit: packageQuantity.unit,
-    },
+    coveredQuantity: { amount: packageQuantity.amount * packageCount, unit: packageQuantity.unit },
     lineTotal: packagePrice * packageCount,
     currencyCode: "RUB",
   };
@@ -93,12 +77,12 @@ function itemResult(item, status, options = {}) {
   };
 }
 
-function unavailable(id, reason, coverage = "CONNECTED", productionAccess = "READY") {
+function unavailable(id, reason) {
   return {
     id,
     displayName: retailerNames[id],
-    coverage,
-    productionAccess,
+    coverage: "CONNECTED",
+    productionAccess: "READY",
     comparisonStatus: "UNAVAILABLE",
     reasons: [reason],
     items: [],
@@ -107,21 +91,11 @@ function unavailable(id, reason, coverage = "CONNECTED", productionAccess = "REA
 
 function buildPreview(request) {
   const [milk, eggs] = request.items;
-  const milkSelection = selection(
-    milk,
-    "Молоко",
-    { amount: 1000, unit: "MILLILITER" },
-    100,
-  );
-  const eggsSelection = selection(
-    eggs,
-    "Яйца",
-    { amount: 10, unit: "PIECE" },
-    120,
-  );
+  const milkSelection = selection(milk, "Молоко", { amount: 1000, unit: "MILLILITER" }, 100);
+  const eggsSelection = selection(eggs, "Яйца", { amount: 10, unit: "PIECE" }, 120);
 
   return {
-    locality: request.locality.trim(),
+    locality: normalizeText(request.locality),
     items: request.items.map(requestedItem),
     retailers: [
       {
@@ -131,18 +105,9 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "READY",
         reasons: [],
-        total: {
-          amount: milkSelection.lineTotal + eggsSelection.lineTotal,
-          currencyCode: "RUB",
-        },
-        freshness: {
-          basis: "OBSERVATION_ONLY",
-          observedAt: "2026-08-12T10:00:00Z",
-        },
-        items: [
-          itemResult(milk, "FULFILLED", { selection: milkSelection }),
-          itemResult(eggs, "FULFILLED", { selection: eggsSelection }),
-        ],
+        total: { amount: milkSelection.lineTotal + eggsSelection.lineTotal, currencyCode: "RUB" },
+        freshness: { basis: "OBSERVATION_ONLY", observedAt: "2026-08-12T10:00:00Z" },
+        items: [itemResult(milk, "FULFILLED", { selection: milkSelection }), itemResult(eggs, "FULFILLED", { selection: eggsSelection })],
       },
       {
         id: "perekrestok",
@@ -151,22 +116,11 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "UNCERTAIN",
         reasons: ["AVAILABILITY_UNKNOWN"],
-        total: {
-          amount: milkSelection.lineTotal + eggsSelection.lineTotal + 10,
-          currencyCode: "RUB",
-        },
-        freshness: {
-          basis: "PROVIDER_TIMESTAMP",
-          observedAt: "2026-08-12T10:00:00Z",
-          providerUpdatedAt: "2026-08-12T09:55:00Z",
-        },
+        total: { amount: milkSelection.lineTotal + eggsSelection.lineTotal + 10, currencyCode: "RUB" },
+        freshness: { basis: "PROVIDER_TIMESTAMP", observedAt: "2026-08-12T10:00:00Z", providerUpdatedAt: "2026-08-12T09:55:00Z" },
         items: [
-          itemResult(milk, "AVAILABILITY_UNKNOWN", {
-            selection: { ...milkSelection, lineTotal: milkSelection.lineTotal + 5 },
-          }),
-          itemResult(eggs, "FULFILLED", {
-            selection: { ...eggsSelection, lineTotal: eggsSelection.lineTotal + 5 },
-          }),
+          itemResult(milk, "AVAILABILITY_UNKNOWN", { selection: { ...milkSelection, lineTotal: milkSelection.lineTotal + 5 } }),
+          itemResult(eggs, "FULFILLED", { selection: { ...eggsSelection, lineTotal: eggsSelection.lineTotal + 5 } }),
         ],
       },
       unavailable("chizhik", "DATA_NOT_AVAILABLE"),
@@ -178,9 +132,7 @@ function buildPreview(request) {
         comparisonStatus: "INCOMPLETE",
         reasons: ["PACKAGE_QUANTITY_UNKNOWN"],
         items: [
-          itemResult(milk, "PACKAGE_QUANTITY_UNKNOWN", {
-            candidateProductNames: ["Молоко"],
-          }),
+          itemResult(milk, "PACKAGE_QUANTITY_UNKNOWN", { candidateProductNames: ["Молоко"] }),
           itemResult(eggs, "FULFILLED", { selection: eggsSelection }),
         ],
       },
@@ -200,11 +152,7 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "INCOMPLETE",
         reasons: ["ITEM_AMBIGUOUS"],
-        items: [
-          itemResult(milk, "AMBIGUOUS", {
-            candidateProductNames: ["Молоко", "Молоко"],
-          }),
-        ],
+        items: [itemResult(milk, "AMBIGUOUS", { candidateProductNames: ["Молоко", "Молоко"] })],
       },
       {
         id: "ozon-fresh",
@@ -213,11 +161,7 @@ function buildPreview(request) {
         productionAccess: "READY",
         comparisonStatus: "INCOMPLETE",
         reasons: ["QUANTITY_UNIT_MISMATCH"],
-        items: [
-          itemResult(milk, "QUANTITY_UNIT_MISMATCH", {
-            candidateProductNames: ["Молоко"],
-          }),
-        ],
+        items: [itemResult(milk, "QUANTITY_UNIT_MISMATCH", { candidateProductNames: ["Молоко"] })],
       },
       unavailable("samokat", "SOURCE_UNAVAILABLE"),
     ],
@@ -231,15 +175,11 @@ function fixedUuid(prefix, index = 1) {
 function buildRecipeComparisonPreview(request) {
   const recipe = request.recipe;
   const scale = recipe.targetServings / recipe.baseServings;
-  const recipeId = fixedUuid("1");
-  const shoppingListId = fixedUuid("3");
-
   const sourceIngredients = recipe.ingredients.map((ingredient, index) => ({
     id: fixedUuid("2", index + 1),
     requirement: normalizeText(ingredient.requirement),
     quantity: canonicalQuantity(ingredient.quantity),
   }));
-
   const groups = new Map();
   for (const ingredient of sourceIngredients) {
     const key = `${ingredient.requirement}\u0000${ingredient.quantity.unit}`;
@@ -256,41 +196,75 @@ function buildRecipeComparisonPreview(request) {
       });
     }
   }
-
-  const shoppingItems = Array.from(groups.values()).map((item, index) => ({
-    id: fixedUuid("4", index + 1),
-    ...item,
-  }));
-
+  const shoppingItems = Array.from(groups.values()).map((item, index) => ({ id: fixedUuid("4", index + 1), ...item }));
   return {
     recipeShoppingPreview: {
       recipe: {
-        id: recipeId,
+        id: fixedUuid("1"),
         title: normalizeText(recipe.title),
         baseServings: recipe.baseServings,
         targetServings: recipe.targetServings,
         ingredients: sourceIngredients,
       },
-      shoppingList: {
-        id: shoppingListId,
-        items: shoppingItems,
-      },
+      shoppingList: { id: fixedUuid("3"), items: shoppingItems },
     },
-    comparisonPreview: buildPreview({
-      locality: request.locality,
-      items: shoppingItems,
-    }),
+    comparisonPreview: buildPreview({ locality: request.locality, items: shoppingItems }),
   };
 }
 
-function invalidComparison(response, message = "deterministic acceptance requires two items") {
-  writeJson(response, 400, {
-    type: "https://zakup-gotov.dev/problems/invalid-comparison-preview",
-    title: "Invalid comparison preview request",
-    status: 400,
-    code: "INVALID_COMPARISON_PREVIEW",
-    errors: [{ field: "items", message }],
+function buildWeeklyPlanComparisonPreview(request) {
+  const occurrences = [];
+  const groups = new Map();
+
+  request.weeklyPlan.occurrences.forEach((occurrence, occurrenceIndex) => {
+    const occurrenceId = fixedUuid("5", occurrenceIndex + 1);
+    const recipeId = fixedUuid("6", occurrenceIndex + 1);
+    const scale = occurrence.targetServings / occurrence.recipe.baseServings;
+    const ingredients = occurrence.recipe.ingredients.map((ingredient, ingredientIndex) => {
+      const canonical = canonicalQuantity(ingredient.quantity);
+      const ingredientId = fixedUuid("7", occurrenceIndex * 100 + ingredientIndex + 1);
+      const requirement = normalizeText(ingredient.requirement);
+      const key = `${requirement}\u0000${canonical.unit}`;
+      const existing = groups.get(key);
+      const source = { occurrenceId, recipeId, recipeIngredientId: ingredientId };
+      if (existing) {
+        existing.quantity.amount += canonical.amount * scale;
+        existing.sources.push(source);
+      } else {
+        groups.set(key, {
+          requirement,
+          quantity: { amount: canonical.amount * scale, unit: canonical.unit },
+          sources: [source],
+        });
+      }
+      return { id: ingredientId, requirement, quantity: canonical };
+    });
+
+    occurrences.push({
+      id: occurrenceId,
+      day: occurrence.day,
+      targetServings: occurrence.targetServings,
+      recipe: {
+        id: recipeId,
+        title: normalizeText(occurrence.recipe.title),
+        baseServings: occurrence.recipe.baseServings,
+        ingredients,
+      },
+    });
   });
+
+  const shoppingItems = Array.from(groups.values()).map((item, index) => ({
+    id: fixedUuid("8", index + 1),
+    ...item,
+  }));
+
+  return {
+    weeklyPlanShoppingPreview: {
+      weeklyPlan: { id: fixedUuid("9"), occurrences },
+      shoppingList: { id: fixedUuid("a"), items: shoppingItems },
+    },
+    comparisonPreview: buildPreview({ locality: request.locality, items: shoppingItems }),
+  };
 }
 
 function invalidRecipeComparison(response, field, message) {
@@ -303,13 +277,22 @@ function invalidRecipeComparison(response, field, message) {
   });
 }
 
+function invalidWeeklyPlanComparison(response, field, message) {
+  writeJson(response, 400, {
+    type: "https://zakup-gotov.dev/problems/invalid-weekly-plan-comparison-preview",
+    title: "Invalid weekly plan comparison preview request",
+    status: 400,
+    code: "INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW",
+    errors: [{ field, message }],
+  });
+}
+
 const server = http.createServer(async (request, response) => {
   if (request.method === "GET" && request.url === "/health") {
     response.writeHead(204);
     response.end();
     return;
   }
-
   if (request.method !== "POST") {
     writeJson(response, 404, { error: "not found" });
     return;
@@ -318,21 +301,31 @@ const server = http.createServer(async (request, response) => {
   try {
     const body = await readJson(request);
 
+    if (request.url === "/api/v1/weekly-plan-comparison-previews") {
+      if (body.locality === "Недоступно") {
+        writeJson(response, 503, { error: "deterministic unavailable scenario" });
+        return;
+      }
+      if (!body.weeklyPlan || !Array.isArray(body.weeklyPlan.occurrences) || body.weeklyPlan.occurrences.length < 1) {
+        invalidWeeklyPlanComparison(response, "weeklyPlan.occurrences", "deterministic acceptance requires occurrences");
+        return;
+      }
+      const result = buildWeeklyPlanComparisonPreview(body);
+      if (result.weeklyPlanShoppingPreview.shoppingList.items.length < 2) {
+        invalidWeeklyPlanComparison(response, "weeklyPlan.occurrences", "deterministic acceptance requires two shopping requirements");
+        return;
+      }
+      writeJson(response, 200, result);
+      return;
+    }
+
     if (request.url === "/api/v1/recipe-comparison-previews") {
       if (body.locality === "Недоступно") {
         writeJson(response, 503, { error: "deterministic unavailable scenario" });
         return;
       }
-      if (
-        !body.recipe ||
-        !Array.isArray(body.recipe.ingredients) ||
-        body.recipe.ingredients.length < 2
-      ) {
-        invalidRecipeComparison(
-          response,
-          "recipe.ingredients",
-          "deterministic acceptance requires two ingredients",
-        );
+      if (!body.recipe || !Array.isArray(body.recipe.ingredients) || body.recipe.ingredients.length < 2) {
+        invalidRecipeComparison(response, "recipe.ingredients", "deterministic acceptance requires two ingredients");
         return;
       }
       writeJson(response, 200, buildRecipeComparisonPreview(body));
@@ -345,7 +338,13 @@ const server = http.createServer(async (request, response) => {
         return;
       }
       if (!Array.isArray(body.items) || body.items.length < 2) {
-        invalidComparison(response);
+        writeJson(response, 400, {
+          type: "https://zakup-gotov.dev/problems/invalid-comparison-preview",
+          title: "Invalid comparison preview request",
+          status: 400,
+          code: "INVALID_COMPARISON_PREVIEW",
+          errors: [{ field: "items", message: "deterministic acceptance requires two items" }],
+        });
         return;
       }
       writeJson(response, 200, buildPreview(body));
@@ -355,10 +354,10 @@ const server = http.createServer(async (request, response) => {
     writeJson(response, 404, { error: "not found" });
   } catch {
     writeJson(response, 400, {
-      type: "https://zakup-gotov.dev/problems/invalid-recipe-comparison-preview",
-      title: "Invalid recipe comparison preview request",
+      type: "https://zakup-gotov.dev/problems/invalid-weekly-plan-comparison-preview",
+      title: "Invalid weekly plan comparison preview request",
       status: 400,
-      code: "INVALID_RECIPE_COMPARISON_PREVIEW",
+      code: "INVALID_WEEKLY_PLAN_COMPARISON_PREVIEW",
       errors: [{ field: "$request", message: "malformed JSON request" }],
     });
   }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -4,8 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import Home from "./page";
 import { loadRetailerReadiness } from "./retailer-readiness";
 
-vi.mock("./retailer-readiness", () => ({
-  loadRetailerReadiness: vi.fn(),
+vi.mock("./retailer-readiness", () => ({ loadRetailerReadiness: vi.fn() }));
+
+vi.mock("./weekly-plan-comparison-form", () => ({
+  WeeklyPlanComparisonForm: () => (
+    <section aria-labelledby="weekly-plan-comparison">
+      <h2 id="weekly-plan-comparison">Собрать неделю</h2>
+    </section>
+  ),
 }));
 
 vi.mock("./recipe-comparison-form", () => ({
@@ -32,27 +38,24 @@ afterEach(() => {
 });
 
 describe("home page", () => {
-  it("renders the M2 Recipe journey first while preserving manual basket comparison", async () => {
+  it("renders M3 Weekly Planning first while preserving Recipe and manual journeys", async () => {
     render(await Home());
 
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
     expect(screen.getByRole("heading", { level: 1, name: "Закуп готов" })).toBeDefined();
-    expect(screen.getByText(/M2 · Recipes/i)).toBeDefined();
-    expect(screen.queryByText(/M1 · Shopping Core/i)).toBeNull();
-    expect(screen.queryByText(/M0 · Product & Integration Discovery/i)).toBeNull();
+    expect(screen.getByText(/M3 · Weekly Planning/i)).toBeDefined();
+    expect(screen.queryByText(/M2 · Recipes/i)).toBeNull();
 
+    const weeklyHeading = screen.getByRole("heading", { level: 2, name: "Собрать неделю" });
     const recipeHeading = screen.getByRole("heading", { level: 2, name: "Сравнить рецепт" });
     const manualHeading = screen.getByRole("heading", { level: 2, name: "Сравнить корзину" });
-    expect(recipeHeading).toBeDefined();
-    expect(manualHeading).toBeDefined();
+    expect(weeklyHeading.compareDocumentPosition(recipeHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(recipeHeading.compareDocumentPosition(manualHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     expect(screen.queryByRole("heading", { level: 2, name: "Покрытие магазинов" })).toBeNull();
     expect(mockedLoadRetailerReadiness).not.toHaveBeenCalled();
 
     const documentation = screen.getByRole("link", { name: "Документация проекта" });
-    expect(documentation.getAttribute("href")).toBe(
-      "https://github.com/True-Ruslan/zakup-gotov#readme",
-    );
+    expect(documentation.getAttribute("href")).toBe("https://github.com/True-Ruslan/zakup-gotov#readme");
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { ComparisonPreviewForm } from "./comparison-preview-form";
 import { RecipeComparisonForm } from "./recipe-comparison-form";
+import { WeeklyPlanComparisonForm } from "./weekly-plan-comparison-form";
 
 export default function Home() {
   return (
@@ -7,7 +8,7 @@ export default function Home() {
       <div className="mx-auto w-full max-w-5xl px-6 py-16 sm:px-10 lg:px-16 lg:py-24">
         <div className="max-w-2xl">
           <p className="text-sm font-medium uppercase tracking-[0.18em] text-stone-500">
-            M2 · Recipes
+            M3 · Weekly Planning
           </p>
 
           <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-6xl">
@@ -15,9 +16,9 @@ export default function Home() {
           </h1>
 
           <p className="mt-6 max-w-xl text-lg leading-8 text-stone-600 sm:text-xl">
-            Превратите рецепт в список покупок для нужного числа порций и сравните
-            корзину по подтверждённым данным магазинов. Неполные корзины и
-            неопределённость остаются видимыми.
+            Соберите блюда на неделю, получите один канонический список покупок и
+            сравните полную корзину по подтверждённым данным магазинов. Неполные
+            корзины и неопределённость остаются видимыми.
           </p>
 
           <section
@@ -28,13 +29,20 @@ export default function Home() {
               Сейчас
             </h2>
             <p className="mt-2 text-base leading-7 text-stone-600">
-              Рецепт и сравнение работают как stateless preview: без аккаунта,
-              сохранения рецепта или адреса. Если для магазина нет безопасных данных,
-              мы не подставляем фиктивную цену.
+              Недельный план работает как stateless preview: без аккаунта, сохранения
+              плана или точного адреса. Порядок блюд задаёте вы, а пересчёт ингредиентов,
+              объединение покупок и сравнение выполняет серверная композиция.
             </p>
           </section>
         </div>
 
+        <WeeklyPlanComparisonForm />
+
+        <div className="mt-16 border-t border-stone-200 pt-8">
+          <p className="max-w-2xl text-sm leading-6 text-stone-600">
+            Планируете одно блюдо? Сравните отдельный рецепт без недельного плана.
+          </p>
+        </div>
         <RecipeComparisonForm />
 
         <div className="mt-16 border-t border-stone-200 pt-8">

--- a/apps/web/src/app/weekly-plan-comparison-form.test.tsx
+++ b/apps/web/src/app/weekly-plan-comparison-form.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createWeeklyPlanComparisonPreview } from "./weekly-plan-comparison";
+import { WeeklyPlanComparisonForm } from "./weekly-plan-comparison-form";
+
+vi.mock("./weekly-plan-comparison", () => ({ createWeeklyPlanComparisonPreview: vi.fn() }));
+vi.mock("./weekly-plan-comparison-results", () => ({
+  WeeklyPlanComparisonResults: () => <section aria-label="Результаты недельного плана">Результаты недельного плана</section>,
+}));
+
+const mockedCreate = vi.mocked(createWeeklyPlanComparisonPreview);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function ready() {
+  mockedCreate.mockResolvedValue({
+    kind: "ready",
+    data: {
+      weeklyPlanShoppingPreview: {
+        weeklyPlan: { id: "10000000-0000-0000-0000-000000000001", occurrences: [] },
+        shoppingList: { id: "13000000-0000-0000-0000-000000000001", items: [] },
+      },
+      comparisonPreview: { locality: "Москва", items: [], retailers: [] },
+    },
+  });
+}
+
+describe("WeeklyPlan comparison form", () => {
+  it("starts with one occurrence and one protected ingredient", () => {
+    render(<WeeklyPlanComparisonForm />);
+    expect(screen.getAllByRole("group", { name: /Блюдо 1/ })).toHaveLength(1);
+    expect(screen.getAllByLabelText("Ингредиент")).toHaveLength(1);
+    expect((screen.getByRole("button", { name: "Удалить блюдо 1" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Переместить блюдо 1 выше" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("adds and explicitly reorders occurrences without sorting by day", () => {
+    render(<WeeklyPlanComparisonForm />);
+    fireEvent.click(screen.getByRole("button", { name: "Добавить блюдо" }));
+
+    const groups = screen.getAllByRole("group", { name: /Блюдо/ });
+    fireEvent.change(within(groups[0]!).getByLabelText("День"), { target: { value: "SUNDAY" } });
+    fireEvent.change(within(groups[1]!).getByLabelText("День"), { target: { value: "MONDAY" } });
+    fireEvent.change(within(groups[0]!).getByLabelText("Название рецепта"), { target: { value: "Первое" } });
+    fireEvent.change(within(groups[1]!).getByLabelText("Название рецепта"), { target: { value: "Второе" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Переместить блюдо 2 выше" }));
+    const reordered = screen.getAllByRole("group", { name: /Блюдо/ });
+    expect((within(reordered[0]!).getByLabelText("Название рецепта") as HTMLInputElement).value).toBe("Второе");
+    expect((within(reordered[0]!).getByLabelText("День") as HTMLSelectElement).value).toBe("MONDAY");
+  });
+
+  it("submits the generated M3.3 request shape and trims presentation text", async () => {
+    ready();
+    render(<WeeklyPlanComparisonForm />);
+
+    fireEvent.change(screen.getByLabelText("Населённый пункт"), { target: { value: "  Москва  " } });
+    const group = screen.getByRole("group", { name: /Блюдо 1/ });
+    fireEvent.change(within(group).getByLabelText("День"), { target: { value: "TUESDAY" } });
+    fireEvent.change(within(group).getByLabelText("Нужно порций"), { target: { value: "4" } });
+    fireEvent.change(within(group).getByLabelText("Название рецепта"), { target: { value: "  Блины  " } });
+    fireEvent.change(within(group).getByLabelText("Порций в рецепте"), { target: { value: "2" } });
+    fireEvent.change(within(group).getByLabelText("Ингредиент"), { target: { value: "  Молоко  " } });
+    fireEvent.change(within(group).getByLabelText("Количество"), { target: { value: "0.5" } });
+    fireEvent.change(within(group).getByLabelText("Единица"), { target: { value: "LITER" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить план" }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate).toHaveBeenCalledWith({
+      locality: "Москва",
+      weeklyPlan: {
+        occurrences: [
+          {
+            day: "TUESDAY",
+            targetServings: 4,
+            recipe: {
+              title: "Блины",
+              baseServings: 2,
+              ingredients: [{ requirement: "Молоко", quantity: { amount: 0.5, unit: "LITER" } }],
+            },
+          },
+        ],
+      },
+    });
+    expect(screen.getByLabelText("Результаты недельного плана")).toBeDefined();
+  });
+
+  it("rejects invalid input before contacting the backend", () => {
+    render(<WeeklyPlanComparisonForm />);
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить план" }));
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Укажите населённый пункт");
+    expect(alert.textContent).toContain("Укажите название рецепта для блюда 1");
+    expect(alert.textContent).toContain("Укажите ингредиент для блюда 1");
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the service is unavailable", async () => {
+    mockedCreate.mockResolvedValue({ kind: "unavailable" });
+    render(<WeeklyPlanComparisonForm />);
+    fireEvent.change(screen.getByLabelText("Населённый пункт"), { target: { value: "Москва" } });
+    const group = screen.getByRole("group", { name: /Блюдо 1/ });
+    fireEvent.change(within(group).getByLabelText("Название рецепта"), { target: { value: "Блины" } });
+    fireEvent.change(within(group).getByLabelText("Ингредиент"), { target: { value: "Молоко" } });
+    fireEvent.click(screen.getByRole("button", { name: "Сравнить план" }));
+    expect((await screen.findByRole("alert")).textContent).toContain("Не удалось сравнить недельный план");
+    expect(screen.queryByLabelText("Результаты недельного плана")).toBeNull();
+  });
+});

--- a/apps/web/src/app/weekly-plan-comparison-form.tsx
+++ b/apps/web/src/app/weekly-plan-comparison-form.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import type { components } from "@zakup-gotov/api-client";
+import {
+  createWeeklyPlanComparisonPreview,
+  type WeeklyPlanComparisonPreviewRequest,
+  type WeeklyPlanComparisonState,
+} from "./weekly-plan-comparison";
+import { WeeklyPlanComparisonResults } from "./weekly-plan-comparison-results";
+
+type QuantityUnit = components["schemas"]["QuantityInputUnit"];
+type WeeklyPlanDay = components["schemas"]["WeeklyPlanDay"];
+
+type IngredientRow = {
+  key: number;
+  requirement: string;
+  amount: string;
+  unit: QuantityUnit;
+};
+
+type OccurrenceRow = {
+  key: number;
+  day: WeeklyPlanDay;
+  targetServings: string;
+  title: string;
+  baseServings: string;
+  ingredients: IngredientRow[];
+};
+
+const days: Array<{ value: WeeklyPlanDay; label: string }> = [
+  { value: "MONDAY", label: "Понедельник" },
+  { value: "TUESDAY", label: "Вторник" },
+  { value: "WEDNESDAY", label: "Среда" },
+  { value: "THURSDAY", label: "Четверг" },
+  { value: "FRIDAY", label: "Пятница" },
+  { value: "SATURDAY", label: "Суббота" },
+  { value: "SUNDAY", label: "Воскресенье" },
+];
+
+const units: Array<{ value: QuantityUnit; label: string }> = [
+  { value: "PIECE", label: "шт." },
+  { value: "GRAM", label: "г" },
+  { value: "KILOGRAM", label: "кг" },
+  { value: "MILLILITER", label: "мл" },
+  { value: "LITER", label: "л" },
+];
+
+function newIngredient(key = 1): IngredientRow {
+  return { key, requirement: "", amount: "1", unit: "PIECE" };
+}
+
+function newOccurrence(key: number): OccurrenceRow {
+  return {
+    key,
+    day: "MONDAY",
+    targetServings: "2",
+    title: "",
+    baseServings: "2",
+    ingredients: [newIngredient()],
+  };
+}
+
+function clientErrors(locality: string, occurrences: OccurrenceRow[]) {
+  const errors: string[] = [];
+  if (!locality.trim()) errors.push("Укажите населённый пункт.");
+
+  occurrences.forEach((occurrence, occurrenceIndex) => {
+    const number = occurrenceIndex + 1;
+    const targetServings = Number(occurrence.targetServings);
+    const baseServings = Number(occurrence.baseServings);
+
+    if (!occurrence.title.trim()) errors.push(`Укажите название рецепта для блюда ${number}.`);
+    if (!Number.isInteger(targetServings) || targetServings <= 0) {
+      errors.push(`Нужно порций для блюда ${number} должно быть целым числом больше 0.`);
+    }
+    if (!Number.isInteger(baseServings) || baseServings <= 0) {
+      errors.push(`Порций в рецепте для блюда ${number} должно быть целым числом больше 0.`);
+    }
+
+    occurrence.ingredients.forEach((ingredient, ingredientIndex) => {
+      if (!ingredient.requirement.trim()) {
+        errors.push(
+          occurrence.ingredients.length === 1
+            ? `Укажите ингредиент для блюда ${number}.`
+            : `Укажите ингредиент ${ingredientIndex + 1} для блюда ${number}.`,
+        );
+      }
+      const amount = Number(ingredient.amount);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        errors.push(`Количество ингредиента ${ingredientIndex + 1} для блюда ${number} должно быть больше 0.`);
+      }
+    });
+  });
+
+  return errors;
+}
+
+export function WeeklyPlanComparisonForm() {
+  const [locality, setLocality] = useState("");
+  const [occurrences, setOccurrences] = useState<OccurrenceRow[]>(() => [newOccurrence(1)]);
+  const [state, setState] = useState<WeeklyPlanComparisonState | null>(null);
+  const [clientMessages, setClientMessages] = useState<string[]>([]);
+  const [pending, setPending] = useState(false);
+
+  function updateOccurrence(key: number, patch: Partial<OccurrenceRow>) {
+    setOccurrences((current) => current.map((item) => item.key === key ? { ...item, ...patch } : item));
+  }
+
+  function addOccurrence() {
+    setOccurrences((current) => {
+      if (current.length >= 35) return current;
+      const key = Math.max(...current.map((item) => item.key)) + 1;
+      return [...current, newOccurrence(key)];
+    });
+  }
+
+  function removeOccurrence(key: number) {
+    setOccurrences((current) => current.length === 1 ? current : current.filter((item) => item.key !== key));
+  }
+
+  function moveOccurrence(index: number, delta: -1 | 1) {
+    setOccurrences((current) => {
+      const target = index + delta;
+      if (index < 0 || index >= current.length || target < 0 || target >= current.length) return current;
+      const next = [...current];
+      [next[index], next[target]] = [next[target]!, next[index]!];
+      return next;
+    });
+  }
+
+  function updateIngredient(occurrenceKey: number, ingredientKey: number, patch: Partial<IngredientRow>) {
+    setOccurrences((current) => current.map((occurrence) => {
+      if (occurrence.key !== occurrenceKey) return occurrence;
+      return {
+        ...occurrence,
+        ingredients: occurrence.ingredients.map((ingredient) =>
+          ingredient.key === ingredientKey ? { ...ingredient, ...patch } : ingredient,
+        ),
+      };
+    }));
+  }
+
+  function addIngredient(occurrenceKey: number) {
+    setOccurrences((current) => current.map((occurrence) => {
+      if (occurrence.key !== occurrenceKey || occurrence.ingredients.length >= 100) return occurrence;
+      const key = Math.max(...occurrence.ingredients.map((ingredient) => ingredient.key)) + 1;
+      return { ...occurrence, ingredients: [...occurrence.ingredients, newIngredient(key)] };
+    }));
+  }
+
+  function removeIngredient(occurrenceKey: number, ingredientKey: number) {
+    setOccurrences((current) => current.map((occurrence) => {
+      if (occurrence.key !== occurrenceKey || occurrence.ingredients.length === 1) return occurrence;
+      return { ...occurrence, ingredients: occurrence.ingredients.filter((ingredient) => ingredient.key !== ingredientKey) };
+    }));
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (pending) return;
+
+    const validationErrors = clientErrors(locality, occurrences);
+    if (validationErrors.length > 0) {
+      setState(null);
+      setClientMessages(validationErrors);
+      return;
+    }
+
+    const request: WeeklyPlanComparisonPreviewRequest = {
+      locality: locality.trim(),
+      weeklyPlan: {
+        occurrences: occurrences.map((occurrence) => ({
+          day: occurrence.day,
+          targetServings: Number(occurrence.targetServings),
+          recipe: {
+            title: occurrence.title.trim(),
+            baseServings: Number(occurrence.baseServings),
+            ingredients: occurrence.ingredients.map((ingredient) => ({
+              requirement: ingredient.requirement.trim(),
+              quantity: { amount: Number(ingredient.amount), unit: ingredient.unit },
+            })),
+          },
+        })),
+      },
+    };
+
+    setClientMessages([]);
+    setPending(true);
+    try {
+      setState(await createWeeklyPlanComparisonPreview(request));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const errorContent = clientMessages.length > 0
+    ? clientMessages.join(" ")
+    : state?.kind === "invalid"
+      ? state.errors.map((error) => `${error.field}: ${error.message}`).join("; ")
+      : state?.kind === "unavailable"
+        ? "Не удалось сравнить недельный план. Основной сервис временно недоступен."
+        : null;
+
+  return (
+    <section aria-labelledby="weekly-plan-comparison" className="mt-12">
+      <div className="max-w-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">Неделя → покупки → магазины</p>
+        <h2 id="weekly-plan-comparison" className="mt-2 text-2xl font-semibold tracking-tight text-stone-950">
+          Собрать неделю
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-stone-600">
+          Добавьте блюда в нужном порядке, выберите дни и порции. Сервис объединит ингредиенты в один список покупок и сравнит корзину по доступным данным магазинов.
+        </p>
+      </div>
+
+      <form onSubmit={submit} className="mt-6 space-y-6" noValidate>
+        <div className="max-w-xl">
+          <label htmlFor="weekly-plan-locality" className="block text-sm font-medium text-stone-800">Населённый пункт</label>
+          <input
+            id="weekly-plan-locality"
+            value={locality}
+            onChange={(event) => setLocality(event.target.value)}
+            maxLength={160}
+            autoComplete="address-level2"
+            className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-4 py-2 text-base outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200"
+          />
+        </div>
+
+        <div className="space-y-5" aria-label="Блюда недели">
+          {occurrences.map((occurrence, occurrenceIndex) => (
+            <fieldset key={occurrence.key} className="rounded-3xl border border-stone-300 bg-stone-100/60 p-4 sm:p-6">
+              <legend className="px-2 text-base font-semibold text-stone-950">Блюдо {occurrenceIndex + 1}</legend>
+
+              <div className="flex flex-wrap gap-2 pb-5">
+                <button type="button" onClick={() => moveOccurrence(occurrenceIndex, -1)} disabled={occurrenceIndex === 0} aria-label={`Переместить блюдо ${occurrenceIndex + 1} выше`} className="min-h-10 rounded-full border border-stone-300 bg-white px-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Выше</button>
+                <button type="button" onClick={() => moveOccurrence(occurrenceIndex, 1)} disabled={occurrenceIndex === occurrences.length - 1} aria-label={`Переместить блюдо ${occurrenceIndex + 1} ниже`} className="min-h-10 rounded-full border border-stone-300 bg-white px-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Ниже</button>
+                <button type="button" onClick={() => removeOccurrence(occurrence.key)} disabled={occurrences.length === 1} aria-label={`Удалить блюдо ${occurrenceIndex + 1}`} className="min-h-10 rounded-full border border-stone-300 bg-white px-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Удалить блюдо</button>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label htmlFor={`weekly-day-${occurrence.key}`} className="block text-sm font-medium text-stone-700">День</label>
+                  <select id={`weekly-day-${occurrence.key}`} value={occurrence.day} onChange={(event) => updateOccurrence(occurrence.key, { day: event.target.value as WeeklyPlanDay })} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200">
+                    {days.map((day) => <option key={day.value} value={day.value}>{day.label}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor={`weekly-target-${occurrence.key}`} className="block text-sm font-medium text-stone-700">Нужно порций</label>
+                  <input id={`weekly-target-${occurrence.key}`} type="number" inputMode="numeric" min="1" step="1" value={occurrence.targetServings} onChange={(event) => updateOccurrence(occurrence.key, { targetServings: event.target.value })} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200" />
+                </div>
+                <div>
+                  <label htmlFor={`weekly-title-${occurrence.key}`} className="block text-sm font-medium text-stone-700">Название рецепта</label>
+                  <input id={`weekly-title-${occurrence.key}`} value={occurrence.title} onChange={(event) => updateOccurrence(occurrence.key, { title: event.target.value })} maxLength={240} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200" />
+                </div>
+                <div>
+                  <label htmlFor={`weekly-base-${occurrence.key}`} className="block text-sm font-medium text-stone-700">Порций в рецепте</label>
+                  <input id={`weekly-base-${occurrence.key}`} type="number" inputMode="numeric" min="1" step="1" value={occurrence.baseServings} onChange={(event) => updateOccurrence(occurrence.key, { baseServings: event.target.value })} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200" />
+                </div>
+              </div>
+
+              <div className="mt-5 space-y-3" aria-label={`Ингредиенты блюда ${occurrenceIndex + 1}`}>
+                {occurrence.ingredients.map((ingredient, ingredientIndex) => (
+                  <fieldset key={ingredient.key} className="rounded-2xl border border-stone-200 bg-white p-4">
+                    <legend className="px-1 text-sm font-medium text-stone-700">Ингредиент {ingredientIndex + 1}</legend>
+                    <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_7rem_auto] sm:items-end">
+                      <div>
+                        <label htmlFor={`weekly-ingredient-${occurrence.key}-${ingredient.key}`} className="block text-sm font-medium text-stone-700">Ингредиент</label>
+                        <input id={`weekly-ingredient-${occurrence.key}-${ingredient.key}`} value={ingredient.requirement} onChange={(event) => updateIngredient(occurrence.key, ingredient.key, { requirement: event.target.value })} maxLength={240} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200" />
+                      </div>
+                      <div>
+                        <label htmlFor={`weekly-amount-${occurrence.key}-${ingredient.key}`} className="block text-sm font-medium text-stone-700">Количество</label>
+                        <input id={`weekly-amount-${occurrence.key}-${ingredient.key}`} type="number" inputMode="decimal" min="0" step="any" value={ingredient.amount} onChange={(event) => updateIngredient(occurrence.key, ingredient.key, { amount: event.target.value })} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200" />
+                      </div>
+                      <div>
+                        <label htmlFor={`weekly-unit-${occurrence.key}-${ingredient.key}`} className="block text-sm font-medium text-stone-700">Единица</label>
+                        <select id={`weekly-unit-${occurrence.key}-${ingredient.key}`} value={ingredient.unit} onChange={(event) => updateIngredient(occurrence.key, ingredient.key, { unit: event.target.value as QuantityUnit })} className="mt-2 min-h-11 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 outline-none focus:border-stone-700 focus:ring-2 focus:ring-stone-200">
+                          {units.map((unit) => <option key={unit.value} value={unit.value}>{unit.label}</option>)}
+                        </select>
+                      </div>
+                      <button type="button" onClick={() => removeIngredient(occurrence.key, ingredient.key)} disabled={occurrence.ingredients.length === 1} aria-label={`Удалить ингредиент ${ingredientIndex + 1} блюда ${occurrenceIndex + 1}`} className="min-h-11 rounded-xl border border-stone-300 px-3 text-sm font-medium text-stone-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Удалить</button>
+                    </div>
+                  </fieldset>
+                ))}
+                <button type="button" onClick={() => addIngredient(occurrence.key)} disabled={occurrence.ingredients.length >= 100} className="min-h-10 rounded-full border border-stone-300 bg-white px-4 text-sm font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Добавить ингредиент</button>
+              </div>
+            </fieldset>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button type="button" onClick={addOccurrence} disabled={occurrences.length >= 35} className="min-h-11 rounded-full border border-stone-300 bg-white px-5 py-2.5 text-sm font-medium text-stone-900 hover:bg-stone-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:opacity-40">Добавить блюдо</button>
+          <button type="submit" disabled={pending} className="min-h-11 rounded-full bg-stone-950 px-5 py-2.5 text-sm font-medium text-white hover:bg-stone-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 disabled:cursor-wait disabled:opacity-60">{pending ? "Сравниваем…" : "Сравнить план"}</button>
+        </div>
+      </form>
+
+      {errorContent ? <div role="alert" className="mt-6 rounded-2xl border border-amber-300 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950">{errorContent}</div> : null}
+      {state?.kind === "ready" ? <WeeklyPlanComparisonResults preview={state.data} /> : null}
+    </section>
+  );
+}

--- a/apps/web/src/app/weekly-plan-comparison-results.test.tsx
+++ b/apps/web/src/app/weekly-plan-comparison-results.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { components } from "@zakup-gotov/api-client";
+import { WeeklyPlanComparisonResults } from "./weekly-plan-comparison-results";
+
+afterEach(cleanup);
+
+const preview: components["schemas"]["WeeklyPlanComparisonPreview"] = {
+  weeklyPlanShoppingPreview: {
+    weeklyPlan: {
+      id: "10000000-0000-0000-0000-000000000001",
+      occurrences: [
+        {
+          id: "11000000-0000-0000-0000-000000000001",
+          day: "MONDAY",
+          targetServings: 4,
+          recipe: { id: "12000000-0000-0000-0000-000000000001", title: "Блины", baseServings: 2, ingredients: [] },
+        },
+      ],
+    },
+    shoppingList: {
+      id: "13000000-0000-0000-0000-000000000001",
+      items: [
+        {
+          id: "14000000-0000-0000-0000-000000000001",
+          requirement: "Молоко",
+          quantity: { amount: 1000, unit: "MILLILITER" },
+          sources: [{ occurrenceId: "11000000-0000-0000-0000-000000000001", recipeId: "12000000-0000-0000-0000-000000000001", recipeIngredientId: "15000000-0000-0000-0000-000000000001" }],
+        },
+        {
+          id: "14000000-0000-0000-0000-000000000002",
+          requirement: "Яйца",
+          quantity: { amount: 10, unit: "PIECE" },
+          sources: [],
+        },
+      ],
+    },
+  },
+  comparisonPreview: {
+    locality: "Москва",
+    items: [
+      { id: "14000000-0000-0000-0000-000000000001", requirement: "Молоко", quantity: { amount: 1000, unit: "MILLILITER" } },
+      { id: "14000000-0000-0000-0000-000000000002", requirement: "Яйца", quantity: { amount: 10, unit: "PIECE" } },
+    ],
+    retailers: [],
+  },
+};
+
+describe("WeeklyPlan comparison results", () => {
+  it("shows canonical weekly shopping before retailer comparison", () => {
+    render(<WeeklyPlanComparisonResults preview={preview} />);
+
+    expect(screen.getByRole("heading", { level: 2, name: "Покупки на неделю" })).toBeDefined();
+    expect(screen.getByText("Молоко")).toBeDefined();
+    expect(screen.getByText("1000 MILLILITER")).toBeDefined();
+    expect(screen.getByText("Яйца")).toBeDefined();
+    expect(screen.getByText("10 PIECE")).toBeDefined();
+    expect(screen.getByRole("heading", { level: 2, name: "Результат для Москва" })).toBeDefined();
+  });
+
+  it("keeps generated identities and provenance out of user-facing text", () => {
+    const { container } = render(<WeeklyPlanComparisonResults preview={preview} />);
+    const text = container.textContent ?? "";
+    expect(text).not.toMatch(/[0-9a-f]{8}-[0-9a-f-]{27,}/i);
+    expect(text).not.toContain("occurrenceId");
+    expect(text).not.toContain("recipeIngredientId");
+  });
+});

--- a/apps/web/src/app/weekly-plan-comparison-results.tsx
+++ b/apps/web/src/app/weekly-plan-comparison-results.tsx
@@ -1,0 +1,34 @@
+import type { components } from "@zakup-gotov/api-client";
+
+import { ComparisonPreviewResults } from "./comparison-preview-results";
+
+type Preview = components["schemas"]["WeeklyPlanComparisonPreview"];
+type ShoppingItem = components["schemas"]["WeeklyPlanShoppingPreviewShoppingItem"];
+
+export function WeeklyPlanComparisonResults({ preview }: { preview: Preview }) {
+  return (
+    <>
+      <section aria-labelledby="weekly-shopping-results" className="mt-12">
+        <div className="max-w-2xl">
+          <h2 id="weekly-shopping-results" className="text-2xl font-semibold tracking-tight text-stone-950">
+            Покупки на неделю
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-stone-600">
+            Сервис объединил блюда в один канонический список. Порядок и количества получены от серверной WeeklyPlan-композиции.
+          </p>
+        </div>
+
+        <ul className="mt-6 grid gap-3 sm:grid-cols-2" aria-label="Покупки на неделю">
+          {preview.weeklyPlanShoppingPreview.shoppingList.items.map((item: ShoppingItem) => (
+            <li key={item.id} className="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
+              <p className="font-medium text-stone-950">{item.requirement}</p>
+              <p className="mt-1 text-sm text-stone-600">{item.quantity.amount} {item.quantity.unit}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <ComparisonPreviewResults preview={preview.comparisonPreview} />
+    </>
+  );
+}

--- a/apps/web/src/app/weekly-plan-comparison.test.ts
+++ b/apps/web/src/app/weekly-plan-comparison.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "@zakup-gotov/api-client";
+import { createWeeklyPlanComparisonPreview } from "./weekly-plan-comparison";
+
+const originalApiBaseUrl = process.env.API_BASE_URL;
+
+type Request = components["schemas"]["WeeklyPlanComparisonPreviewRequest"];
+
+const request: Request = {
+  locality: "Москва",
+  weeklyPlan: {
+    occurrences: [
+      {
+        day: "MONDAY",
+        targetServings: 4,
+        recipe: {
+          title: "Блины",
+          baseServings: 2,
+          ingredients: [
+            { requirement: "Молоко", quantity: { amount: 0.5, unit: "LITER" } },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+function restoreApiBaseUrl() {
+  if (originalApiBaseUrl === undefined) delete process.env.API_BASE_URL;
+  else process.env.API_BASE_URL = originalApiBaseUrl;
+}
+
+afterEach(() => {
+  restoreApiBaseUrl();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("WeeklyPlan comparison transport", () => {
+  it("fails closed without API_BASE_URL and performs no request", async () => {
+    delete process.env.API_BASE_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createWeeklyPlanComparisonPreview(request)).resolves.toEqual({ kind: "unavailable" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the typed composed preview unchanged", async () => {
+    process.env.API_BASE_URL = "http://api.test";
+    const response: components["schemas"]["WeeklyPlanComparisonPreview"] = {
+      weeklyPlanShoppingPreview: {
+        weeklyPlan: {
+          id: "10000000-0000-0000-0000-000000000001",
+          occurrences: [
+            {
+              id: "11000000-0000-0000-0000-000000000001",
+              day: "MONDAY",
+              targetServings: 4,
+              recipe: {
+                id: "12000000-0000-0000-0000-000000000001",
+                title: "Блины",
+                baseServings: 2,
+                ingredients: [],
+              },
+            },
+          ],
+        },
+        shoppingList: { id: "13000000-0000-0000-0000-000000000001", items: [] },
+      },
+      comparisonPreview: { locality: "Москва", items: [], retailers: [] },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(createWeeklyPlanComparisonPreview(request)).resolves.toEqual({
+      kind: "ready",
+      data: response,
+    });
+  });
+
+  it("returns only generated product-safe validation fields for HTTP 400", async () => {
+    process.env.API_BASE_URL = "http://api.test";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            type: "https://zakup-gotov.dev/problems/invalid-weekly-plan-shopping-preview",
+            title: "Invalid weekly plan shopping preview request",
+            status: 400,
+            code: "INVALID_WEEKLY_PLAN_SHOPPING_PREVIEW",
+            errors: [{ field: "weeklyPlan.occurrences[0].targetServings", message: "must be greater than 0" }],
+          }),
+          { status: 400, headers: { "content-type": "application/problem+json" } },
+        ),
+      ),
+    );
+
+    await expect(createWeeklyPlanComparisonPreview(request)).resolves.toEqual({
+      kind: "invalid",
+      errors: [
+        { field: "weeklyPlan.occurrences[0].targetServings", message: "must be greater than 0" },
+      ],
+    });
+  });
+
+  it("aborts a hanging backend request within the bounded timeout", async () => {
+    vi.useFakeTimers();
+    process.env.API_BASE_URL = "http://api.test";
+    let aborted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = input instanceof globalThis.Request ? input.signal : init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            aborted = true;
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+      }),
+    );
+
+    const result = createWeeklyPlanComparisonPreview(request);
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(aborted).toBe(true);
+    await expect(result).resolves.toEqual({ kind: "unavailable" });
+  });
+});

--- a/apps/web/src/app/weekly-plan-comparison.ts
+++ b/apps/web/src/app/weekly-plan-comparison.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import {
+  WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH,
+  createZakupGotovClient,
+  type components,
+} from "@zakup-gotov/api-client";
+
+const WEEKLY_PLAN_COMPARISON_PREVIEW_TIMEOUT_MS = 3_000;
+
+export type WeeklyPlanComparisonPreviewRequest =
+  components["schemas"]["WeeklyPlanComparisonPreviewRequest"];
+export type WeeklyPlanComparisonPreviewResponse =
+  components["schemas"]["WeeklyPlanComparisonPreview"];
+export type WeeklyPlanComparisonPreviewValidationError =
+  | components["schemas"]["WeeklyPlanComparisonPreviewValidationError"]
+  | components["schemas"]["WeeklyPlanShoppingPreviewValidationError"]
+  | components["schemas"]["RecipeShoppingPreviewValidationError"]
+  | components["schemas"]["ComparisonPreviewValidationError"];
+
+export type WeeklyPlanComparisonState =
+  | { kind: "ready"; data: WeeklyPlanComparisonPreviewResponse }
+  | { kind: "invalid"; errors: WeeklyPlanComparisonPreviewValidationError[] }
+  | { kind: "unavailable" };
+
+export async function createWeeklyPlanComparisonPreview(
+  request: WeeklyPlanComparisonPreviewRequest,
+): Promise<WeeklyPlanComparisonState> {
+  const baseUrl = process.env.API_BASE_URL;
+  if (!baseUrl) return { kind: "unavailable" };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), WEEKLY_PLAN_COMPARISON_PREVIEW_TIMEOUT_MS);
+
+  try {
+    const client = createZakupGotovClient(baseUrl);
+    const { data, error, response } = await client.POST(WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH, {
+      body: request,
+      signal: controller.signal,
+    });
+
+    if (data) return { kind: "ready", data };
+    if (response.status === 400 && error && "errors" in error) {
+      const errors = error.errors as WeeklyPlanComparisonPreviewValidationError[];
+      return {
+        kind: "invalid",
+        errors: errors.map(({ field, message }) => ({ field, message })),
+      };
+    }
+    return { kind: "unavailable" };
+  } catch {
+    return { kind: "unavailable" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui-shipping.md
+++ b/docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui-shipping.md
@@ -1,0 +1,119 @@
+# M3.4 Responsive Weekly Planning UI — Shipping Evidence
+
+Date: 2026-08-15  
+Issue: #118  
+PR: #119  
+Status: **IMPLEMENTED / TESTED / SHIPPING — acceptance pending**
+
+Authoritative design: `docs/superpowers/specs/2026-08-15-m3-4-responsive-weekly-planning-ui-design.md`  
+Implementation plan: `docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui.md`
+
+## Delivered scope
+
+M3.4 makes the already accepted M3.3 composed boundary the primary browser journey:
+
+`ordered weekly meal occurrences + locality → POST /api/v1/weekly-plan-comparison-previews → canonical weekly shopping → truthful retailer comparison`
+
+Delivered behavior:
+
+- the homepage advances to `M3 · Weekly Planning` and keeps Recipe and manual-list comparison as secondary flows;
+- the planner edits explicit ordered meal occurrences without adding breakfast/lunch/dinner/snack taxonomy;
+- users can add/remove occurrences within the accepted `1..35` bound and explicitly move an occurrence up/down without automatic day sorting;
+- each occurrence edits accepted Monday..Sunday day metadata, positive target servings, Recipe title/base servings and explicit ingredients;
+- nested ingredients retain the accepted Recipe input vocabulary and at least one ingredient per Recipe;
+- all WeeklyPlan/occurrence/Recipe/ingredient/ShoppingList/ShoppingItem identities remain server-owned; browser-local numeric keys exist only for React list identity and never cross the request boundary;
+- the transport consumes generated `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH` and generated OpenAPI component types rather than defining parallel frontend DTOs;
+- browser preflight validation is limited to presentation-safe required/positive/integer checks; authoritative planner/Recipe/comparison semantics remain server-side;
+- canonical weekly shopping requirements are rendered in server order before the existing `ComparisonPreviewResults` projection;
+- the browser performs no serving scaling, cross-Recipe merge, canonicalization, matching, package arithmetic, basket total, winner or retailer-state recomputation;
+- generated IDs and public planner provenance tuples remain hidden from ordinary user-facing output;
+- missing API configuration, timeout, network/non-400/unexpected service failures fail closed as one unavailable state; generated 400 field/message evidence is projected without transport/provider internals;
+- responsive and accessibility coverage includes 390 px mobile overflow, keyboard focus, occurrence-specific move/remove control names and pending submit protection;
+- deterministic Playwright uses only the local mock API; no live retailer request, credential, cookie, token, precise address or provider identifier is introduced;
+- persistence/history, pantry/exclusions, nutrition, calendar/time-zone semantics, fuzzy/AI equivalence, retailer onboarding and production-access policy remain out of scope.
+
+## Explicit TDD evidence
+
+### M3.3 transport
+
+RED `8f6cce844be477fca5cc5777c552ce1bd6479e59`:
+
+- `weekly-plan-comparison.test.ts` was committed before the production transport module;
+- tests require fail-closed missing configuration, typed successful composed response, sanitized generated 400 errors and bounded request abort;
+- the exact RED head triggered the normal PR workflow set before `weekly-plan-comparison.ts` existed.
+
+GREEN `ec0f768c49bdcdd75f4924e5bbfbf7abfbcbec50`:
+
+- added the minimal server transport over generated `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH`;
+- uses a 3 second `AbortController` boundary and returns only `ready / invalid / unavailable` presentation states;
+- generated M3.3/M3.2/Recipe/Comparison validation fields/messages are retained while all other failures fail closed.
+
+### Canonical weekly-shopping result projection
+
+RED `afdd80457ccb25234023d7e34ee024689cf7580a`:
+
+- tests required canonical weekly shopping output before retailer comparison and prohibited generated UUID/provenance text.
+
+GREEN `55bfacc885c8c80defcbc5f105c67d04461aeaa2`:
+
+- added `WeeklyPlanComparisonResults`;
+- reads `weeklyPlanShoppingPreview.shoppingList.items` directly in accepted server order;
+- reuses existing `ComparisonPreviewResults` unchanged after canonical shopping output.
+
+### Planner editor
+
+RED `b0a2cd9afba1eb0e93a52409afd21b9042bd79a6`:
+
+- tests required safe one-occurrence/one-ingredient defaults, add/reorder behavior independent from day metadata, exact generated M3.3 request projection, preflight rejection and unavailable fail-closed behavior.
+
+GREEN `507d596d0451849ef6a8d0948c79988be463ca29`:
+
+- added the responsive nested WeeklyPlan editor;
+- explicit array order is authoritative and move operations swap only adjacent occurrence positions;
+- add/remove limits mirror accepted API cardinality without synthesizing domain identities;
+- only generated day/unit vocabulary is submitted;
+- successful response replaces result state atomically and failures never fabricate prior/new comparison output.
+
+### Homepage integration
+
+RED `45e85d6746bb71d330d908305bb3b941728d0034`:
+
+- homepage test required Weekly Planning to become the first product journey while preserving Recipe and manual-list flows.
+
+GREEN `3537a724d1705b7653c617fe3f7c629b8e8162b0`:
+
+- homepage advances from M2 Recipe-first positioning to M3 Weekly Planning;
+- Recipe and manual comparison remain rendered below as explicit secondary paths.
+
+### Deterministic browser acceptance
+
+RED `da51ab446218a7349fca36a9f879b69d3270812f`:
+
+- Playwright coverage was updated first to require desktop WeeklyPlan → weekly shopping → retailer comparison, explicit reorder behavior, 390 px no-overflow, unavailable fail-closed state, keyboard focus and preserved Recipe/manual regressions before the deterministic weekly endpoint existed.
+
+GREEN `b690a9b9e21fde748c5102e5d57e1977cca3f6ff`:
+
+- deterministic `/api/v1/weekly-plan-comparison-previews` fixture was added without live traffic;
+- fixture creates server-owned test identities, applies deterministic serving scale/canonical-unit grouping for browser-contract verification and projects the existing eight-retailer comparison fixture;
+- exact-head Web CI passed API-client build, lint, TypeScript typecheck, Vitest/component tests and production Next.js build;
+- exact-head Web E2E passed production build, Chromium installation and the full responsive Playwright suite, including the new M3.4 and retained M2/M1 journeys.
+
+## Architecture / privacy / network scope
+
+M3.4 changes only browser/application presentation code and deterministic test support plus design/shipping documentation. It adds no database migration, persistence, authentication/authorization behavior, provider adapter, retailer activation, production-access rule or backend M3.3 domain/application behavior.
+
+The production web transport addresses only the accepted generated M3.3 application path. Runtime provider/acquisition identifiers, store bindings and precise addresses are neither requested nor rendered. Normal browser acceptance remains completely retailer-network-free.
+
+## Current shipping checkpoint
+
+Functional implementation and deterministic browser fixtures are frozen at GREEN head `b690a9b9e21fde748c5102e5d57e1977cca3f6ff`.
+
+The shipping-evidence commit creates a new exact PR head. M3.4 remains **acceptance pending** until all of the following are proven:
+
+1. 9/9 normal PR workflow groups SUCCESS on one exact final head;
+2. read-only review reports no unresolved P0/P1/P2/P3 findings and review threads are clear;
+3. PR #119 is marked ready and squash-merged with expected-head protection;
+4. issue #118 closes completed;
+5. exactly 8 normal push workflows succeed on the implementation merge SHA;
+6. canonical PROJECT_STATE/ROADMAP/CHANGELOG and dedicated M3.4 acceptance evidence are synchronized in a docs-only acceptance PR;
+7. the final canonical docs merge SHA also passes the normal post-merge push workflow set.

--- a/docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui.md
+++ b/docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui.md
@@ -1,0 +1,96 @@
+# M3.4 Responsive Weekly Planning UI — Implementation Plan
+
+Date: 2026-08-15  
+Issue: #118  
+Design: `docs/superpowers/specs/2026-08-15-m3-4-responsive-weekly-planning-ui-design.md`
+
+## Objective
+
+Implement a responsive WeeklyPlan-first web journey over the already accepted M3.3 composed endpoint. Preserve all accepted lower-layer semantics and existing Recipe/manual journeys.
+
+## Task 1 — Transport RED → GREEN
+
+Files:
+- create `apps/web/src/app/weekly-plan-comparison.test.ts` first;
+- then create `apps/web/src/app/weekly-plan-comparison.ts`.
+
+Tests prove:
+- no API configuration fails closed without fetch;
+- successful typed M3.3 response is returned unchanged;
+- generated 400 validation fields/messages are sanitized;
+- hanging request is aborted within the bounded timeout.
+
+Implementation uses `createZakupGotovClient` + generated `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH` and generated schema aliases only.
+
+## Task 2 — Results projection RED → GREEN
+
+Files:
+- create `apps/web/src/app/weekly-plan-comparison-results.test.tsx` first;
+- then create `apps/web/src/app/weekly-plan-comparison-results.tsx`.
+
+Render canonical weekly shopping items in server order before reusing `ComparisonPreviewResults`. Do not expose IDs/provenance tuples or recalculate quantities/totals.
+
+## Task 3 — Planner form RED → GREEN
+
+Files:
+- create `apps/web/src/app/weekly-plan-comparison-form.test.tsx` first;
+- then create `apps/web/src/app/weekly-plan-comparison-form.tsx`.
+
+Cover:
+- safe defaults: one occurrence, one ingredient;
+- occurrence add/remove with 1..35 bound;
+- explicit move up/down preserving caller order;
+- day and target servings;
+- nested Recipe title/base servings and ingredient add/remove;
+- exact generated M3.3 request shape;
+- preflight validation without backend call;
+- generated field errors and unavailable state;
+- pending submit protection.
+
+Local keys remain React-only.
+
+## Task 4 — Primary homepage integration RED → GREEN
+
+Update `apps/web/src/app/page.test.tsx` first to require M3 Weekly Planning first and preserve Recipe/manual paths. Then update `apps/web/src/app/page.tsx`.
+
+Order:
+1. WeeklyPlan primary journey;
+2. Recipe secondary journey;
+3. manual-list secondary journey.
+
+No existing journey is deleted.
+
+## Task 5 — Deterministic browser acceptance RED → GREEN
+
+Update `apps/web/e2e/home.spec.ts` first with planner critical journeys. Then extend `apps/web/e2e/mock-api.mjs` with a deterministic weekly-plan composed route.
+
+Browser assertions:
+- desktop planner request produces canonical weekly shopping and all eight retailer cards;
+- occurrence order can be changed independently from day metadata;
+- mobile 390px has no horizontal overflow;
+- keyboard focus is visible;
+- unavailable response yields one alert and no fabricated result;
+- Recipe and manual-list regression scenarios remain green.
+
+Mock route must not contain live retailer traffic or sensitive/provider internals.
+
+## Task 6 — Hardening and shipping evidence
+
+Run/verify through GitHub Actions on the exact feature head:
+- API CI;
+- Web CI (lint/typecheck/unit/build/Playwright as configured);
+- Contract CI/generated-client freshness;
+- Release Contract CI;
+- Security CI;
+- CodeQL;
+- Dependency Review;
+- Retailer Bridge CI;
+- any remaining normal PR workflow group configured by the repository.
+
+Fix all feature-caused failures. Add shipping evidence with RED/GREEN commit SHAs and exact-head workflow results.
+
+Then perform read-only diff/review, resolve all P0/P1/P2/P3 findings, mark PR ready, squash merge with expected-head protection, close #118 and verify exactly 8 normal post-merge `main` workflows SUCCESS.
+
+## Scope guard
+
+No persistence, database, OpenAPI schema, backend M3.3 semantics, pantry/exclusion, retailer connector, production-access or release-version behavior changes unless an implementation defect proves one is strictly necessary. Any such discovery is split into a separate issue rather than silently expanding M3.4.

--- a/docs/superpowers/specs/2026-08-15-m3-4-responsive-weekly-planning-ui-design.md
+++ b/docs/superpowers/specs/2026-08-15-m3-4-responsive-weekly-planning-ui-design.md
@@ -1,0 +1,95 @@
+# M3.4 Responsive Weekly Planning UI — Design
+
+Date: 2026-08-15  
+Issue: #118  
+Status: APPROVED FOR IMPLEMENTATION
+
+## Goal
+
+Expose the accepted M3.3 WeeklyPlan → Comparison composition as the primary M3 browser journey without moving planner, Recipe, Shopping or Comparison semantics into browser code.
+
+Product flow:
+
+`ordered meal occurrences + locality → POST /api/v1/weekly-plan-comparison-previews → canonical weekly shopping requirements → truthful retailer comparison`
+
+## Authoritative boundary
+
+The browser uses only the generated `WEEKLY_PLAN_COMPARISON_PREVIEWS_PATH` contract. It must not compose `/weekly-plan-shopping-previews` and `/comparison-previews` itself.
+
+Generated OpenAPI types are authoritative for request/response/day/unit vocabulary. Browser-local numeric keys exist only for React list identity and are never sent as WeeklyPlan, occurrence, Recipe, ingredient, ShoppingList or ShoppingItem identity.
+
+## Interaction model
+
+The page advances its primary journey to `M3 · Weekly Planning` while keeping Recipe and manual-list comparison as secondary regression-covered paths.
+
+The planner begins with one occurrence. Each occurrence contains:
+
+- day (`MONDAY..SUNDAY`);
+- target servings;
+- Recipe title;
+- base servings;
+- one or more explicit ingredients with requirement, quantity and generated unit vocabulary.
+
+Users may add/remove occurrences up to the accepted API limit of 35 and move an occurrence one position up/down. Reordering changes only explicit caller order; the UI never auto-sorts by day. No breakfast/lunch/dinner/snack taxonomy is introduced.
+
+Each Recipe keeps at least one ingredient. Browser validation is presentation/preflight only: required text, positive finite quantities and positive integer servings. Authoritative semantic validation remains server-side.
+
+## Results
+
+A successful response renders:
+
+1. canonical weekly shopping requirements from `weeklyPlanShoppingPreview.shoppingList.items`, in server order;
+2. the existing `ComparisonPreviewResults` projection unchanged.
+
+Generated IDs and source tuples are intentionally hidden from normal user-facing output. The browser does not recalculate scaling, aggregation, canonicalization, matching, package counts, totals, winner ranking or retailer status.
+
+## Failure behavior
+
+Transport follows the accepted Recipe UI pattern:
+
+- missing `API_BASE_URL` → unavailable;
+- finite timeout → unavailable;
+- network/non-400/unexpected failure → unavailable;
+- generated 400 problem fields/messages only → invalid;
+- never fabricate shopping or retailer results after failure.
+
+Changing form input after a prior result does not mutate the accepted response; a new submit replaces state atomically.
+
+## Responsive and accessibility requirements
+
+- semantic `section`, `form`, `fieldset`, `legend`, `label` relationships;
+- all controls keyboard reachable with visible focus;
+- move buttons have occurrence-specific accessible names;
+- disabled boundary move/remove controls communicate impossible actions;
+- mobile width 390px has no horizontal document overflow;
+- pending submit is disabled and announces concise progress through button text;
+- one accessible alert is used for preflight/backend/unavailable failures.
+
+## Deterministic testing boundary
+
+Ordinary Playwright uses the existing local mock API only. Add a deterministic `/api/v1/weekly-plan-comparison-previews` route that projects request data into fixed server-owned IDs, canonical weekly shopping and the existing eight-retailer comparison fixture. No live retailer request, cookie, token, store address or provider identifier enters browser acceptance.
+
+Required regression coverage:
+
+- desktop planner → weekly shopping → comparison;
+- add/remove/reorder and day/servings request projection;
+- mobile no-overflow;
+- keyboard focus;
+- unavailable fail-closed path;
+- existing Recipe journey;
+- existing manual-list journey.
+
+## Non-goals
+
+- persistence/saved plans/history;
+- pantry or exclusion subtraction;
+- calendar dates/time zones;
+- meal-slot taxonomy;
+- nutrition;
+- fuzzy/synonym/AI ingredient equivalence;
+- retailer onboarding or production-access changes;
+- browser-side comparison optimization.
+
+## Acceptance gate
+
+M3.4 is accepted only after RED→GREEN evidence, fresh exact-head 9/9 normal PR workflow groups, clean review/no unresolved threads, squash merge, issue closure and 8/8 normal post-merge `main` workflows.


### PR DESCRIPTION
Implements and closes #118 using the approved M3.4 design and implementation plan.

Authoritative design: `docs/superpowers/specs/2026-08-15-m3-4-responsive-weekly-planning-ui-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui.md`
Shipping evidence: `docs/superpowers/plans/2026-08-15-m3-4-responsive-weekly-planning-ui-shipping.md`

## Delivered
- WeeklyPlan-first responsive homepage journey over generated `POST /api/v1/weekly-plan-comparison-previews`;
- ordered occurrence add/remove/reorder with Monday..Sunday + target servings;
- nested explicit Recipe/ingredient editing without client-owned domain IDs;
- canonical weekly shopping rendered before the accepted retailer comparison projection;
- fail-closed generated transport/error handling;
- Recipe/manual-list journeys preserved;
- deterministic desktop/mobile/accessibility Playwright with no live retailer traffic.

## TDD checkpoints
- transport RED `8f6cce844be477fca5cc5777c552ce1bd6479e59` → GREEN `ec0f768c49bdcdd75f4924e5bbfbf7abfbcbec50`;
- results RED `afdd80457ccb25234023d7e34ee024689cf7580a` → GREEN `55bfacc885c8c80defcbc5f105c67d04461aeaa2`;
- form RED `b0a2cd9afba1eb0e93a52409afd21b9042bd79a6` → GREEN `507d596d0451849ef6a8d0948c79988be463ca29`;
- homepage RED `45e85d6746bb71d330d908305bb3b941728d0034` → GREEN `3537a724d1705b7653c617fe3f7c629b8e8162b0`;
- browser RED `da51ab446218a7349fca36a9f879b69d3270812f` → GREEN `b690a9b9e21fde748c5102e5d57e1977cca3f6ff`.

Final shipping-evidence head is `12973650f274f76ec54865be41963843afcb4558`; PR remains draft until exact-head 9/9 normal workflow groups and clean read-only review are proven.