### PR TITLE
feat(m3): add Pantry subtraction semantics

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustment.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustment.java
@@ -1,0 +1,17 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.util.List;
+import java.util.Objects;
+
+public record PantryAdjustment(
+        ShoppingList remainingShoppingList,
+        List<PantryAdjustmentEvidence> evidence) {
+
+    public PantryAdjustment {
+        remainingShoppingList = Objects.requireNonNull(
+                remainingShoppingList,
+                "remainingShoppingList must not be null");
+        evidence = List.copyOf(Objects.requireNonNull(evidence, "evidence must not be null"));
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java
@@ -1,0 +1,90 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.util.Objects;
+import java.util.Optional;
+
+public record PantryAdjustmentEvidence(
+        ShoppingItemId itemId,
+        ShoppingRequirement requirement,
+        Quantity required,
+        Optional<Quantity> pantryUsed,
+        Optional<Quantity> remaining,
+        PantryAdjustmentStatus status) {
+
+    public PantryAdjustmentEvidence {
+        itemId = Objects.requireNonNull(itemId, "itemId must not be null");
+        requirement = Objects.requireNonNull(requirement, "requirement must not be null");
+        required = Objects.requireNonNull(required, "required must not be null");
+        pantryUsed = Objects.requireNonNull(pantryUsed, "pantryUsed must not be null");
+        remaining = Objects.requireNonNull(remaining, "remaining must not be null");
+        status = Objects.requireNonNull(status, "status must not be null");
+
+        pantryUsed.ifPresent(quantity -> requireSameUnit(required, quantity));
+        remaining.ifPresent(quantity -> requireSameUnit(required, quantity));
+
+        switch (status) {
+            case UNCHANGED -> validateUnchanged(required, pantryUsed, remaining);
+            case PARTIALLY_COVERED -> validatePartial(required, pantryUsed, remaining);
+            case FULLY_COVERED -> validateFull(required, pantryUsed, remaining);
+        }
+    }
+
+    private static void validateUnchanged(
+            Quantity required,
+            Optional<Quantity> pantryUsed,
+            Optional<Quantity> remaining) {
+        if (pantryUsed.isPresent()
+                || remaining.isEmpty()
+                || !sameAmount(required, remaining.orElseThrow())) {
+            throw new IllegalArgumentException(
+                    "unchanged evidence must have no pantry usage and remaining equal to required");
+        }
+    }
+
+    private static void validatePartial(
+            Quantity required,
+            Optional<Quantity> pantryUsed,
+            Optional<Quantity> remaining) {
+        if (pantryUsed.isEmpty() || remaining.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "partial evidence must contain pantry usage and remaining quantity");
+        }
+
+        var used = pantryUsed.orElseThrow();
+        var left = remaining.orElseThrow();
+        if (used.amount().compareTo(required.amount()) >= 0
+                || left.amount().compareTo(required.amount()) >= 0) {
+            throw new IllegalArgumentException(
+                    "partial evidence parts must each be smaller than required");
+        }
+        if (used.amount().add(left.amount()).compareTo(required.amount()) != 0) {
+            throw new IllegalArgumentException(
+                    "partial evidence pantry usage plus remaining must equal required");
+        }
+    }
+
+    private static void validateFull(
+            Quantity required,
+            Optional<Quantity> pantryUsed,
+            Optional<Quantity> remaining) {
+        if (pantryUsed.isEmpty()
+                || remaining.isPresent()
+                || !sameAmount(required, pantryUsed.orElseThrow())) {
+            throw new IllegalArgumentException(
+                    "full evidence must use exactly the required quantity and have no remaining quantity");
+        }
+    }
+
+    private static void requireSameUnit(Quantity expected, Quantity actual) {
+        if (expected.unit() != actual.unit()) {
+            throw new IllegalArgumentException("evidence quantity unit must match required unit");
+        }
+    }
+
+    private static boolean sameAmount(Quantity first, Quantity second) {
+        return first.amount().compareTo(second.amount()) == 0;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java
@@ -22,8 +22,12 @@ public record PantryAdjustmentEvidence(
         remaining = Objects.requireNonNull(remaining, "remaining must not be null");
         status = Objects.requireNonNull(status, "status must not be null");
 
-        pantryUsed.ifPresent(quantity -> requireSameUnit(required, quantity));
-        remaining.ifPresent(quantity -> requireSameUnit(required, quantity));
+        if (pantryUsed.isPresent()) {
+            requireSameUnit(required, pantryUsed.orElseThrow());
+        }
+        if (remaining.isPresent()) {
+            requireSameUnit(required, remaining.orElseThrow());
+        }
 
         switch (status) {
             case UNCHANGED -> validateUnchanged(required, pantryUsed, remaining);

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentStatus.java
@@ -1,0 +1,7 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+public enum PantryAdjustmentStatus {
+    UNCHANGED,
+    PARTIALLY_COVERED,
+    FULLY_COVERED
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryItem.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryItem.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.util.Objects;
+
+public record PantryItem(ShoppingRequirement requirement, Quantity quantity) {
+
+    public PantryItem {
+        requirement = Objects.requireNonNull(requirement, "requirement must not be null");
+        quantity = Objects.requireNonNull(quantity, "quantity must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryMatchKey.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryMatchKey.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.util.Objects;
+
+record PantryMatchKey(ShoppingRequirement requirement, QuantityUnit unit) {
+
+    PantryMatchKey {
+        requirement = Objects.requireNonNull(requirement, "requirement must not be null");
+        unit = Objects.requireNonNull(unit, "unit must not be null");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjuster.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjuster.java
@@ -1,0 +1,91 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class PantryShoppingListAdjuster {
+
+    public PantryAdjustment adjust(ShoppingList source, List<PantryItem> pantryItems) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(pantryItems, "pantryItems must not be null");
+
+        var stock = aggregatePantryStock(pantryItems);
+        var remainingShoppingList = new ShoppingList(source.id());
+        var evidence = new ArrayList<PantryAdjustmentEvidence>(source.items().size());
+
+        for (var item : source.items()) {
+            adjustItem(item, stock, remainingShoppingList, evidence);
+        }
+
+        return new PantryAdjustment(remainingShoppingList, evidence);
+    }
+
+    private static LinkedHashMap<PantryMatchKey, BigDecimal> aggregatePantryStock(
+            List<PantryItem> pantryItems) {
+        var stock = new LinkedHashMap<PantryMatchKey, BigDecimal>();
+        for (var pantryItem : pantryItems) {
+            var item = Objects.requireNonNull(pantryItem, "pantry item must not be null");
+            var key = new PantryMatchKey(item.requirement(), item.quantity().unit());
+            stock.merge(key, item.quantity().amount(), BigDecimal::add);
+        }
+        return stock;
+    }
+
+    private static void adjustItem(
+            ShoppingItem item,
+            LinkedHashMap<PantryMatchKey, BigDecimal> stock,
+            ShoppingList remainingShoppingList,
+            List<PantryAdjustmentEvidence> evidence) {
+        var required = item.quantity();
+        var key = new PantryMatchKey(item.requirement(), required.unit());
+        var available = stock.getOrDefault(key, BigDecimal.ZERO);
+        var usedAmount = required.amount().min(available);
+
+        if (usedAmount.signum() == 0) {
+            remainingShoppingList.add(item);
+            evidence.add(new PantryAdjustmentEvidence(
+                    item.id(),
+                    item.requirement(),
+                    required,
+                    Optional.empty(),
+                    Optional.of(required),
+                    PantryAdjustmentStatus.UNCHANGED));
+            return;
+        }
+
+        stock.put(key, available.subtract(usedAmount));
+        var used = new Quantity(usedAmount, required.unit());
+        var remainingAmount = required.amount().subtract(usedAmount);
+
+        if (remainingAmount.signum() == 0) {
+            evidence.add(new PantryAdjustmentEvidence(
+                    item.id(),
+                    item.requirement(),
+                    required,
+                    Optional.of(used),
+                    Optional.empty(),
+                    PantryAdjustmentStatus.FULLY_COVERED));
+            return;
+        }
+
+        var remaining = new Quantity(remainingAmount, required.unit());
+        remainingShoppingList.add(new ShoppingItem(
+                item.id(),
+                item.requirement(),
+                remaining));
+        evidence.add(new PantryAdjustmentEvidence(
+                item.id(),
+                item.requirement(),
+                required,
+                Optional.of(used),
+                Optional.of(remaining),
+                PantryAdjustmentStatus.PARTIALLY_COVERED));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java
@@ -1,0 +1,141 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PantryAdjustmentEvidenceTest {
+
+    @Test
+    void unchangedEvidenceHasNoUsedQuantityAndKeepsRequiredAsRemaining() {
+        var required = quantity("500", QuantityUnit.GRAM);
+
+        var evidence = new PantryAdjustmentEvidence(
+                itemId(1),
+                new ShoppingRequirement("Rice"),
+                required,
+                Optional.empty(),
+                Optional.of(required),
+                PantryAdjustmentStatus.UNCHANGED);
+
+        assertThat(evidence.pantryUsed()).isEmpty();
+        assertThat(evidence.remaining()).contains(required);
+        assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.UNCHANGED);
+    }
+
+    @Test
+    void partiallyCoveredEvidenceRequiresUsedPlusRemainingToEqualRequired() {
+        var evidence = new PantryAdjustmentEvidence(
+                itemId(1),
+                new ShoppingRequirement("Rice"),
+                quantity("500", QuantityUnit.GRAM),
+                Optional.of(quantity("125", QuantityUnit.GRAM)),
+                Optional.of(quantity("375", QuantityUnit.GRAM)),
+                PantryAdjustmentStatus.PARTIALLY_COVERED);
+
+        assertThat(evidence.pantryUsed()).contains(quantity("125", QuantityUnit.GRAM));
+        assertThat(evidence.remaining()).contains(quantity("375", QuantityUnit.GRAM));
+    }
+
+    @Test
+    void fullyCoveredEvidenceKeepsRequiredAndUsedButHasNoRemainingQuantity() {
+        var required = quantity("500", QuantityUnit.GRAM);
+
+        var evidence = new PantryAdjustmentEvidence(
+                itemId(1),
+                new ShoppingRequirement("Rice"),
+                required,
+                Optional.of(required),
+                Optional.empty(),
+                PantryAdjustmentStatus.FULLY_COVERED);
+
+        assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.FULLY_COVERED);
+        assertThat(evidence.pantryUsed()).contains(required);
+        assertThat(evidence.remaining()).isEmpty();
+    }
+
+    @Test
+    void rejectsUnchangedEvidenceWithPantryUsage() {
+        var required = quantity("500", QuantityUnit.GRAM);
+
+        assertThatThrownBy(() -> new PantryAdjustmentEvidence(
+                        itemId(1),
+                        new ShoppingRequirement("Rice"),
+                        required,
+                        Optional.of(quantity("100", QuantityUnit.GRAM)),
+                        Optional.of(required),
+                        PantryAdjustmentStatus.UNCHANGED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unchanged");
+    }
+
+    @Test
+    void rejectsPartialEvidenceWithoutBothPositiveParts() {
+        assertThatThrownBy(() -> new PantryAdjustmentEvidence(
+                        itemId(1),
+                        new ShoppingRequirement("Rice"),
+                        quantity("500", QuantityUnit.GRAM),
+                        Optional.of(quantity("100", QuantityUnit.GRAM)),
+                        Optional.empty(),
+                        PantryAdjustmentStatus.PARTIALLY_COVERED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("partial");
+    }
+
+    @Test
+    void rejectsPartialEvidenceWhenArithmeticDoesNotBalance() {
+        assertThatThrownBy(() -> new PantryAdjustmentEvidence(
+                        itemId(1),
+                        new ShoppingRequirement("Rice"),
+                        quantity("500", QuantityUnit.GRAM),
+                        Optional.of(quantity("100", QuantityUnit.GRAM)),
+                        Optional.of(quantity("350", QuantityUnit.GRAM)),
+                        PantryAdjustmentStatus.PARTIALLY_COVERED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("required");
+    }
+
+    @Test
+    void rejectsEvidenceWithIncompatibleUnits() {
+        assertThatThrownBy(() -> new PantryAdjustmentEvidence(
+                        itemId(1),
+                        new ShoppingRequirement("Milk"),
+                        quantity("500", QuantityUnit.MILLILITER),
+                        Optional.of(quantity("100", QuantityUnit.GRAM)),
+                        Optional.of(quantity("400", QuantityUnit.MILLILITER)),
+                        PantryAdjustmentStatus.PARTIALLY_COVERED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unit");
+    }
+
+    @Test
+    void rejectsFullEvidenceWithRemainingQuantity() {
+        var required = quantity("500", QuantityUnit.GRAM);
+
+        assertThatThrownBy(() -> new PantryAdjustmentEvidence(
+                        itemId(1),
+                        new ShoppingRequirement("Rice"),
+                        required,
+                        Optional.of(required),
+                        Optional.of(quantity("1", QuantityUnit.GRAM)),
+                        PantryAdjustmentStatus.FULLY_COVERED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("full");
+    }
+
+    private static Quantity quantity(String amount, QuantityUnit unit) {
+        return new Quantity(new BigDecimal(amount), unit);
+    }
+
+    private static ShoppingItemId itemId(int seed) {
+        return new ShoppingItemId(new UUID(0L, seed));
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java
@@ -1,0 +1,84 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class PantryArchitectureTest {
+
+    private static final String ROOT = "io.github.trueruslan.zakupgotov.";
+    private static final String PANTRY = ROOT + "pantry";
+
+    @Test
+    void pantryProductionBoundaryExists() {
+        var classes = productionClasses();
+
+        assertThat(classes.stream()
+                        .anyMatch(javaClass -> javaClass.getPackageName().equals(PANTRY)))
+                .as("M3.5.1 pantry production package must exist")
+                .isTrue();
+    }
+
+    @Test
+    void pantryDependsOnlyOnShoppingProjectPackage() {
+        var classes = productionClasses();
+
+        var projectDependencies = classes.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(PANTRY))
+                .flatMap(javaClass -> javaClass.getDirectDependenciesFromSelf().stream())
+                .map(dependency -> dependency.getTargetClass())
+                .filter(target -> target.getName().startsWith(ROOT))
+                .filter(target -> !target.getPackageName().equals(PANTRY))
+                .map(target -> target.getPackageName())
+                .collect(Collectors.toSet());
+
+        assertThat(projectDependencies)
+                .allSatisfy(packageName -> assertThat(packageName)
+                        .matches(ROOT + "shopping(\\..*)?"));
+    }
+
+    @Test
+    void pantryDoesNotReachIntoUpstreamDownstreamTransportOrPersistencePackages() {
+        var classes = productionClasses();
+
+        noClasses()
+                .that().resideInAPackage("..pantry..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "..recipe..",
+                        "..weeklyplan..",
+                        "..weeklyplanpreview..",
+                        "..weeklyplancomparisonpreview..",
+                        "..preview..",
+                        "..recipepreview..",
+                        "..recipecomparisonpreview..",
+                        "..provider..",
+                        "..retailer..",
+                        "..matching..",
+                        "..basket..",
+                        "..comparison..",
+                        "..database..",
+                        "org.springframework..")
+                .check(classes);
+    }
+
+    @Test
+    void acceptedShoppingRecipeAndWeeklyPlanPackagesRemainIndependentFromPantry() {
+        var classes = productionClasses();
+
+        noClasses()
+                .that().resideInAnyPackage("..shopping..", "..recipe..", "..weeklyplan..")
+                .should().dependOnClassesThat().resideInAPackage("..pantry..")
+                .check(classes);
+    }
+
+    private static JavaClasses productionClasses() {
+        return new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.github.trueruslan.zakupgotov");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjusterTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjusterTest.java
@@ -1,0 +1,257 @@
+package io.github.trueruslan.zakupgotov.pantry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.shopping.Quantity;
+import io.github.trueruslan.zakupgotov.shopping.QuantityUnit;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItem;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingItemId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingList;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingListId;
+import io.github.trueruslan.zakupgotov.shopping.ShoppingRequirement;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PantryShoppingListAdjusterTest {
+
+    private final PantryShoppingListAdjuster adjuster = new PantryShoppingListAdjuster();
+
+    @Test
+    void partialCoverageReducesQuantityAndPreservesIdentityOrderAndSource() {
+        var source = shoppingList(
+                item(1, "Rice", "1000", QuantityUnit.GRAM),
+                item(2, "Milk", "1000", QuantityUnit.MILLILITER));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "250", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().id()).isEqualTo(source.id());
+        assertThat(result.remainingShoppingList().items())
+                .extracting(ShoppingItem::id)
+                .containsExactly(itemId(1), itemId(2));
+        assertThat(result.remainingShoppingList().items().getFirst().requirement())
+                .isEqualTo(new ShoppingRequirement("Rice"));
+        assertThat(result.remainingShoppingList().items().getFirst().quantity())
+                .isEqualTo(quantity("750", QuantityUnit.GRAM));
+        assertThat(result.remainingShoppingList().items().get(1).quantity())
+                .isEqualTo(quantity("1000", QuantityUnit.MILLILITER));
+
+        assertThat(result.evidence())
+                .extracting(PantryAdjustmentEvidence::status)
+                .containsExactly(
+                        PantryAdjustmentStatus.PARTIALLY_COVERED,
+                        PantryAdjustmentStatus.UNCHANGED);
+        assertThat(result.evidence().getFirst().pantryUsed())
+                .contains(quantity("250", QuantityUnit.GRAM));
+        assertThat(result.evidence().getFirst().remaining())
+                .contains(quantity("750", QuantityUnit.GRAM));
+
+        assertThat(source.items().getFirst().quantity())
+                .isEqualTo(quantity("1000", QuantityUnit.GRAM));
+    }
+
+    @Test
+    void unmatchedPantryLeavesItemUnchangedWithUnchangedEvidence() {
+        var source = shoppingList(item(1, "Rice", "500", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Pasta", "500", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items()).containsExactly(source.items().getFirst());
+        assertThat(result.evidence()).singleElement().satisfies(evidence -> {
+            assertThat(evidence.itemId()).isEqualTo(itemId(1));
+            assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.UNCHANGED);
+            assertThat(evidence.pantryUsed()).isEmpty();
+            assertThat(evidence.remaining()).contains(quantity("500", QuantityUnit.GRAM));
+        });
+    }
+
+    @Test
+    void fullCoverageRemovesItemButKeepsFullAuditEvidence() {
+        var source = shoppingList(
+                item(1, "Rice", "500", QuantityUnit.GRAM),
+                item(2, "Milk", "1000", QuantityUnit.MILLILITER));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "500", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items())
+                .extracting(ShoppingItem::id)
+                .containsExactly(itemId(2));
+        assertThat(result.evidence()).hasSize(2);
+        assertThat(result.evidence().getFirst().itemId()).isEqualTo(itemId(1));
+        assertThat(result.evidence().getFirst().status())
+                .isEqualTo(PantryAdjustmentStatus.FULLY_COVERED);
+        assertThat(result.evidence().getFirst().pantryUsed())
+                .contains(quantity("500", QuantityUnit.GRAM));
+        assertThat(result.evidence().getFirst().remaining()).isEmpty();
+    }
+
+    @Test
+    void kilogramsCoverGramRequirementsThroughAcceptedQuantityCanonicalization() {
+        var source = shoppingList(item(1, "Rice", "1000", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "0.25", QuantityUnit.KILOGRAM)));
+
+        assertThat(result.remainingShoppingList().items().getFirst().quantity())
+                .isEqualTo(quantity("750", QuantityUnit.GRAM));
+        assertThat(result.evidence().getFirst().pantryUsed())
+                .contains(quantity("250", QuantityUnit.GRAM));
+    }
+
+    @Test
+    void litersCoverMilliliterRequirementsThroughAcceptedQuantityCanonicalization() {
+        var source = shoppingList(item(1, "Milk", "1500", QuantityUnit.MILLILITER));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Milk", "0.5", QuantityUnit.LITER)));
+
+        assertThat(result.remainingShoppingList().items().getFirst().quantity())
+                .isEqualTo(quantity("1000", QuantityUnit.MILLILITER));
+        assertThat(result.evidence().getFirst().pantryUsed())
+                .contains(quantity("500", QuantityUnit.MILLILITER));
+    }
+
+    @Test
+    void incompatibleQuantityDimensionsDoNotMatch() {
+        var source = shoppingList(item(1, "Eggs", "6", QuantityUnit.PIECE));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Eggs", "600", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items()).containsExactly(source.items().getFirst());
+        assertThat(result.evidence().getFirst().status())
+                .isEqualTo(PantryAdjustmentStatus.UNCHANGED);
+    }
+
+    @Test
+    void duplicatePantryRowsAggregateByExactRequirementAndCanonicalUnit() {
+        var source = shoppingList(item(1, "Rice", "500", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "100", QuantityUnit.GRAM),
+                pantry("Rice", "0.25", QuantityUnit.KILOGRAM)));
+
+        assertThat(result.remainingShoppingList().items().getFirst().quantity())
+                .isEqualTo(quantity("150", QuantityUnit.GRAM));
+        assertThat(result.evidence().getFirst().pantryUsed())
+                .contains(quantity("350", QuantityUnit.GRAM));
+    }
+
+    @Test
+    void sharedPantryStockIsConsumedOnceAcrossDuplicateSourceKeysInSourceOrder() {
+        var source = shoppingList(
+                item(1, "Rice", "300", QuantityUnit.GRAM),
+                item(2, "Rice", "300", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "400", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items())
+                .extracting(ShoppingItem::id)
+                .containsExactly(itemId(2));
+        assertThat(result.remainingShoppingList().items().getFirst().quantity())
+                .isEqualTo(quantity("200", QuantityUnit.GRAM));
+        assertThat(result.evidence())
+                .extracting(PantryAdjustmentEvidence::itemId)
+                .containsExactly(itemId(1), itemId(2));
+        assertThat(result.evidence())
+                .extracting(PantryAdjustmentEvidence::status)
+                .containsExactly(
+                        PantryAdjustmentStatus.FULLY_COVERED,
+                        PantryAdjustmentStatus.PARTIALLY_COVERED);
+        assertThat(result.evidence().get(1).pantryUsed())
+                .contains(quantity("100", QuantityUnit.GRAM));
+    }
+
+    @Test
+    void excessPantryNeverCreatesZeroOrNegativeShoppingQuantity() {
+        var source = shoppingList(item(1, "Rice", "100", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("Rice", "1000", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items()).isEmpty();
+        assertThat(result.evidence()).singleElement().satisfies(evidence -> {
+            assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.FULLY_COVERED);
+            assertThat(evidence.pantryUsed()).contains(quantity("100", QuantityUnit.GRAM));
+            assertThat(evidence.remaining()).isEmpty();
+        });
+    }
+
+    @Test
+    void exactRequirementMatchingRemainsCaseSensitive() {
+        var source = shoppingList(item(1, "Rice", "500", QuantityUnit.GRAM));
+
+        var result = adjuster.adjust(source, List.of(
+                pantry("rice", "500", QuantityUnit.GRAM)));
+
+        assertThat(result.remainingShoppingList().items()).containsExactly(source.items().getFirst());
+        assertThat(result.evidence().getFirst().status())
+                .isEqualTo(PantryAdjustmentStatus.UNCHANGED);
+    }
+
+    @Test
+    void doesNotMutateCallerOwnedPantryCollection() {
+        var source = shoppingList(item(1, "Rice", "500", QuantityUnit.GRAM));
+        var pantryRows = new ArrayList<>(List.of(
+                pantry("Rice", "100", QuantityUnit.GRAM),
+                pantry("Rice", "50", QuantityUnit.GRAM)));
+        var snapshot = List.copyOf(pantryRows);
+
+        adjuster.adjust(source, pantryRows);
+
+        assertThat(pantryRows).containsExactlyElementsOf(snapshot);
+    }
+
+    @Test
+    void rejectsNullInputsAndNullPantryRows() {
+        var source = shoppingList(item(1, "Rice", "500", QuantityUnit.GRAM));
+
+        assertThatThrownBy(() -> adjuster.adjust(null, List.of()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> adjuster.adjust(source, null))
+                .isInstanceOf(NullPointerException.class);
+
+        var pantryRows = new ArrayList<PantryItem>();
+        pantryRows.add(null);
+        assertThatThrownBy(() -> adjuster.adjust(source, pantryRows))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private static ShoppingList shoppingList(ShoppingItem... items) {
+        var list = new ShoppingList(new ShoppingListId(new UUID(1L, 1L)));
+        for (var item : items) {
+            list.add(item);
+        }
+        return list;
+    }
+
+    private static ShoppingItem item(
+            int seed,
+            String requirement,
+            String amount,
+            QuantityUnit unit) {
+        return new ShoppingItem(
+                itemId(seed),
+                new ShoppingRequirement(requirement),
+                quantity(amount, unit));
+    }
+
+    private static PantryItem pantry(String requirement, String amount, QuantityUnit unit) {
+        return new PantryItem(new ShoppingRequirement(requirement), quantity(amount, unit));
+    }
+
+    private static Quantity quantity(String amount, QuantityUnit unit) {
+        return new Quantity(new BigDecimal(amount), unit);
+    }
+
+    private static ShoppingItemId itemId(int seed) {
+        return new ShoppingItemId(new UUID(0L, seed));
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md
+++ b/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md
@@ -1,0 +1,152 @@
+# M3.5.1 Pantry Subtraction Semantics — Shipping Evidence
+
+Date: 2026-08-15  
+Issue: #121  
+PR: #122  
+Baseline: `e11fd532c8d1f927a14cb886abaa9e9988f9b21b`
+
+Design: [`../specs/2026-08-15-m3-5-1-pantry-subtraction-semantics-design.md`](../specs/2026-08-15-m3-5-1-pantry-subtraction-semantics-design.md)  
+Implementation plan: [`2026-08-15-m3-5-1-pantry-subtraction-semantics.md`](2026-08-15-m3-5-1-pantry-subtraction-semantics.md)
+
+## Delivered boundary
+
+M3.5.1 introduces one new pure production package:
+
+`io.github.trueruslan.zakupgotov.pantry`
+
+It adjusts an already canonical `ShoppingList` using caller-supplied household stock:
+
+`ShoppingList + PantryItem[] → PantryAdjustment(remaining ShoppingList + ordered audit evidence)`
+
+The layer does not compose with WeeklyPlan/Comparison yet and has no HTTP, persistence or browser surface.
+
+## Accepted semantics implemented
+
+- exact match key is `(ShoppingRequirement, canonical QuantityUnit)`, matching the accepted Recipe/WeeklyPlan aggregation vocabulary;
+- `Quantity` remains the only unit canonicalizer, therefore kg→g and l→ml compatibility is reused rather than reimplemented;
+- requirement equality remains case-sensitive and whitespace semantics remain owned by `ShoppingRequirement`;
+- no fuzzy, synonym, transliteration, stemming or AI equivalence exists;
+- duplicate Pantry rows with the same exact key are additive;
+- Pantry stock is allocated sequentially in source ShoppingList order and consumed at most once;
+- each source row consumes `min(required, available)` and can never produce negative demand;
+- unmatched rows remain unchanged;
+- partially covered rows preserve ShoppingListId, ShoppingItemId, ShoppingRequirement and order while reducing only Quantity;
+- fully covered rows disappear from the remaining ShoppingList but retain explicit source-ID audit evidence;
+- excess Pantry stock is ignored rather than represented as a zero/negative Shopping quantity;
+- source ShoppingList and caller-owned Pantry collections are not mutated;
+- audit evidence is immutable and validates `UNCHANGED`, `PARTIALLY_COVERED` and `FULLY_COVERED` structural/arithmetic invariants.
+
+## TDD evidence
+
+### Evidence model
+
+RED head:
+
+`e95b076825278a4653939fe06599d5b42b3097f5`
+
+On that exact SHA, API CI failed in `Run API verification` before Pantry production types existed.
+
+Initial implementation head:
+
+`a3d502d0667b48c3a21bf8f4ac0c75e7b54c91f6`
+
+This correctly exposed a Java compile issue in the compact record constructor: reassigned constructor parameters were captured from lambdas and therefore were not effectively final. The test contract was not changed.
+
+Corrected GREEN head:
+
+`0b04b775b80e480c7082872b70729ec01663109d`
+
+On that exact SHA, full API CI / Maven `verify` succeeded.
+
+### Subtraction core
+
+RED head:
+
+`289e973463bf2d391442a9645651851ad587e177`
+
+On that exact SHA, API `testCompile` failed because `PantryShoppingListAdjuster` did not exist.
+
+GREEN head:
+
+`a88092c914ffe5c80e4d4ad1da672ba8dcd2033d`
+
+On that exact SHA, full API CI / Maven `verify` succeeded with the complete subtraction test contract.
+
+### Architecture boundary
+
+Architecture-test head:
+
+`2066135d8a275feb78904bba71fec0dce7cf9625`
+
+On that exact SHA, full API CI / Maven `verify` succeeded. ArchUnit verifies:
+
+- the Pantry production boundary exists;
+- Pantry direct project dependencies target only `shopping`;
+- Pantry does not depend on Recipe, WeeklyPlan, preview/comparison, matching/basket, provider/retailer, database or Spring packages;
+- accepted Shopping, Recipe and WeeklyPlan packages do not depend on Pantry in M3.5.1.
+
+## Test coverage
+
+The Pantry test suite covers:
+
+1. unmatched stock;
+2. partial coverage;
+3. full coverage;
+4. kg/g canonical compatibility;
+5. l/ml canonical compatibility;
+6. incompatible dimensions;
+7. duplicate Pantry aggregation;
+8. single-consumption allocation across duplicate source keys;
+9. excess stock without zero/negative Shopping quantities;
+10. case-sensitive exact requirement matching;
+11. source ShoppingList immutability;
+12. caller-owned Pantry collection immutability;
+13. null input/row rejection;
+14. evidence status/unit/arithmetic invariants;
+15. package dependency direction.
+
+## Scope proof before final gate
+
+PR #122 changed only:
+
+- six production files under `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/`;
+- three tests under `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/`;
+- M3.5.1 design/plan/shipping documentation.
+
+No changed file is under:
+
+- OpenAPI/contracts/generated clients;
+- `apps/web`;
+- database/migrations;
+- retailer/provider bridges;
+- existing Shopping, Recipe, WeeklyPlan, preview/comparison production packages.
+
+Therefore M3.5.1 does not silently alter accepted M3.1–M3.4 runtime behavior.
+
+## Explicit non-goals preserved
+
+M3.5.1 does not add:
+
+- API endpoint/OpenAPI/generated-client exposure;
+- WeeklyPlan → Pantry → Comparison composition;
+- browser UI;
+- saved Pantry inventory/history/database schema;
+- dietary/medical or boolean “never buy” exclusions;
+- fuzzy/synonym/AI equivalence;
+- nutrition/macros;
+- retailer/provider onboarding or activation;
+- calendar/time-zone semantics.
+
+## Final acceptance gate
+
+The commit created by this shipping-evidence change becomes the final feature candidate. It must not be merged until:
+
+1. all **9/9 normal PR workflow groups** succeed on that exact head;
+2. failure count is zero;
+3. a read-only change review finds no unresolved P0–P3 issues;
+4. review threads are empty;
+5. PR #122 is marked ready only after those exact-head checks;
+6. squash merge uses expected-head protection;
+7. all normal post-merge `main` push workflows succeed.
+
+Only after those gates may M3.5.1 be called implemented → tested → reviewed → merged → accepted.

--- a/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics.md
+++ b/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics.md
@@ -1,294 +1,120 @@
 # M3.5.1 Pantry Subtraction Semantics Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Execution workflow:** superpowers:executing-plans, TDD-first, isolated GitHub feature branch.
 
-**Goal:** Add a pure deterministic Pantry domain layer that subtracts household stock from a canonical ShoppingList with explicit immutable audit evidence.
+**Goal:** Add a pure deterministic Pantry domain layer that subtracts household stock from a canonical `ShoppingList` with explicit immutable audit evidence.
 
-**Architecture:** Create `io.github.trueruslan.zakupgotov.pantry` depending only on accepted `shopping` types. Pantry stock is aggregated by exact `(ShoppingRequirement, canonical QuantityUnit)`, consumed sequentially in source ShoppingList order, and projected to a new remaining ShoppingList preserving source IDs plus per-item adjustment evidence.
+**Architecture:** `io.github.trueruslan.zakupgotov.pantry` depends only on accepted `shopping` types. Pantry stock is aggregated by exact `(ShoppingRequirement, canonical QuantityUnit)`, consumed sequentially in source `ShoppingList` order, and projected to a remaining `ShoppingList` preserving source IDs plus per-item adjustment evidence.
 
-**Tech Stack:** Java 25, JUnit 5, AssertJ, ArchUnit, existing Gradle/API CI.
+**Tech stack / verification:** Java 25, Maven 3.9.16 via repository `./mvnw`, JUnit 5, AssertJ, ArchUnit, GitHub Actions API CI.
 
-## Global Constraints
+## Global constraints
 
 - Baseline: `e11fd532c8d1f927a14cb886abaa9e9988f9b21b`.
 - Issue: #121.
-- No production code without a failing test first.
-- `pantry` may depend only on `shopping` project package.
+- PR: #122.
+- No production code before the corresponding failing behavior test.
+- `pantry` may depend only on the `shopping` project package.
 - No endpoint/OpenAPI/generated-client/UI/persistence/provider/retailer changes.
 - Exact matching only; no case folding, fuzzy, synonym or AI equivalence.
 - `Quantity` remains authoritative for positive values and kg/g + l/ml canonicalization.
-- Input ShoppingList and caller-owned pantry collection must never be mutated.
-- Preserve source ShoppingListId, surviving ShoppingItemId values and source item order.
+- Input `ShoppingList` and caller-owned pantry collection must never be mutated.
+- Preserve source `ShoppingListId`, surviving `ShoppingItemId` values and source item order.
+
+## Verification commands
+
+Focused tests may be run with Surefire selectors, while the authoritative gate is the same full Maven verification used by API CI:
+
+```bash
+./mvnw --batch-mode --no-transfer-progress -Dtest=PantryAdjustmentEvidenceTest test
+./mvnw --batch-mode --no-transfer-progress -Dtest=PantryShoppingListAdjusterTest test
+./mvnw --batch-mode --no-transfer-progress -Dtest=PantryArchitectureTest test
+./mvnw --batch-mode --no-transfer-progress verify
+```
+
+GitHub Actions on exact commit SHAs is authoritative in this connector-only execution environment.
 
 ---
 
 ### Task 1: Pantry value objects and evidence invariants
 
 **Files:**
-- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryItem.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentStatus.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryItem.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentStatus.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java`
 
-**Interfaces:**
-- Produces: `PantryItem(ShoppingRequirement requirement, Quantity quantity)`.
-- Produces: enum `PantryAdjustmentStatus { UNCHANGED, PARTIALLY_COVERED, FULLY_COVERED }`.
-- Produces: `PantryAdjustmentEvidence(ShoppingItemId itemId, ShoppingRequirement requirement, Quantity required, Optional<Quantity> pantryUsed, Optional<Quantity> remaining, PantryAdjustmentStatus status)`.
-
-- [ ] **Step 1: Write failing evidence tests**
-
-Cover valid UNCHANGED/PARTIAL/FULL states and reject impossible combinations such as `UNCHANGED` with used quantity, `PARTIALLY_COVERED` without both quantities, FULL with remaining quantity, mismatched units, used > required, or required != used + remaining.
-
-Representative test:
-
-```java
-@Test
-void fullyCoveredEvidenceKeepsRequiredAndUsedButHasNoRemainingQuantity() {
-    var required = quantity("500", QuantityUnit.GRAM);
-
-    var evidence = new PantryAdjustmentEvidence(
-            itemId(1),
-            new ShoppingRequirement("Rice"),
-            required,
-            Optional.of(required),
-            Optional.empty(),
-            PantryAdjustmentStatus.FULLY_COVERED);
-
-    assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.FULLY_COVERED);
-    assertThat(evidence.pantryUsed()).contains(required);
-    assertThat(evidence.remaining()).isEmpty();
-}
-```
-
-- [ ] **Step 2: Verify RED**
-
-Run:
-
-```bash
-./gradlew :apps:api:test --tests '*PantryAdjustmentEvidenceTest'
-```
-
-Expected: FAIL because Pantry production types do not exist.
-
-- [ ] **Step 3: Implement minimal value objects**
-
-`PantryItem` null-checks both fields. `PantryAdjustmentEvidence` defensively null-checks all fields and validates status structure, equal units, arithmetic consistency and positive `Quantity` invariants inherited from Shopping.
-
-Use `BigDecimal.compareTo` for arithmetic equality after canonicalization.
-
-- [ ] **Step 4: Verify GREEN**
-
-Run the same focused test command; expected PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry \
-        apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java
-git commit -m "feat(m3): define Pantry adjustment evidence"
-```
+- [x] Define valid `UNCHANGED`, `PARTIALLY_COVERED`, `FULLY_COVERED` evidence and reject impossible status/value/unit/arithmetic combinations.
+- [x] RED: `e95b076825278a4653939fe06599d5b42b3097f5` — API verification failed before Pantry production types existed.
+- [x] Implement immutable value types.
+- [x] Correct Java compact-record constructor capture issue without changing the test contract.
+- [x] GREEN: `0b04b775b80e480c7082872b70729ec01663109d` — full API CI / Maven `verify` SUCCESS.
 
 ---
 
 ### Task 2: Deterministic Pantry subtraction core
 
 **Files:**
-- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjusterTest.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryMatchKey.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustment.java`
-- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjuster.java`
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjusterTest.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryMatchKey.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustment.java`
+- `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjuster.java`
 
-**Interfaces:**
-- `PantryAdjustment` exposes `ShoppingList remainingShoppingList()` and immutable `List<PantryAdjustmentEvidence> evidence()`.
-- `PantryShoppingListAdjuster#adjust(ShoppingList source, List<PantryItem> pantryItems)` returns `PantryAdjustment`.
-- `PantryMatchKey` is package-private and contains only `ShoppingRequirement requirement, QuantityUnit unit`.
+Required behavior:
 
-- [ ] **Step 1: Write the first failing subtraction test**
-
-Start with partial coverage and identity/order preservation:
-
-```java
-@Test
-void partialCoverageReducesQuantityAndPreservesIdentity() {
-    var source = shoppingList(
-            item(1, "Rice", "1000", QuantityUnit.GRAM),
-            item(2, "Milk", "1000", QuantityUnit.MILLILITER));
-
-    var result = adjuster.adjust(source, List.of(
-            pantry("Rice", "250", QuantityUnit.GRAM)));
-
-    assertThat(result.remainingShoppingList().id()).isEqualTo(source.id());
-    assertThat(result.remainingShoppingList().items())
-            .extracting(item -> item.id().value())
-            .containsExactly(itemId(1).value(), itemId(2).value());
-    assertThat(result.remainingShoppingList().items().getFirst().quantity())
-            .isEqualTo(quantity("750", QuantityUnit.GRAM));
-    assertThat(source.items().getFirst().quantity())
-            .isEqualTo(quantity("1000", QuantityUnit.GRAM));
-}
-```
-
-- [ ] **Step 2: Verify RED**
-
-```bash
-./gradlew :apps:api:test --tests '*PantryShoppingListAdjusterTest'
-```
-
-Expected: FAIL because adjuster/result types do not exist.
-
-- [ ] **Step 3: Implement minimal partial subtraction**
-
-Create a new `ShoppingList(source.id())`, copy surviving items with original IDs/requirements and subtract using canonical amounts. Emit one evidence row per source item.
-
-- [ ] **Step 4: Verify focused GREEN**
-
-Run the focused test; expected PASS.
-
-- [ ] **Step 5: Add RED cases incrementally**
-
-Add one failing behavior at a time, running after each addition:
-
-1. unmatched pantry → item unchanged + UNCHANGED evidence;
-2. full coverage → source item absent from remaining list + FULLY_COVERED evidence;
-3. kg pantry covers gram requirement;
-4. liter pantry covers milliliter requirement;
+1. unmatched pantry leaves source requirement unchanged;
+2. partial coverage reduces only quantity while preserving IDs/order;
+3. full coverage omits item from remaining list while retaining audit evidence;
+4. kg/g and l/ml compatibility comes only from accepted `Quantity` canonicalization;
 5. incompatible dimensions do not match;
-6. duplicate pantry entries with the same key aggregate;
-7. duplicate source keys consume shared pantry only once in source order;
-8. excess pantry never creates zero/negative Shopping quantities;
-9. result evidence stays in source order;
-10. input source/pantry list remains unchanged.
+6. duplicate pantry rows aggregate by exact accepted match key;
+7. pantry stock is consumed once across duplicate source keys in source order;
+8. excess pantry never creates zero/negative `Quantity`;
+9. exact requirement equality remains case-sensitive;
+10. input shopping/pantry collections are not mutated;
+11. null inputs/rows fail closed as domain misuse.
 
-- [ ] **Step 6: Implement each GREEN minimally**
-
-Maintain a `LinkedHashMap<PantryMatchKey, BigDecimal>` of remaining pantry amounts. Aggregate duplicate pantry entries by addition. For each source item, compute:
-
-```java
-var available = stock.getOrDefault(key, BigDecimal.ZERO);
-var used = required.min(available);
-var remaining = required.subtract(used);
-stock.put(key, available.subtract(used));
-```
-
-Create `Quantity` only for strictly positive `used`/`remaining` amounts. Never mutate the source item/list or caller collection.
-
-- [ ] **Step 7: Verify complete subtraction suite GREEN**
-
-```bash
-./gradlew :apps:api:test --tests '*PantryShoppingListAdjusterTest' --tests '*PantryAdjustmentEvidenceTest'
-```
-
-Expected: PASS.
-
-- [ ] **Step 8: Commit**
-
-```bash
-git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry \
-        apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry
-git commit -m "feat(m3): add deterministic Pantry subtraction"
-```
+- [x] RED: `289e973463bf2d391442a9645651851ad587e177` — API test compilation failed because `PantryShoppingListAdjuster` did not exist.
+- [x] Implement `LinkedHashMap<PantryMatchKey, BigDecimal>` stock aggregation and sequential `min(required, available)` consumption.
+- [x] Preserve source `ShoppingListId`, surviving `ShoppingItemId`, requirement and source order.
+- [x] Emit one evidence row per source item in source order.
+- [x] GREEN: `a88092c914ffe5c80e4d4ad1da672ba8dcd2033d` — full API CI / Maven `verify` SUCCESS.
 
 ---
 
 ### Task 3: Architecture hardening
 
-**Files:**
-- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java`
+**File:**
+- `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java`
 
-**Interfaces:**
-- No production API changes.
-- Enforces package dependency direction.
+Rules:
 
-- [ ] **Step 1: Write failing architecture test before any forbidden dependency exists**
+- production `pantry` package must exist;
+- direct project dependencies from `pantry` may target only `shopping`;
+- no `pantry` dependency on Recipe, WeeklyPlan, preview/comparison, retailer/provider, matching/basket, database or Spring packages;
+- accepted `shopping`, `recipe` and `weeklyplan` packages must not depend on `pantry` in M3.5.1.
 
-The architecture test must assert the production package exists, collect direct project-package dependencies from `..pantry..`, allow only `..shopping..`, and assert no reverse dependencies from accepted `shopping`, `recipe` or `weeklyplan` packages.
-
-Core rule:
-
-```java
-noClasses()
-        .that().resideInAPackage("..pantry..")
-        .should().dependOnClassesThat().resideInAnyPackage(
-                "..recipe..",
-                "..weeklyplan..",
-                "..preview..",
-                "..comparison..",
-                "..basket..",
-                "..matching..",
-                "..provider..",
-                "..retailer..",
-                "..database..",
-                "org.springframework..")
-        .check(classes);
-```
-
-Also assert:
-
-```java
-noClasses()
-        .that().resideInAnyPackage("..shopping..", "..recipe..", "..weeklyplan..")
-        .should().dependOnClassesThat().resideInAPackage("..pantry..")
-        .check(classes);
-```
-
-- [ ] **Step 2: Verify the architecture test runs GREEN against the already implemented allowed dependency graph**
-
-This task is an architecture characterization/hardening test; no production change is expected if Task 2 respected the design.
-
-```bash
-./gradlew :apps:api:test --tests '*PantryArchitectureTest'
-```
-
-Expected: PASS. If it fails, fix the production dependency violation, not the rule.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java
-git commit -m "test(m3): harden Pantry architecture boundary"
-```
+- [x] Add ArchUnit characterization/hardening tests after the TDD core exists.
+- [ ] Confirm full API CI / Maven `verify` SUCCESS on exact architecture-test head `2066135d8a275feb78904bba71fec0dce7cf9625`.
 
 ---
 
 ### Task 4: Full verification and shipping evidence
 
-**Files:**
-- Create: `docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md`
+**File:**
+- `docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md`
 
-**Interfaces:**
-- No production API changes.
-
-- [ ] **Step 1: Run focused and full API verification**
-
-```bash
-./gradlew :apps:api:test --tests '*Pantry*'
-./gradlew :apps:api:check
-```
-
-Both must PASS.
-
-- [ ] **Step 2: Confirm scope**
-
-Verify no changes under OpenAPI/generated clients/web/database/provider/retailer and no edits to accepted M3.1–M3.4 production packages other than imports required by tests (prefer none).
-
-- [ ] **Step 3: Write shipping evidence**
-
-Record baseline, RED/GREEN commit SHAs, focused/full test results, exact changed files, explicit non-goals and the expected PR acceptance gate.
-
-- [ ] **Step 4: Commit shipping evidence**
-
-```bash
-git add docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md
-git commit -m "docs(m3): record Pantry subtraction shipping evidence"
-```
-
-- [ ] **Step 5: PR acceptance gate**
-
-Open a draft PR closing #121. On the exact final head require all normal PR workflow groups to complete successfully, perform a read-only review with no unresolved P0–P3 findings, mark ready only after the exact-head gate, squash-merge with expected-head protection, then require all normal `main` push workflows to succeed before declaring M3.5.1 accepted.
+- [ ] Confirm architecture gate.
+- [ ] Confirm final scope contains no endpoint/OpenAPI/generated client/web/database/provider/retailer changes and no accepted M3.1–M3.4 production edits.
+- [ ] Record RED→GREEN evidence and exact changed files.
+- [ ] Require all 9 normal PR workflow groups SUCCESS on the exact final head, with failure count 0.
+- [ ] Perform read-only review; resolve any P0–P3 findings before merge.
+- [ ] Mark PR ready only after exact-head CI/review gate.
+- [ ] Squash-merge with expected-head protection.
+- [ ] Require all normal `main` push workflows SUCCESS before declaring implementation accepted.
 
 ## Self-review
 
-- Spec coverage: all matching, arithmetic, identity, ordering, provenance, immutability, architecture and non-goal requirements map to Tasks 1–4.
-- Placeholder scan: no TODO/TBD/unspecified implementation steps remain.
-- Type consistency: `PantryItem`, `PantryAdjustmentEvidence`, `PantryAdjustment`, `PantryShoppingListAdjuster` signatures are consistent across tasks.
+- Spec coverage: matching, arithmetic, identity, ordering, provenance, immutability, architecture and non-goals all map to Tasks 1–4.
+- Tooling correction: this project uses Maven/API CI, not Gradle; all executable commands above match the repository CI toolchain.
 - Scope remains one independently testable subsystem: pure Pantry subtraction semantics only.

--- a/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics.md
+++ b/docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics.md
@@ -1,0 +1,294 @@
+# M3.5.1 Pantry Subtraction Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pure deterministic Pantry domain layer that subtracts household stock from a canonical ShoppingList with explicit immutable audit evidence.
+
+**Architecture:** Create `io.github.trueruslan.zakupgotov.pantry` depending only on accepted `shopping` types. Pantry stock is aggregated by exact `(ShoppingRequirement, canonical QuantityUnit)`, consumed sequentially in source ShoppingList order, and projected to a new remaining ShoppingList preserving source IDs plus per-item adjustment evidence.
+
+**Tech Stack:** Java 25, JUnit 5, AssertJ, ArchUnit, existing Gradle/API CI.
+
+## Global Constraints
+
+- Baseline: `e11fd532c8d1f927a14cb886abaa9e9988f9b21b`.
+- Issue: #121.
+- No production code without a failing test first.
+- `pantry` may depend only on `shopping` project package.
+- No endpoint/OpenAPI/generated-client/UI/persistence/provider/retailer changes.
+- Exact matching only; no case folding, fuzzy, synonym or AI equivalence.
+- `Quantity` remains authoritative for positive values and kg/g + l/ml canonicalization.
+- Input ShoppingList and caller-owned pantry collection must never be mutated.
+- Preserve source ShoppingListId, surviving ShoppingItemId values and source item order.
+
+---
+
+### Task 1: Pantry value objects and evidence invariants
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryItem.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentStatus.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidence.java`
+
+**Interfaces:**
+- Produces: `PantryItem(ShoppingRequirement requirement, Quantity quantity)`.
+- Produces: enum `PantryAdjustmentStatus { UNCHANGED, PARTIALLY_COVERED, FULLY_COVERED }`.
+- Produces: `PantryAdjustmentEvidence(ShoppingItemId itemId, ShoppingRequirement requirement, Quantity required, Optional<Quantity> pantryUsed, Optional<Quantity> remaining, PantryAdjustmentStatus status)`.
+
+- [ ] **Step 1: Write failing evidence tests**
+
+Cover valid UNCHANGED/PARTIAL/FULL states and reject impossible combinations such as `UNCHANGED` with used quantity, `PARTIALLY_COVERED` without both quantities, FULL with remaining quantity, mismatched units, used > required, or required != used + remaining.
+
+Representative test:
+
+```java
+@Test
+void fullyCoveredEvidenceKeepsRequiredAndUsedButHasNoRemainingQuantity() {
+    var required = quantity("500", QuantityUnit.GRAM);
+
+    var evidence = new PantryAdjustmentEvidence(
+            itemId(1),
+            new ShoppingRequirement("Rice"),
+            required,
+            Optional.of(required),
+            Optional.empty(),
+            PantryAdjustmentStatus.FULLY_COVERED);
+
+    assertThat(evidence.status()).isEqualTo(PantryAdjustmentStatus.FULLY_COVERED);
+    assertThat(evidence.pantryUsed()).contains(required);
+    assertThat(evidence.remaining()).isEmpty();
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+./gradlew :apps:api:test --tests '*PantryAdjustmentEvidenceTest'
+```
+
+Expected: FAIL because Pantry production types do not exist.
+
+- [ ] **Step 3: Implement minimal value objects**
+
+`PantryItem` null-checks both fields. `PantryAdjustmentEvidence` defensively null-checks all fields and validates status structure, equal units, arithmetic consistency and positive `Quantity` invariants inherited from Shopping.
+
+Use `BigDecimal.compareTo` for arithmetic equality after canonicalization.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the same focused test command; expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry \
+        apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustmentEvidenceTest.java
+git commit -m "feat(m3): define Pantry adjustment evidence"
+```
+
+---
+
+### Task 2: Deterministic Pantry subtraction core
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjusterTest.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryMatchKey.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryAdjustment.java`
+- Create: `apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry/PantryShoppingListAdjuster.java`
+
+**Interfaces:**
+- `PantryAdjustment` exposes `ShoppingList remainingShoppingList()` and immutable `List<PantryAdjustmentEvidence> evidence()`.
+- `PantryShoppingListAdjuster#adjust(ShoppingList source, List<PantryItem> pantryItems)` returns `PantryAdjustment`.
+- `PantryMatchKey` is package-private and contains only `ShoppingRequirement requirement, QuantityUnit unit`.
+
+- [ ] **Step 1: Write the first failing subtraction test**
+
+Start with partial coverage and identity/order preservation:
+
+```java
+@Test
+void partialCoverageReducesQuantityAndPreservesIdentity() {
+    var source = shoppingList(
+            item(1, "Rice", "1000", QuantityUnit.GRAM),
+            item(2, "Milk", "1000", QuantityUnit.MILLILITER));
+
+    var result = adjuster.adjust(source, List.of(
+            pantry("Rice", "250", QuantityUnit.GRAM)));
+
+    assertThat(result.remainingShoppingList().id()).isEqualTo(source.id());
+    assertThat(result.remainingShoppingList().items())
+            .extracting(item -> item.id().value())
+            .containsExactly(itemId(1).value(), itemId(2).value());
+    assertThat(result.remainingShoppingList().items().getFirst().quantity())
+            .isEqualTo(quantity("750", QuantityUnit.GRAM));
+    assertThat(source.items().getFirst().quantity())
+            .isEqualTo(quantity("1000", QuantityUnit.GRAM));
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+./gradlew :apps:api:test --tests '*PantryShoppingListAdjusterTest'
+```
+
+Expected: FAIL because adjuster/result types do not exist.
+
+- [ ] **Step 3: Implement minimal partial subtraction**
+
+Create a new `ShoppingList(source.id())`, copy surviving items with original IDs/requirements and subtract using canonical amounts. Emit one evidence row per source item.
+
+- [ ] **Step 4: Verify focused GREEN**
+
+Run the focused test; expected PASS.
+
+- [ ] **Step 5: Add RED cases incrementally**
+
+Add one failing behavior at a time, running after each addition:
+
+1. unmatched pantry → item unchanged + UNCHANGED evidence;
+2. full coverage → source item absent from remaining list + FULLY_COVERED evidence;
+3. kg pantry covers gram requirement;
+4. liter pantry covers milliliter requirement;
+5. incompatible dimensions do not match;
+6. duplicate pantry entries with the same key aggregate;
+7. duplicate source keys consume shared pantry only once in source order;
+8. excess pantry never creates zero/negative Shopping quantities;
+9. result evidence stays in source order;
+10. input source/pantry list remains unchanged.
+
+- [ ] **Step 6: Implement each GREEN minimally**
+
+Maintain a `LinkedHashMap<PantryMatchKey, BigDecimal>` of remaining pantry amounts. Aggregate duplicate pantry entries by addition. For each source item, compute:
+
+```java
+var available = stock.getOrDefault(key, BigDecimal.ZERO);
+var used = required.min(available);
+var remaining = required.subtract(used);
+stock.put(key, available.subtract(used));
+```
+
+Create `Quantity` only for strictly positive `used`/`remaining` amounts. Never mutate the source item/list or caller collection.
+
+- [ ] **Step 7: Verify complete subtraction suite GREEN**
+
+```bash
+./gradlew :apps:api:test --tests '*PantryShoppingListAdjusterTest' --tests '*PantryAdjustmentEvidenceTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/main/java/io/github/trueruslan/zakupgotov/pantry \
+        apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry
+git commit -m "feat(m3): add deterministic Pantry subtraction"
+```
+
+---
+
+### Task 3: Architecture hardening
+
+**Files:**
+- Create: `apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java`
+
+**Interfaces:**
+- No production API changes.
+- Enforces package dependency direction.
+
+- [ ] **Step 1: Write failing architecture test before any forbidden dependency exists**
+
+The architecture test must assert the production package exists, collect direct project-package dependencies from `..pantry..`, allow only `..shopping..`, and assert no reverse dependencies from accepted `shopping`, `recipe` or `weeklyplan` packages.
+
+Core rule:
+
+```java
+noClasses()
+        .that().resideInAPackage("..pantry..")
+        .should().dependOnClassesThat().resideInAnyPackage(
+                "..recipe..",
+                "..weeklyplan..",
+                "..preview..",
+                "..comparison..",
+                "..basket..",
+                "..matching..",
+                "..provider..",
+                "..retailer..",
+                "..database..",
+                "org.springframework..")
+        .check(classes);
+```
+
+Also assert:
+
+```java
+noClasses()
+        .that().resideInAnyPackage("..shopping..", "..recipe..", "..weeklyplan..")
+        .should().dependOnClassesThat().resideInAPackage("..pantry..")
+        .check(classes);
+```
+
+- [ ] **Step 2: Verify the architecture test runs GREEN against the already implemented allowed dependency graph**
+
+This task is an architecture characterization/hardening test; no production change is expected if Task 2 respected the design.
+
+```bash
+./gradlew :apps:api:test --tests '*PantryArchitectureTest'
+```
+
+Expected: PASS. If it fails, fix the production dependency violation, not the rule.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/test/java/io/github/trueruslan/zakupgotov/pantry/PantryArchitectureTest.java
+git commit -m "test(m3): harden Pantry architecture boundary"
+```
+
+---
+
+### Task 4: Full verification and shipping evidence
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md`
+
+**Interfaces:**
+- No production API changes.
+
+- [ ] **Step 1: Run focused and full API verification**
+
+```bash
+./gradlew :apps:api:test --tests '*Pantry*'
+./gradlew :apps:api:check
+```
+
+Both must PASS.
+
+- [ ] **Step 2: Confirm scope**
+
+Verify no changes under OpenAPI/generated clients/web/database/provider/retailer and no edits to accepted M3.1–M3.4 production packages other than imports required by tests (prefer none).
+
+- [ ] **Step 3: Write shipping evidence**
+
+Record baseline, RED/GREEN commit SHAs, focused/full test results, exact changed files, explicit non-goals and the expected PR acceptance gate.
+
+- [ ] **Step 4: Commit shipping evidence**
+
+```bash
+git add docs/superpowers/plans/2026-08-15-m3-5-1-pantry-subtraction-semantics-shipping.md
+git commit -m "docs(m3): record Pantry subtraction shipping evidence"
+```
+
+- [ ] **Step 5: PR acceptance gate**
+
+Open a draft PR closing #121. On the exact final head require all normal PR workflow groups to complete successfully, perform a read-only review with no unresolved P0–P3 findings, mark ready only after the exact-head gate, squash-merge with expected-head protection, then require all normal `main` push workflows to succeed before declaring M3.5.1 accepted.
+
+## Self-review
+
+- Spec coverage: all matching, arithmetic, identity, ordering, provenance, immutability, architecture and non-goal requirements map to Tasks 1–4.
+- Placeholder scan: no TODO/TBD/unspecified implementation steps remain.
+- Type consistency: `PantryItem`, `PantryAdjustmentEvidence`, `PantryAdjustment`, `PantryShoppingListAdjuster` signatures are consistent across tasks.
+- Scope remains one independently testable subsystem: pure Pantry subtraction semantics only.

--- a/docs/superpowers/specs/2026-08-15-m3-5-1-pantry-subtraction-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-15-m3-5-1-pantry-subtraction-semantics-design.md
@@ -1,0 +1,207 @@
+# M3.5.1 Pantry Subtraction Semantics — Design
+
+Date: 2026-08-15  
+Status: **APPROVED FOR IMPLEMENTATION**  
+Issue: #121  
+Baseline: `e11fd532c8d1f927a14cb886abaa9e9988f9b21b`
+
+## Goal
+
+Introduce the first Pantry / exclusions capability as a pure, deterministic domain layer that subtracts household pantry availability from an already canonical `ShoppingList` while preserving item identity, source order and explicit audit evidence.
+
+M3.5.1 deliberately stops before transport, WeeklyPlan/Comparison integration, browser UI or persistence. Its purpose is to make the subtraction semantics independently testable and reusable before any API contract exposes them.
+
+## Placement
+
+Accepted flow before M3.5:
+
+`Recipe → canonical ShoppingList → WeeklyPlan composition → Comparison Preview`
+
+M3.5.1 adds a pure boundary that can later be composed as:
+
+`canonical ShoppingList → Pantry adjustment → remaining ShoppingList → Comparison Preview`
+
+The Pantry package must depend only on the accepted `shopping` package. It must not depend on Recipe, WeeklyPlan, preview/comparison, retailer/provider, Spring or persistence packages.
+
+## Alternatives considered
+
+### A. Subtract pantry at Recipe / ingredient level
+
+Rejected. This would alter accepted M3.1/M3.2 serving scale, merge and provenance semantics and could cause the same pantry stock to be consumed separately by multiple Recipe occurrences before canonical aggregation.
+
+### B. Dedicated pure ShoppingList adjustment layer
+
+**Selected.** It operates on the canonical Shopping vocabulary after all Recipe/WeeklyPlan aggregation and before retailer comparison. It has one responsibility: household stock subtraction plus audit evidence.
+
+### C. Subtract inside retailer comparison
+
+Rejected. Household inventory is not retailer evidence. Coupling it to comparison would contaminate basket/ranking semantics and make pantry behavior retailer-dependent.
+
+## Domain vocabulary
+
+### `PantryItem`
+
+A positive amount of an exact shopping requirement already available at home:
+
+- `ShoppingRequirement requirement`
+- `Quantity quantity`
+
+`Quantity` remains authoritative for validation and unit canonicalization. Therefore `1 kg` enters Pantry semantics as `1000 g`, and `1 l` as `1000 ml`, exactly as in existing Shopping/Recipe semantics.
+
+Pantry entries have no persistence identity in M3.5.1. Their purpose is input stock, not a saved inventory model.
+
+### Exact match key
+
+Pantry matching uses the same semantic key already used by Recipe aggregation:
+
+`(ShoppingRequirement, canonical QuantityUnit)`
+
+Consequences:
+
+- whitespace normalization comes from `ShoppingRequirement`;
+- kg/g and l/ml compatibility comes from `Quantity` canonicalization;
+- `PIECE`, `GRAM` and `MILLILITER` remain distinct dimensions;
+- matching remains case-sensitive because accepted `ShoppingRequirement` equality is case-sensitive;
+- there is no synonym, fuzzy, stemming, transliteration or AI equivalence.
+
+M3.5.1 must not introduce a second ingredient-normalization algorithm.
+
+### `PantryAdjustmentStatus`
+
+Per shopping item:
+
+- `UNCHANGED` — no matching pantry quantity was consumed;
+- `PARTIALLY_COVERED` — pantry consumed a positive amount smaller than the requirement;
+- `FULLY_COVERED` — pantry consumed the entire requirement and the item is omitted from the remaining ShoppingList.
+
+### `PantryAdjustmentEvidence`
+
+Audit evidence for every source `ShoppingItem`, in source order:
+
+- source `ShoppingItemId`;
+- `ShoppingRequirement`;
+- original required `Quantity`;
+- optional positive pantry-used `Quantity`;
+- optional positive remaining `Quantity`;
+- `PantryAdjustmentStatus`.
+
+Zero is never encoded as `Quantity`, preserving the accepted invariant that `Quantity.amount > 0`.
+
+Evidence rules:
+
+- `UNCHANGED`: `pantryUsed = empty`, `remaining = required`;
+- `PARTIALLY_COVERED`: both values are present and positive;
+- `FULLY_COVERED`: `pantryUsed = required`, `remaining = empty`.
+
+Evidence is immutable and must validate these structural invariants.
+
+### `PantryAdjustment`
+
+Result containing:
+
+- `ShoppingList remainingShoppingList`;
+- immutable ordered `List<PantryAdjustmentEvidence> evidence`.
+
+The remaining list keeps the source `ShoppingListId`. Every surviving item keeps the source `ShoppingItemId` and `ShoppingRequirement`; only the quantity may decrease. Fully covered items are absent from the remaining list but remain visible in evidence.
+
+## Subtraction algorithm
+
+1. Validate non-null source list and pantry list.
+2. Aggregate duplicate pantry entries in insertion order by exact match key, summing canonical amounts.
+3. Iterate source `ShoppingList.items()` in source order.
+4. For each item, look up currently unconsumed pantry amount for its exact key.
+5. Consume `min(required, available)`.
+6. Decrement the matching pantry stock so the same household quantity can never cover two source requirements.
+7. If consumed is zero, copy the item unchanged to the remaining list and emit `UNCHANGED` evidence.
+8. If consumed is less than required, copy the item with the same ID/requirement and a positive reduced `Quantity`; emit `PARTIALLY_COVERED` evidence.
+9. If consumed equals required, do not add an item to the remaining list; emit `FULLY_COVERED` evidence.
+10. Ignore unmatched or excess pantry stock. M3.5.1 is a shopping-requirement adjustment, not a persisted pantry inventory ledger.
+
+The algorithm never mutates the input `ShoppingList` or caller-owned pantry list.
+
+## Duplicate behavior
+
+Duplicate pantry entries with the same exact key are intentionally additive. This permits callers to describe household stock in multiple rows without changing semantics.
+
+A source ShoppingList normally already has one row per accepted Recipe merge key, but the adjuster must still behave safely for arbitrary valid ShoppingLists containing multiple IDs with the same requirement/unit: pantry stock is allocated sequentially in source order and is consumed only once.
+
+## Identity and provenance
+
+M3.5.1 does not derive new Shopping identities:
+
+- source `ShoppingListId` is preserved;
+- surviving `ShoppingItemId` values are preserved;
+- fully covered source IDs remain in evidence;
+- no Pantry UUID is introduced.
+
+This allows later M3.5 composition to retain the accepted WeeklyPlan ingredient provenance keyed by the same `ShoppingItemId` without rewriting M3.2 identity rules.
+
+## Validation and failure model
+
+Programmer/domain misuse fails immediately:
+
+- null inputs/items are rejected;
+- `PantryItem` delegates positive amount/unit validation to accepted Shopping types;
+- evidence constructors reject impossible status/value combinations;
+- unexpected arithmetic/unit drift is an `IllegalStateException`, not silent coercion.
+
+There is no HTTP validation model in M3.5.1 because no endpoint is introduced.
+
+## Architecture boundary
+
+Create production package:
+
+`io.github.trueruslan.zakupgotov.pantry`
+
+Allowed project dependency:
+
+- `io.github.trueruslan.zakupgotov.shopping`
+
+Forbidden dependencies include:
+
+- `recipe`, `weeklyplan`, `weeklyplanpreview`, `weeklyplancomparisonpreview`;
+- `preview`, `comparison`, `basket`, `matching`;
+- `retailer`, `provider`;
+- `database` / persistence;
+- Spring web/framework transport code.
+
+Accepted `shopping`, `recipe` and `weeklyplan` packages must remain independent from `pantry` in this slice.
+
+## Test contract
+
+TDD coverage must include at least:
+
+1. unmatched pantry leaves a source item unchanged;
+2. partial coverage reduces quantity while preserving IDs/order;
+3. full coverage removes the item from remaining ShoppingList but keeps full evidence;
+4. kg/g canonical compatibility;
+5. l/ml canonical compatibility;
+6. incompatible dimensions do not match;
+7. duplicate pantry entries aggregate deterministically;
+8. pantry stock is consumed once across duplicate source keys in source order;
+9. excess pantry never creates negative/zero Shopping quantities;
+10. input ShoppingList and input pantry collection are not mutated;
+11. evidence structural invariants reject impossible states;
+12. ArchUnit enforces `pantry → shopping only` and prevents reverse dependencies.
+
+## Non-goals
+
+M3.5.1 does **not** add:
+
+- endpoint/OpenAPI/generated-client changes;
+- integration into `WeeklyPlanComparisonPreviewService`;
+- browser UI;
+- saved pantry inventory, history or database schema;
+- explicit dietary/medical exclusion rules;
+- a boolean “never buy this” rule hidden inside Pantry stock;
+- fuzzy/synonym/AI equivalence;
+- nutrition/macros;
+- retailer/provider changes;
+- calendar/time-zone semantics;
+- changes to accepted Recipe, Shopping, WeeklyPlan or Comparison algorithms.
+
+Explicit non-stock exclusions, if still needed after Pantry subtraction is accepted, must be designed as a separate semantic rule rather than being overloaded onto a zero/negative Pantry quantity.
+
+## Acceptance decision
+
+Implement M3.5.1 as the dedicated pure `pantry` domain package described above. A later M3.5 slice may expose and compose it with WeeklyPlan/Comparison only after this semantic layer is independently accepted.


### PR DESCRIPTION
Implements M3.5.1 pure Pantry subtraction semantics tracked by #121.

## Intended scope
- pure `pantry` domain package over accepted Shopping types;
- exact canonical requirement/unit matching;
- deterministic stock consumption and no negative demand;
- stable Shopping IDs/order for remaining requirements;
- immutable per-item audit evidence;
- architecture boundary: Pantry → Shopping only.

## Explicit non-goals
No endpoint/OpenAPI/generated-client, WeeklyPlan/Comparison integration, UI, persistence/database, fuzzy/AI matching, retailer/provider or accepted M3.1–M3.4 semantic changes.

## TDD state
This PR is intentionally opened in RED state at head `e95b076825278a4653939fe06599d5b42b3097f5`: the first evidence contract test exists before production Pantry types. It remains draft until all planned RED→GREEN cycles, exact-head CI and read-only review are complete.

Closes #121.