### PR TITLE
feat(m4): add deterministic basket optimizer

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationEvaluation.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationEvaluation.java
@@ -1,0 +1,13 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import java.util.List;
+
+record BasketOptimizationEvaluation(
+        BasketOptimizationStatus status,
+        List<RetailerCheckoutAssessmentResult> optimalCandidates) {
+
+    BasketOptimizationEvaluation {
+        optimalCandidates = List.copyOf(optimalCandidates);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationResult.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationResult.java
@@ -1,0 +1,34 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import io.github.trueruslan.zakupgotov.basket.BasketTotal;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public record BasketOptimizationResult(
+        List<RetailerCheckoutAssessmentResult> candidates,
+        BasketOptimizationStatus status,
+        List<RetailerCheckoutAssessmentResult> optimalCandidates) {
+
+    public BasketOptimizationResult {
+        candidates = List.copyOf(Objects.requireNonNull(candidates, "candidates must not be null"));
+        status = Objects.requireNonNull(status, "status must not be null");
+        optimalCandidates = List.copyOf(Objects.requireNonNull(optimalCandidates, "optimalCandidates must not be null"));
+
+        var expected = BasketOptimizationRules.evaluate(candidates);
+        if (status != expected.status()) {
+            throw new IllegalArgumentException("optimization status must match deterministic candidate evaluation");
+        }
+        if (!optimalCandidates.equals(expected.optimalCandidates())) {
+            throw new IllegalArgumentException("optimal candidates must exactly match deterministic minimum set and order");
+        }
+    }
+
+    public Optional<BasketTotal> lowestComparableCheckoutTotal() {
+        if (optimalCandidates.isEmpty()) {
+            return Optional.empty();
+        }
+        return optimalCandidates.getFirst().assessment().orElseThrow().comparableCheckoutTotal();
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
@@ -38,8 +38,8 @@ final class BasketOptimizationRules {
             var total = assessment.orElseThrow().comparableCheckoutTotal().orElseThrow(() ->
                     new IllegalArgumentException("COMPARABLE checkout assessment requires comparable total"));
             if (comparableCurrency == null) {
-                comparableCurrency = total.currency();
-            } else if (!comparableCurrency.equals(total.currency())) {
+                comparableCurrency = total.currencyCode();
+            } else if (!comparableCurrency.equals(total.currencyCode())) {
                 throw new IllegalArgumentException("comparable optimizer candidates must use one currency");
             }
 

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
@@ -1,6 +1,5 @@
 package io.github.trueruslan.zakupgotov.basketoptimization;
 
-import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
 import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutComparabilityStatus;
 import java.math.BigDecimal;
@@ -8,7 +7,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 final class BasketOptimizationRules {
 
@@ -68,11 +66,10 @@ final class BasketOptimizationRules {
     }
 
     private static void validateUniqueRetailers(List<RetailerCheckoutAssessmentResult> candidates) {
-        Set<RetailerId> retailers = new HashSet<>();
+        var retailers = new HashSet<>();
         for (var candidate : candidates) {
             Objects.requireNonNull(candidate, "optimizer candidate must not be null");
-            var retailerId = candidate.retailerId();
-            if (!retailers.add(retailerId)) {
+            if (!retailers.add(candidate.retailerId())) {
                 throw new IllegalArgumentException("optimizer candidates must contain unique retailer ids");
             }
         }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
@@ -71,7 +71,7 @@ final class BasketOptimizationRules {
         Set<RetailerId> retailers = new HashSet<>();
         for (var candidate : candidates) {
             Objects.requireNonNull(candidate, "optimizer candidate must not be null");
-            var retailerId = candidate.comparison().retailerId();
+            var retailerId = candidate.retailerId();
             if (!retailers.add(retailerId)) {
                 throw new IllegalArgumentException("optimizer candidates must contain unique retailer ids");
             }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationRules.java
@@ -1,0 +1,80 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutComparabilityStatus;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+final class BasketOptimizationRules {
+
+    private BasketOptimizationRules() {}
+
+    static BasketOptimizationEvaluation evaluate(List<RetailerCheckoutAssessmentResult> candidates) {
+        Objects.requireNonNull(candidates, "candidates must not be null");
+        if (candidates.isEmpty()) {
+            throw new IllegalArgumentException("optimizer candidates must not be empty");
+        }
+
+        var snapshot = List.copyOf(candidates);
+        validateUniqueRetailers(snapshot);
+
+        String comparableCurrency = null;
+        BigDecimal lowestAmount = null;
+        var optimalCandidates = new ArrayList<RetailerCheckoutAssessmentResult>();
+
+        for (var candidate : snapshot) {
+            var assessment = candidate.assessment();
+            if (assessment.isEmpty()
+                    || assessment.orElseThrow().comparabilityStatus()
+                            != RetailerCheckoutComparabilityStatus.COMPARABLE) {
+                continue;
+            }
+
+            var total = assessment.orElseThrow().comparableCheckoutTotal().orElseThrow(() ->
+                    new IllegalArgumentException("COMPARABLE checkout assessment requires comparable total"));
+            if (comparableCurrency == null) {
+                comparableCurrency = total.currency();
+            } else if (!comparableCurrency.equals(total.currency())) {
+                throw new IllegalArgumentException("comparable optimizer candidates must use one currency");
+            }
+
+            if (lowestAmount == null) {
+                lowestAmount = total.amount();
+                optimalCandidates.add(candidate);
+                continue;
+            }
+
+            var comparison = total.amount().compareTo(lowestAmount);
+            if (comparison < 0) {
+                lowestAmount = total.amount();
+                optimalCandidates.clear();
+                optimalCandidates.add(candidate);
+            } else if (comparison == 0) {
+                optimalCandidates.add(candidate);
+            }
+        }
+
+        var status = switch (optimalCandidates.size()) {
+            case 0 -> BasketOptimizationStatus.NO_COMPARABLE_CANDIDATES;
+            case 1 -> BasketOptimizationStatus.UNIQUE_WINNER;
+            default -> BasketOptimizationStatus.TIE;
+        };
+        return new BasketOptimizationEvaluation(status, optimalCandidates);
+    }
+
+    private static void validateUniqueRetailers(List<RetailerCheckoutAssessmentResult> candidates) {
+        Set<RetailerId> retailers = new HashSet<>();
+        for (var candidate : candidates) {
+            Objects.requireNonNull(candidate, "optimizer candidate must not be null");
+            var retailerId = candidate.comparison().retailerId();
+            if (!retailers.add(retailerId)) {
+                throw new IllegalArgumentException("optimizer candidates must contain unique retailer ids");
+            }
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationStatus.java
@@ -1,0 +1,7 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+public enum BasketOptimizationStatus {
+    NO_COMPARABLE_CANDIDATES,
+    UNIQUE_WINNER,
+    TIE
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizer.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizer.java
@@ -1,0 +1,12 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import java.util.List;
+
+public final class BasketOptimizer {
+
+    public BasketOptimizationResult optimize(List<RetailerCheckoutAssessmentResult> candidates) {
+        var evaluation = BasketOptimizationRules.evaluate(candidates);
+        return new BasketOptimizationResult(candidates, evaluation.status(), evaluation.optimalCandidates());
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailercheckout/RetailerCheckoutAssessmentResult.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/retailercheckout/RetailerCheckoutAssessmentResult.java
@@ -1,6 +1,7 @@
 package io.github.trueruslan.zakupgotov.retailercheckout;
 
 import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonView;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -19,5 +20,9 @@ public record RetailerCheckoutAssessmentResult(
         if (assessment.isPresent() && !assessment.orElseThrow().comparison().equals(comparison)) {
             throw new IllegalArgumentException("checkout assessment must reference the same retailer comparison");
         }
+    }
+
+    public RetailerId retailerId() {
+        return comparison.retailerId();
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationArchitectureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationArchitectureTest.java
@@ -1,0 +1,90 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import io.github.trueruslan.zakupgotov.basket.BasketTotal;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.util.LinkedHashSet;
+import org.junit.jupiter.api.Test;
+
+class BasketOptimizationArchitectureTest {
+
+    @Test
+    void optimizerDoesNotReachIntoAcquisitionMatchingOrApplicationLayers() {
+        var classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.github.trueruslan.zakupgotov");
+
+        noClasses()
+                .that().resideInAPackage("..basketoptimization..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "..provider..",
+                        "..matching..",
+                        "..shopping..",
+                        "..location..",
+                        "..comparison..",
+                        "..preview..",
+                        "..database..",
+                        "..recipe..",
+                        "..recipepreview..",
+                        "..recipecomparisonpreview..",
+                        "..weeklyplan..",
+                        "..weeklyplanpreview..",
+                        "..weeklyplancomparisonpreview..",
+                        "..weeklyplanpantrypreview..",
+                        "..weeklyplanpantrycomparisonpreview..",
+                        "..pantry..",
+                        "..operations..",
+                        "..system..",
+                        "org.springframework..",
+                        "org.jooq..",
+                        "jakarta..")
+                .check(classes);
+    }
+
+    @Test
+    void basketDependencyIsLimitedToBasketTotal() {
+        assertDirectProjectDependencies("io.github.trueruslan.zakupgotov.basket", BasketTotal.class.getName());
+    }
+
+    @Test
+    void retailerDependencyIsLimitedToRetailerIdentity() {
+        assertDirectProjectDependencies("io.github.trueruslan.zakupgotov.retailer", RetailerId.class.getName());
+    }
+
+    @Test
+    void acceptedUpstreamPackagesDoNotDependBackOnOptimizer() {
+        var classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.github.trueruslan.zakupgotov");
+
+        noClasses()
+                .that().resideInAnyPackage("..basket..", "..comparison..", "..retailer..", "..retailercheckout..")
+                .should().dependOnClassesThat().resideInAPackage("..basketoptimization..")
+                .check(classes);
+    }
+
+    private static void assertDirectProjectDependencies(String targetPackage, String... expectedClassNames) {
+        var classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.github.trueruslan.zakupgotov");
+        var dependencies = new LinkedHashSet<String>();
+
+        for (var javaClass : classes) {
+            if (!javaClass.getPackageName().equals("io.github.trueruslan.zakupgotov.basketoptimization")) {
+                continue;
+            }
+            for (var dependency : javaClass.getDirectDependenciesFromSelf()) {
+                var target = dependency.getTargetClass();
+                if (target.getPackageName().equals(targetPackage)) {
+                    dependencies.add(target.getName());
+                }
+            }
+        }
+
+        assertThat(dependencies).containsExactlyInAnyOrder(expectedClassNames);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationArchitectureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationArchitectureTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import io.github.trueruslan.zakupgotov.basket.BasketTotal;
-import io.github.trueruslan.zakupgotov.retailer.RetailerId;
 import java.util.LinkedHashSet;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +25,7 @@ class BasketOptimizationArchitectureTest {
                         "..shopping..",
                         "..location..",
                         "..comparison..",
+                        "..retailer..",
                         "..preview..",
                         "..database..",
                         "..recipe..",
@@ -48,11 +48,6 @@ class BasketOptimizationArchitectureTest {
     @Test
     void basketDependencyIsLimitedToBasketTotal() {
         assertDirectProjectDependencies("io.github.trueruslan.zakupgotov.basket", BasketTotal.class.getName());
-    }
-
-    @Test
-    void retailerDependencyIsLimitedToRetailerIdentity() {
-        assertDirectProjectDependencies("io.github.trueruslan.zakupgotov.retailer", RetailerId.class.getName());
     }
 
     @Test

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationInvariantTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizationInvariantTest.java
@@ -1,0 +1,191 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.basket.BasketEconomics;
+import io.github.trueruslan.zakupgotov.basket.BasketFee;
+import io.github.trueruslan.zakupgotov.basket.BasketTotal;
+import io.github.trueruslan.zakupgotov.basket.MinimumOrderConstraint;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonView;
+import io.github.trueruslan.zakupgotov.comparison.RetailerCoverageStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerFreshness;
+import io.github.trueruslan.zakupgotov.comparison.RetailerFreshnessBasis;
+import io.github.trueruslan.zakupgotov.comparison.RetailerProductionAccessStatus;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentService;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutEconomicsEvidence;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class BasketOptimizationInvariantTest {
+
+    @Test
+    void optimizerRejectsEmptyCandidateSet() {
+        assertThatThrownBy(() -> new BasketOptimizer().optimize(List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void optimizerRejectsNullCandidate() {
+        var candidates = new ArrayList<RetailerCheckoutAssessmentResult>();
+        candidates.add(null);
+
+        assertThatThrownBy(() -> new BasketOptimizer().optimize(candidates))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void optimizerRejectsDuplicateRetailerIds() {
+        var first = comparable(RetailerId.PYATEROCHKA, "1000.00", "RUB");
+        var second = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizer().optimize(List.of(first, second)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unique retailer ids");
+    }
+
+    @Test
+    void resultRejectsForgedStatus() {
+        var winner = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+        var other = comparable(RetailerId.PEREKRESTOK, "1000.00", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(winner, other),
+                        BasketOptimizationStatus.TIE,
+                        List.of(winner)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("status");
+    }
+
+    @Test
+    void resultRejectsMissingCandidateFromTrueTie() {
+        var first = comparable(RetailerId.PYATEROCHKA, "900.0", "RUB");
+        var second = comparable(RetailerId.PEREKRESTOK, "900.00", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(first, second),
+                        BasketOptimizationStatus.TIE,
+                        List.of(first)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("optimal candidates");
+    }
+
+    @Test
+    void resultRejectsExtraNonMinimumCandidate() {
+        var winner = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+        var higher = comparable(RetailerId.PEREKRESTOK, "1000.00", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(winner, higher),
+                        BasketOptimizationStatus.UNIQUE_WINNER,
+                        List.of(winner, higher)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("optimal candidates");
+    }
+
+    @Test
+    void resultRejectsNonComparableCandidateAsWinner() {
+        var ineligible = ineligible(RetailerId.PYATEROCHKA, "200.00", "500.00", "RUB");
+        var comparable = comparable(RetailerId.PEREKRESTOK, "900.00", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(ineligible, comparable),
+                        BasketOptimizationStatus.UNIQUE_WINNER,
+                        List.of(ineligible)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("optimal candidates");
+    }
+
+    @Test
+    void resultRejectsReorderedTieWinners() {
+        var first = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+        var second = comparable(RetailerId.PEREKRESTOK, "900.0", "RUB");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(first, second),
+                        BasketOptimizationStatus.TIE,
+                        List.of(second, first)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("optimal candidates");
+    }
+
+    @Test
+    void resultRejectsMixedComparableCurrencies() {
+        var rub = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+        var usd = comparable(RetailerId.PEREKRESTOK, "10.00", "USD");
+
+        assertThatThrownBy(() -> new BasketOptimizationResult(
+                        List.of(rub, usd),
+                        BasketOptimizationStatus.TIE,
+                        List.of(rub, usd)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("currency");
+    }
+
+    @Test
+    void resultDefensivelyCopiesCandidateLists() {
+        var first = comparable(RetailerId.PYATEROCHKA, "900.00", "RUB");
+        var second = comparable(RetailerId.PEREKRESTOK, "1000.00", "RUB");
+        var source = new ArrayList<>(List.of(first, second));
+
+        var result = new BasketOptimizer().optimize(source);
+        source.clear();
+
+        assertThat(result.candidates()).containsExactly(first, second);
+        assertThat(result.optimalCandidates()).containsExactly(first);
+    }
+
+    private static RetailerCheckoutAssessmentResult comparable(
+            RetailerId retailerId,
+            String amount,
+            String currency) {
+        return assess(retailerId, amount, "0", currency);
+    }
+
+    private static RetailerCheckoutAssessmentResult ineligible(
+            RetailerId retailerId,
+            String amount,
+            String minimum,
+            String currency) {
+        return assess(retailerId, amount, minimum, currency);
+    }
+
+    private static RetailerCheckoutAssessmentResult assess(
+            RetailerId retailerId,
+            String amount,
+            String minimum,
+            String currency) {
+        var subtotal = money(amount, currency);
+        var comparison = new RetailerComparisonView(
+                retailerId,
+                retailerId.name(),
+                RetailerCoverageStatus.CONNECTED,
+                RetailerProductionAccessStatus.READY,
+                RetailerComparisonStatus.READY,
+                List.of(),
+                Optional.of(subtotal),
+                Optional.of(new RetailerFreshness(
+                        RetailerFreshnessBasis.OBSERVATION_ONLY,
+                        Instant.parse("2026-08-15T12:00:00Z"),
+                        Optional.empty())));
+        var economics = new BasketEconomics(
+                BasketFee.known(money("0", currency)),
+                BasketFee.known(money("0", currency)),
+                MinimumOrderConstraint.known(money(minimum, currency)));
+        return new RetailerCheckoutAssessmentService().assess(
+                comparison,
+                new RetailerCheckoutEconomicsEvidence(retailerId, economics));
+    }
+
+    private static BasketTotal money(String amount, String currency) {
+        return new BasketTotal(new BigDecimal(amount), currency);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizerTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/basketoptimization/BasketOptimizerTest.java
@@ -1,0 +1,229 @@
+package io.github.trueruslan.zakupgotov.basketoptimization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.trueruslan.zakupgotov.basket.BasketEconomics;
+import io.github.trueruslan.zakupgotov.basket.BasketFee;
+import io.github.trueruslan.zakupgotov.basket.BasketTotal;
+import io.github.trueruslan.zakupgotov.basket.MinimumOrderConstraint;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonReason;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonView;
+import io.github.trueruslan.zakupgotov.comparison.RetailerCoverageStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerFreshness;
+import io.github.trueruslan.zakupgotov.comparison.RetailerFreshnessBasis;
+import io.github.trueruslan.zakupgotov.comparison.RetailerProductionAccessStatus;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentResult;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutAssessmentService;
+import io.github.trueruslan.zakupgotov.retailercheckout.RetailerCheckoutEconomicsEvidence;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class BasketOptimizerTest {
+
+    private final BasketOptimizer optimizer = new BasketOptimizer();
+
+    @Test
+    void selectsUniqueLowestComparableCandidateWithoutSortingOriginalCandidates() {
+        var expensive = comparable(RetailerId.PYATEROCHKA, "1200.00", "2026-08-15T12:00:00Z");
+        var winner = comparable(RetailerId.PEREKRESTOK, "950.00", "2026-08-15T11:00:00Z");
+        var middle = comparable(RetailerId.MAGNIT, "1100.00", "2026-08-15T13:00:00Z");
+        var input = List.of(expensive, winner, middle);
+
+        var result = optimizer.optimize(input);
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.UNIQUE_WINNER);
+        assertThat(result.candidates()).containsExactlyElementsOf(input);
+        assertThat(result.optimalCandidates()).containsExactly(winner);
+        assertThat(result.lowestComparableCheckoutTotal()).contains(money("950.00", "RUB"));
+    }
+
+    @Test
+    void numericEqualMinimumsAreExplicitTieEvenWhenDecimalScaleDiffers() {
+        var first = comparable(RetailerId.PYATEROCHKA, "1000.0", "2026-08-15T12:00:00Z");
+        var second = comparable(RetailerId.PEREKRESTOK, "1000.00", "2026-08-15T13:00:00Z");
+        var higher = comparable(RetailerId.MAGNIT, "1001.00", "2026-08-15T14:00:00Z");
+
+        var result = optimizer.optimize(List.of(first, second, higher));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.TIE);
+        assertThat(result.optimalCandidates()).containsExactly(first, second);
+        assertThat(result.lowestComparableCheckoutTotal()).contains(money("1000.0", "RUB"));
+    }
+
+    @Test
+    void nonEmptyVisibleSetWithNoComparableCandidatesIsExplicit() {
+        var ineligible = ineligible(RetailerId.PYATEROCHKA, "500.00", "1000.00", "RUB");
+        var uncertain = uncertain(RetailerId.PEREKRESTOK, "450.00", "RUB", "2026-08-15T12:00:00Z");
+        var incomplete = incomplete(RetailerId.MAGNIT);
+
+        var result = optimizer.optimize(List.of(ineligible, uncertain, incomplete));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.NO_COMPARABLE_CANDIDATES);
+        assertThat(result.optimalCandidates()).isEmpty();
+        assertThat(result.lowestComparableCheckoutTotal()).isEmpty();
+    }
+
+    @Test
+    void cheaperIneligibleCandidateNeverBeatsComparableCandidate() {
+        var ineligible = ineligible(RetailerId.PYATEROCHKA, "300.00", "1000.00", "RUB");
+        var comparable = comparable(RetailerId.PEREKRESTOK, "700.00", "2026-08-15T12:00:00Z");
+
+        var result = optimizer.optimize(List.of(ineligible, comparable));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.UNIQUE_WINNER);
+        assertThat(result.optimalCandidates()).containsExactly(comparable);
+    }
+
+    @Test
+    void cheaperUncertainArithmeticTotalNeverBeatsComparableCandidate() {
+        var uncertain = uncertain(RetailerId.PYATEROCHKA, "250.00", "RUB", "2026-08-15T14:00:00Z");
+        var comparable = comparable(RetailerId.PEREKRESTOK, "700.00", "2026-08-15T10:00:00Z");
+
+        var result = optimizer.optimize(List.of(uncertain, comparable));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.UNIQUE_WINNER);
+        assertThat(result.optimalCandidates()).containsExactly(comparable);
+    }
+
+    @Test
+    void mixedCurrenciesAmongComparableCandidatesFailClosed() {
+        var rub = comparable(RetailerId.PYATEROCHKA, "700.00", "RUB", "2026-08-15T12:00:00Z");
+        var usd = comparable(RetailerId.PEREKRESTOK, "10.00", "USD", "2026-08-15T12:00:00Z");
+
+        assertThatThrownBy(() -> optimizer.optimize(List.of(rub, usd)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("currency");
+    }
+
+    @Test
+    void differentCurrencyNonComparableCandidateDoesNotPoisonValidWinner() {
+        var usdIneligible = ineligible(RetailerId.PYATEROCHKA, "10.00", "100.00", "USD");
+        var rubWinner = comparable(RetailerId.PEREKRESTOK, "700.00", "RUB", "2026-08-15T12:00:00Z");
+
+        var result = optimizer.optimize(List.of(usdIneligible, rubWinner));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.UNIQUE_WINNER);
+        assertThat(result.optimalCandidates()).containsExactly(rubWinner);
+    }
+
+    @Test
+    void freshnessDifferencesNeverBreakExactMonetaryTie() {
+        var older = comparable(RetailerId.PYATEROCHKA, "800.00", "2026-08-15T08:00:00Z");
+        var newer = comparable(RetailerId.PEREKRESTOK, "800.00", "2026-08-15T18:00:00Z");
+
+        var result = optimizer.optimize(List.of(older, newer));
+
+        assertThat(result.status()).isEqualTo(BasketOptimizationStatus.TIE);
+        assertThat(result.optimalCandidates()).containsExactly(older, newer);
+    }
+
+    private static RetailerCheckoutAssessmentResult comparable(
+            RetailerId retailerId,
+            String amount,
+            String observedAt) {
+        return comparable(retailerId, amount, "RUB", observedAt);
+    }
+
+    private static RetailerCheckoutAssessmentResult comparable(
+            RetailerId retailerId,
+            String amount,
+            String currency,
+            String observedAt) {
+        var subtotal = money(amount, currency);
+        return new RetailerCheckoutAssessmentService().assess(
+                ready(retailerId, subtotal, observedAt),
+                new RetailerCheckoutEconomicsEvidence(
+                        retailerId,
+                        new BasketEconomics(
+                                BasketFee.known(money("0", currency)),
+                                BasketFee.known(money("0", currency)),
+                                MinimumOrderConstraint.known(money("0", currency)))));
+    }
+
+    private static RetailerCheckoutAssessmentResult ineligible(
+            RetailerId retailerId,
+            String amount,
+            String minimum,
+            String currency) {
+        var subtotal = money(amount, currency);
+        return new RetailerCheckoutAssessmentService().assess(
+                ready(retailerId, subtotal, "2026-08-15T12:00:00Z"),
+                new RetailerCheckoutEconomicsEvidence(
+                        retailerId,
+                        new BasketEconomics(
+                                BasketFee.known(money("0", currency)),
+                                BasketFee.known(money("0", currency)),
+                                MinimumOrderConstraint.known(money(minimum, currency)))));
+    }
+
+    private static RetailerCheckoutAssessmentResult uncertain(
+            RetailerId retailerId,
+            String amount,
+            String currency,
+            String observedAt) {
+        var subtotal = money(amount, currency);
+        return new RetailerCheckoutAssessmentService().assess(
+                new RetailerComparisonView(
+                        retailerId,
+                        displayName(retailerId),
+                        RetailerCoverageStatus.CONNECTED,
+                        RetailerProductionAccessStatus.READY,
+                        RetailerComparisonStatus.UNCERTAIN,
+                        List.of(RetailerComparisonReason.AVAILABILITY_UNKNOWN),
+                        Optional.of(subtotal),
+                        Optional.of(freshness(observedAt))),
+                new RetailerCheckoutEconomicsEvidence(
+                        retailerId,
+                        new BasketEconomics(
+                                BasketFee.known(money("0", currency)),
+                                BasketFee.known(money("0", currency)),
+                                MinimumOrderConstraint.known(money("0", currency)))));
+    }
+
+    private static RetailerCheckoutAssessmentResult incomplete(RetailerId retailerId) {
+        return new RetailerCheckoutAssessmentResult(
+                new RetailerComparisonView(
+                        retailerId,
+                        displayName(retailerId),
+                        RetailerCoverageStatus.CONNECTED,
+                        RetailerProductionAccessStatus.READY,
+                        RetailerComparisonStatus.INCOMPLETE,
+                        List.of(RetailerComparisonReason.ITEM_UNMATCHED),
+                        Optional.empty(),
+                        Optional.empty()),
+                Optional.empty());
+    }
+
+    private static RetailerComparisonView ready(RetailerId retailerId, BasketTotal subtotal, String observedAt) {
+        return new RetailerComparisonView(
+                retailerId,
+                displayName(retailerId),
+                RetailerCoverageStatus.CONNECTED,
+                RetailerProductionAccessStatus.READY,
+                RetailerComparisonStatus.READY,
+                List.of(),
+                Optional.of(subtotal),
+                Optional.of(freshness(observedAt)));
+    }
+
+    private static RetailerFreshness freshness(String observedAt) {
+        return new RetailerFreshness(
+                RetailerFreshnessBasis.OBSERVATION_ONLY,
+                Instant.parse(observedAt),
+                Optional.empty());
+    }
+
+    private static String displayName(RetailerId retailerId) {
+        return retailerId.name();
+    }
+
+    private static BasketTotal money(String amount, String currency) {
+        return new BasketTotal(new BigDecimal(amount), currency);
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/retailercheckout/RetailerCheckoutAssessmentResultIdentityTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/retailercheckout/RetailerCheckoutAssessmentResultIdentityTest.java
@@ -1,0 +1,33 @@
+package io.github.trueruslan.zakupgotov.retailercheckout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonReason;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerComparisonView;
+import io.github.trueruslan.zakupgotov.comparison.RetailerCoverageStatus;
+import io.github.trueruslan.zakupgotov.comparison.RetailerProductionAccessStatus;
+import io.github.trueruslan.zakupgotov.retailer.RetailerId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RetailerCheckoutAssessmentResultIdentityTest {
+
+    @Test
+    void exposesRetailerIdentityWithoutReachingThroughComparisonAtDownstreamCallers() {
+        var result = new RetailerCheckoutAssessmentResult(
+                new RetailerComparisonView(
+                        RetailerId.PYATEROCHKA,
+                        "Пятёрочка",
+                        RetailerCoverageStatus.CONNECTED,
+                        RetailerProductionAccessStatus.READY,
+                        RetailerComparisonStatus.INCOMPLETE,
+                        List.of(RetailerComparisonReason.ITEM_UNMATCHED),
+                        Optional.empty(),
+                        Optional.empty()),
+                Optional.empty());
+
+        assertThat(result.retailerId()).isEqualTo(RetailerId.PYATEROCHKA);
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md
+++ b/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md
@@ -1,0 +1,164 @@
+# M4.3 Deterministic Basket Optimizer — Shipping Evidence
+
+**Issue:** #139  
+**Implementation PR:** #140  
+**Baseline:** `b32c461eb49eefa5ab37f23d45491e9f46356c10`  
+**Branch:** `feat/m4-3-deterministic-basket-optimizer`
+
+## Design and plan
+
+- initial design: `dae2eae96c0dfeffa9f6ed2e5251ee4deb2912d0`
+- initial plan: `86b88ec2badbe5b0e43626a8a7f5bdc79d56d098`
+- architecture-hardening design amendment: `836e2669f1b0b52ea5ed289fa0c428c6ce2b4990`
+- architecture-hardening plan amendment: `2f685b934a055ebc6145daecb1e634f8a9ff742a`
+
+The final design keeps M4.3 a pure selection layer over accepted M4.2 checkout assessments. It never recomputes M1 packages/substitutions, never converts freshness into a hidden price penalty and never breaks a monetary tie by retailer/freshness/provider metadata.
+
+## Core TDD evidence
+
+### RED — optimizer behavior contract
+
+Test-only checkpoint:
+
+`e6923b46aa80a4ca8c9536568f8072be7c4f7c53`
+
+Draft PR #140 API CI:
+
+- run: `31901576243`
+- job: `95053058883`
+- Java 25/toolchain setup: SUCCESS
+- expected test-compilation FAILURE
+- exact cause: missing `BasketOptimizer` / `BasketOptimizationStatus` production symbols
+- no `basketoptimization` production package existed at the RED checkpoint.
+
+The RED contract covers unique winner, explicit numeric tie, no-comparable state, exclusion of cheaper ineligible/uncertain candidates, comparable-currency failure, non-comparable foreign-currency tolerance, freshness-neutral ties and preservation of input order.
+
+### GREEN — minimal deterministic optimizer
+
+Initial production commit:
+
+`0df063bd00f37c1e6ed02831b8fc0b67dc3635a9`
+
+Added:
+
+- `BasketOptimizationStatus`
+- package-private `BasketOptimizationEvaluation`
+- package-private `BasketOptimizationRules`
+- self-validating `BasketOptimizationResult`
+- `BasketOptimizer`
+
+The first compile candidate used the wrong accepted `BasketTotal` accessor (`currency()` instead of `currencyCode()`). This was a compile-only defect with no semantic change.
+
+Behavior-GREEN head:
+
+`6ccf4296c7112b7171a9ad08ef8c619fb3abbb3e`
+
+API CI:
+
+- run: `31901741891`
+- job: `95053464294`
+- status: **SUCCESS**
+- optimizer behavior tests: 8/8 PASS
+- full accepted upstream regression suite remained green.
+
+## Invariant hardening
+
+Invariant test commit:
+
+`567261da582fe1e5385bbc0a8042c1c187485c03`
+
+`BasketOptimizationInvariantTest` proves:
+
+- empty input fails closed;
+- null candidate fails closed;
+- duplicate retailer IDs fail closed;
+- wrong optimization status cannot be forged;
+- a real tie cannot be collapsed into a hidden winner;
+- a unique minimum cannot be inflated into a tie;
+- non-comparable/non-minimum candidates cannot be forged as optimal;
+- tied minima must be complete and retain original order;
+- mixed comparable currencies fail closed;
+- candidate lists are defensively copied.
+
+The shared deterministic rules already enforce these states, so no artificial invariant RED was manufactured.
+
+## Architecture proof and corrective TDD
+
+Initial architecture-test head:
+
+`0c607f121682738b795a41cfae995446a7d3164f`
+
+API CI:
+
+- run: `31901840678`
+- job: `95053726783`
+- optimizer behavior: 8/8 PASS
+- optimizer invariants: 10/10 PASS
+- full suite: **450 tests, 2 failures, 0 errors, 5 intentionally skipped live probes**
+- both failures were architecture-only.
+
+ArchUnit found a real abstraction leak: duplicate-retailer validation called `candidate.comparison().retailerId()`, creating a direct M4.3 dependency on the accepted M1 `comparison` layer. The architecture test also proved there was no actual direct `retailer` dependency, so weakening the boundary to allow `comparison` would have been incorrect.
+
+### RED — M4.2-owned retailer identity projection
+
+Targeted test-only checkpoint:
+
+`06b55b1f71bf2cb4bc5750384a0892020a5017d4`
+
+API CI:
+
+- run: `31901963844`
+- job: `95053998802`
+- Java 25/toolchain setup: SUCCESS
+- expected test-compilation FAILURE
+- exact cause: missing `RetailerCheckoutAssessmentResult.retailerId()`.
+
+### GREEN — remove M4.3 direct comparison/retailer dependency
+
+Corrective chain:
+
+- `187b7f41cb3b7e75c2c4df5adecc7262745f7065` — additive, non-semantic M4.2 `retailerId()` projection;
+- `d24604e7a0091e05fecc985ebf80952266852221` — M4.3 consumes retailer identity through the M4.2 boundary instead of `comparison()`;
+- `f410d175c535100b091882b8495a55138ee9c7db` — remove the redundant source-level direct `RetailerId` generic;
+- `cab385ff194c295a073862a35f8ff088e2d45579` — final architecture guard requires no direct M4.3 dependency on either `comparison` or `retailer`.
+
+API CI on `cab385ff...`:
+
+- run: `31902117168`
+- job: `95054389341`
+- status: **SUCCESS**
+- behavior and invariant tests remain green;
+- M4.2 identity-projection regression passes;
+- architecture guards pass.
+
+The M4.2 addition is intentionally non-semantic: `retailerId()` returns the retailer identity already owned by the embedded accepted `RetailerComparisonView`; it does not alter M4.2 eligibility, comparability, economics or validation.
+
+## Final implemented semantics awaiting immutable PR gate
+
+- optimizer input is a non-empty ordered list of M4.2 results with unique retailer identities;
+- all original candidates remain visible in original order;
+- only explicit M4.2 `COMPARABLE` candidates compete;
+- comparable candidates must use one currency;
+- exact `BigDecimal.compareTo` ordering is used with no rounding/rescaling;
+- numerically equal minima are an explicit `TIE`, including different decimal scales;
+- all tied minima remain in original input order;
+- no input/canonical retailer order is a tie-break;
+- freshness/provider timestamps/package/SKU evidence never break a tie or become hidden price penalties;
+- cheaper ineligible/unknown/uncertain/incomplete/unavailable evidence cannot win;
+- no package/SKU/substitution recomputation, provider acquisition, HTTP/OpenAPI/UI or multi-store split is introduced;
+- `BasketOptimizationResult` recomputes and validates its own deterministic status/optimal candidate set;
+- final M4.3 production dependencies are accepted M4.2 plus neutral `BasketTotal`; no direct `comparison` or `retailer` dependency exists.
+
+## Final gate
+
+This evidence document is committed before the immutable final PR gate. Acceptance still requires the resulting exact PR head to prove:
+
+- exactly 9 normal PR workflow groups;
+- 9/9 SUCCESS, 0 failure/skipped/cancelled;
+- clean read-only review with no P0/P1/P2/P3/nitpicks;
+- zero unresolved review threads;
+- mergeable=true;
+- expected-head protected squash merge;
+- exact implementation merge with 8/8 normal push workflows SUCCESS.
+
+Canonical project-state/roadmap/changelog acceptance remains a separate post-merge docs PR.

--- a/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md
+++ b/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md
@@ -1,0 +1,127 @@
+# M4.3 Deterministic Basket Optimizer — Implementation Plan
+
+**Issue:** #139  
+**Baseline:** `b32c461eb49eefa5ab37f23d45491e9f46356c10`  
+**Branch:** `feat/m4-3-deterministic-basket-optimizer`
+
+## Goal
+
+Implement a pure deterministic optimizer over accepted M4.2 checkout assessments. Only explicit `COMPARABLE` candidates may compete; exact monetary ties remain ties; M1 package/freshness evidence is preserved rather than reinterpreted.
+
+## Task 1 — RED: optimizer behavior
+
+Add `BasketOptimizerTest` before production optimizer types exist.
+
+Required scenarios:
+
+1. one comparable candidate with the lowest checkout total -> `UNIQUE_WINNER`;
+2. two numeric-equal minima, including different decimal scales -> `TIE`, both retained in input order;
+3. all candidates non-comparable -> `NO_COMPARABLE_CANDIDATES`;
+4. a cheaper arithmetic total from an ineligible/non-comparable candidate is excluded;
+5. an upstream UNCERTAIN candidate with a lower arithmetic total is excluded;
+6. mixed comparable currencies fail closed;
+7. a different-currency non-comparable candidate does not poison a valid winner;
+8. freshness differences do not break an exact monetary tie;
+9. input candidate order is preserved even when the unique winner is not first.
+
+Commit test-only RED and use draft PR API CI to prove failure is missing M4.3 symbols, not infrastructure.
+
+## Task 2 — GREEN: minimal optimizer
+
+Add package `io.github.trueruslan.zakupgotov.basketoptimization`:
+
+- `BasketOptimizationStatus`
+- package-private `BasketOptimizationEvaluation`
+- package-private `BasketOptimizationRules`
+- `BasketOptimizationResult`
+- `BasketOptimizer`
+
+Rules:
+
+- input list required, non-empty, defensive-copy;
+- null candidate rejected;
+- duplicate retailer IDs rejected;
+- only M4.2 COMPARABLE candidates enter monetary comparison;
+- mixed comparable currencies rejected;
+- numeric ordering uses exact `BigDecimal.compareTo`, no rounding/rescaling;
+- unique minimum -> one optimal candidate;
+- numeric tie -> all minima, original order;
+- no comparable candidate -> explicit status;
+- result exposes original candidates and optimal candidates, not a sorted ranking.
+
+Run full API verification to GREEN.
+
+## Task 3 — invariant hardening
+
+Add `BasketOptimizationInvariantTest` proving `BasketOptimizationResult` rejects:
+
+- empty/null/duplicate-retailer candidate set;
+- wrong status;
+- missing unique winner;
+- fabricated unique winner from a tie;
+- fabricated tie when a unique minimum exists;
+- non-comparable optimal candidate;
+- non-minimum optimal candidate;
+- missing/extra/reordered tied optimal candidates;
+- mixed comparable currencies.
+
+If shared deterministic rules already reject all states, record GREEN proof without manufacturing an artificial RED.
+
+## Task 4 — architecture proof
+
+Add `BasketOptimizationArchitectureTest` proving:
+
+- production package has no provider, matching, shopping, location, comparison-direct, preview, persistence/database, Spring, jOOQ, Recipe, WeeklyPlan or Pantry dependency;
+- allowed project dependencies are accepted `retailercheckout`, neutral `basket.BasketTotal` and finite `retailer.RetailerId` only;
+- `basket`, `comparison`, `retailer`, and `retailercheckout` do not depend back on `basketoptimization`.
+
+Run full API verification.
+
+## Task 5 — shipping evidence and review
+
+Record RED/GREEN/architecture evidence in:
+
+`docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md`
+
+Open/maintain draft PR linked to #139. Perform read-only review for:
+
+- hidden tie-breaks;
+- currency behavior;
+- freshness/confidence leakage into winner selection;
+- package/substitution recomputation;
+- preservation of non-comparable candidates;
+- constructor forgeability;
+- architecture direction.
+
+Correct verified findings through additional TDD only.
+
+## Task 6 — exact-head acceptance
+
+Freeze final feature SHA and require:
+
+- exactly 9 normal PR workflow groups;
+- 9/9 SUCCESS, no failure/skipped/cancelled;
+- clean read-only review, no P0/P1/P2/P3/nitpicks;
+- zero unresolved review threads;
+- mergeable=true.
+
+Mark ready and squash merge with `expected_head_sha`.
+
+## Task 7 — post-merge and canonical docs
+
+Verify exact implementation merge:
+
+- `main` points to merge SHA;
+- issue #139 closed completed;
+- exactly 8 normal push workflows;
+- 8/8 SUCCESS.
+
+Then create separate docs-only acceptance PR updating:
+
+- M4.3 acceptance record;
+- `docs/PROJECT_STATE.md`;
+- `docs/ROADMAP.md`;
+- `CHANGELOG.md`;
+- next deterministic target to M4.4 Optimization UX.
+
+Require docs PR 9/9 + clean review, expected-head squash merge, final main 8/8.

--- a/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md
+++ b/docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md
@@ -40,7 +40,7 @@ Rules:
 
 - input list required, non-empty, defensive-copy;
 - null candidate rejected;
-- duplicate retailer IDs rejected;
+- duplicate retailer IDs rejected through the M4.2 result abstraction;
 - only M4.2 COMPARABLE candidates enter monetary comparison;
 - mixed comparable currencies rejected;
 - numeric ordering uses exact `BigDecimal.compareTo`, no rounding/rescaling;
@@ -71,9 +71,17 @@ If shared deterministic rules already reject all states, record GREEN proof with
 
 Add `BasketOptimizationArchitectureTest` proving:
 
-- production package has no provider, matching, shopping, location, comparison-direct, preview, persistence/database, Spring, jOOQ, Recipe, WeeklyPlan or Pantry dependency;
-- allowed project dependencies are accepted `retailercheckout`, neutral `basket.BasketTotal` and finite `retailer.RetailerId` only;
+- production package has no provider, matching, shopping, location, direct comparison, direct retailer, preview, persistence/database, Spring, jOOQ, Recipe, WeeklyPlan or Pantry dependency;
+- the only direct basket dependency is neutral `BasketTotal`;
+- retailer identity is consumed through accepted M4.2 `RetailerCheckoutAssessmentResult` rather than by reaching through to M1 comparison;
 - `basket`, `comparison`, `retailer`, and `retailercheckout` do not depend back on `basketoptimization`.
+
+If the first architecture proof finds direct M4.3 access to `RetailerComparisonView`, treat it as a real abstraction leak rather than weakening the guard:
+
+1. add a test-first M4.2 identity projection requirement;
+2. expose non-semantic `RetailerCheckoutAssessmentResult.retailerId()` returning its embedded accepted comparison identity;
+3. consume only that M4.2 projection from M4.3;
+4. require final M4.3 bytecode to have no direct `comparison` or `retailer` dependency.
 
 Run full API verification.
 
@@ -91,7 +99,8 @@ Open/maintain draft PR linked to #139. Perform read-only review for:
 - package/substitution recomputation;
 - preservation of non-comparable candidates;
 - constructor forgeability;
-- architecture direction.
+- architecture direction;
+- whether the additive M4.2 identity projection changes accepted M4.2 semantics (it must not).
 
 Correct verified findings through additional TDD only.
 

--- a/docs/superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md
+++ b/docs/superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md
@@ -1,0 +1,204 @@
+# M4.3 Deterministic Basket Optimizer — Design
+
+**Date:** 2026-08-15  
+**Issue:** #139  
+**Baseline:** `b32c461eb49eefa5ab37f23d45491e9f46356c10`
+
+## Goal
+
+Select the lowest truthful single-retailer checkout option over accepted M4.2 retailer checkout assessments without recomputing retailer baskets, inventing confidence, applying hidden freshness penalties or selecting an arbitrary winner from an exact monetary tie.
+
+M4.3 is a **selection layer**, not a package/SKU optimizer. Accepted M1 matching/package/basket decisions and accepted M4.2 eligibility/comparability decisions are immutable inputs.
+
+## Boundary
+
+New downstream package:
+
+`io.github.trueruslan.zakupgotov.basketoptimization`
+
+Public boundary:
+
+`BasketOptimizer.optimize(List<RetailerCheckoutAssessmentResult> candidates)`
+
+Allowed domain dependencies:
+
+- accepted `retailercheckout` M4.2 types;
+- `BasketTotal` for explicit lowest-total projection;
+- finite `RetailerId` identity bridge for duplicate-retailer validation.
+
+No reverse dependency from basket/retailercheckout/comparison/retailer into basketoptimization.
+
+No provider, matching, shopping, package recomputation, persistence, Spring, HTTP/OpenAPI/UI, network acquisition or multi-store split.
+
+## Input contract
+
+The optimizer accepts an **ordered, non-empty** list of M4.2 `RetailerCheckoutAssessmentResult` values.
+
+Input rules:
+
+- list is required and defensively copied;
+- null candidates are rejected;
+- retailer IDs must be unique;
+- original candidate order is retained in the result for inspectability;
+- original order is never used to prefer one retailer over another.
+
+The pure optimizer does not require the entire canonical registry itself. Canonical retailer visibility remains an upstream comparison/composition responsibility. It does reject an empty set because silently optimizing no visible retailers would hide an integration/composition error. `NO_COMPARABLE_CANDIDATES` is reserved for a non-empty visible candidate set whose members are all non-comparable.
+
+## Competitive eligibility
+
+Only an M4.2 assessment whose `comparabilityStatus == COMPARABLE` may compete.
+
+By accepted M4.2 invariant, every comparable assessment has `comparableCheckoutTotal` present.
+
+All other candidates remain in `BasketOptimizationResult.candidates` but are excluded from winner calculation:
+
+- M4.2 `NOT_COMPARABLE`;
+- `INELIGIBLE`;
+- eligibility `UNKNOWN`;
+- upstream `UNCERTAIN`;
+- upstream `INCOMPLETE`;
+- upstream `UNAVAILABLE`.
+
+M4.3 never attempts to repair or upgrade an upstream candidate.
+
+## Currency rule
+
+All **comparable** candidates in one optimization call must use the same normalized ISO-4217 currency.
+
+If two comparable candidates use different currencies, optimization fails closed with `IllegalArgumentException`. M4.3 has no currency-conversion contract and therefore must not rank one currency against another.
+
+A non-comparable candidate in another currency does not poison a valid comparable set because it does not participate in monetary comparison. It remains visible in the original candidate list.
+
+## Amount comparison
+
+Comparable checkout amounts are compared using exact `BigDecimal.compareTo` semantics:
+
+- no `double`/`float` conversion;
+- no rounding;
+- no scale normalization/rescaling;
+- numerically equal amounts compare equal even if source decimal scales differ, e.g. `1200.0` and `1200.00`.
+
+This preserves exact arithmetic while avoiding a false winner based only on decimal representation scale.
+
+## Outcome model
+
+`BasketOptimizationStatus` has exactly:
+
+- `NO_COMPARABLE_CANDIDATES`
+- `UNIQUE_WINNER`
+- `TIE`
+
+`BasketOptimizationResult` contains:
+
+- `List<RetailerCheckoutAssessmentResult> candidates` — all original candidates in original order;
+- `BasketOptimizationStatus status`;
+- `List<RetailerCheckoutAssessmentResult> optimalCandidates` — none, one or all exact minima in original order.
+
+A convenience method `lowestComparableCheckoutTotal()` derives the lowest total from the first optimal candidate when one exists. It is absent for `NO_COMPARABLE_CANDIDATES`.
+
+### NO_COMPARABLE_CANDIDATES
+
+- input candidates remain non-empty;
+- no candidate is M4.2 COMPARABLE;
+- `optimalCandidates` is empty;
+- lowest total is absent.
+
+### UNIQUE_WINNER
+
+- at least one comparable candidate exists;
+- exactly one comparable candidate has the numerically lowest checkout amount;
+- `optimalCandidates` contains exactly that candidate;
+- lowest total is its exact M4.2 `BasketTotal` value.
+
+### TIE
+
+- at least two comparable candidates share the numerically lowest amount;
+- `optimalCandidates` contains **all** tied minima in original input order;
+- no other candidate is included;
+- no single winner is exposed.
+
+## Tie policy
+
+A tie is never broken by:
+
+- original/canonical retailer order;
+- retailer ID;
+- freshness basis;
+- `observedAt`;
+- provider update time;
+- package/SKU identity;
+- availability observation timing;
+- arbitrary iteration order.
+
+M4.3 exposes the tie honestly. A later product policy may add user-selected convenience preferences, but that requires a separate explicit design.
+
+## Package/substitution policy
+
+M4.3 does not alter product/package selections.
+
+The accepted M1/M4.2 candidate already represents a deterministic retailer basket. M4.3 compares only final M4.2 comparable checkout totals. It does not:
+
+- search alternative SKUs;
+- substitute brands/products;
+- change package counts;
+- combine products across retailers;
+- rebuild matching or package arithmetic.
+
+Any future intra-retailer substitute/package optimizer must be designed as a separate upstream slice that produces a new truthful M4.2-compatible candidate. M4.3 must never infer such alternatives from presentation text or price.
+
+## Freshness/confidence policy
+
+Freshness remains preserved inside the original M1 comparison evidence carried by each M4.2 candidate.
+
+M4.3 does **not**:
+
+- convert freshness into a monetary penalty;
+- use newer freshness as a tie-break;
+- invent a confidence score;
+- use provider timestamp presence as ranking preference.
+
+Reason: the project has no accepted quantitative staleness threshold or confidence model. Inventing one would create hidden optimization semantics. Matching/availability uncertainty already makes candidates non-comparable upstream where appropriate.
+
+## Self-validation
+
+`BasketOptimizationResult` recomputes the expected optimization outcome from its candidate list and rejects forged states:
+
+- empty candidates;
+- null entries;
+- duplicate retailer IDs;
+- mixed currencies among comparable candidates;
+- wrong status;
+- missing/extra/reordered optimal candidates;
+- a non-comparable optimal candidate;
+- a candidate above the numeric minimum appearing as optimal;
+- hidden unique winner when the true outcome is a tie;
+- hidden tie when a unique minimum exists.
+
+The service and result share one package-private deterministic evaluation helper so validation and production selection cannot drift.
+
+## Non-goals
+
+- HTTP/OpenAPI/browser UX;
+- multi-store split basket;
+- package/SKU/substitute search;
+- discount/loyalty/subscription/tip modeling;
+- currency conversion;
+- freshness thresholds/penalties;
+- confidence scoring;
+- user-preference tie-breaks;
+- provider acquisition.
+
+## Required acceptance proof
+
+1. Unique lowest comparable candidate -> `UNIQUE_WINNER`.
+2. Equal numeric totals, including different decimal scale -> `TIE` with every minimum in input order.
+3. Non-empty all-non-comparable set -> `NO_COMPARABLE_CANDIDATES`.
+4. Cheaper ineligible/unknown/uncertain/incomplete/unavailable candidate never wins.
+5. Mixed currencies among comparable candidates fail closed.
+6. Different-currency non-comparable candidate does not poison a valid comparable winner.
+7. Empty input, null candidate and duplicate retailer IDs fail closed.
+8. Public result rejects forged status/optimal sets.
+9. Freshness differences never break a monetary tie.
+10. Candidate list/order is preserved and no input object is mutated.
+11. Architecture allows only accepted M4.2 + neutral total/retailer identity and has no reverse/provider/matching/API/database coupling.
+12. Existing M1/M4.1/M4.2 tests remain unchanged and green.

--- a/docs/superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md
+++ b/docs/superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md
@@ -23,8 +23,11 @@ Public boundary:
 Allowed domain dependencies:
 
 - accepted `retailercheckout` M4.2 types;
-- `BasketTotal` for explicit lowest-total projection;
-- finite `RetailerId` identity bridge for duplicate-retailer validation.
+- `BasketTotal` for explicit lowest-total projection.
+
+Retailer identity is owned and projected by M4.2 through `RetailerCheckoutAssessmentResult.retailerId()`. M4.3 must not reach through that result into `RetailerComparisonView`, and it has no direct `comparison` or `retailer` dependency.
+
+The `retailerId()` convenience projection is a non-semantic M4.2 abstraction seam: it returns the already-public identity of the embedded accepted comparison and changes no M4.2 eligibility/comparability behavior.
 
 No reverse dependency from basket/retailercheckout/comparison/retailer into basketoptimization.
 
@@ -38,7 +41,7 @@ Input rules:
 
 - list is required and defensively copied;
 - null candidates are rejected;
-- retailer IDs must be unique;
+- retailer IDs, obtained only through the M4.2 result abstraction, must be unique;
 - original candidate order is retained in the result for inspectability;
 - original order is never used to prefer one retailer over another.
 
@@ -176,6 +179,19 @@ Reason: the project has no accepted quantitative staleness threshold or confiden
 
 The service and result share one package-private deterministic evaluation helper so validation and production selection cannot drift.
 
+## Review-driven architecture hardening
+
+The first proof-layer implementation obtained retailer identity through `candidate.comparison().retailerId()`. ArchUnit correctly rejected this as a direct M4.3 dependency on the M1 `comparison` layer.
+
+The accepted correction is:
+
+1. M4.2 `RetailerCheckoutAssessmentResult` exposes `retailerId()` as an identity projection of its already-owned comparison;
+2. M4.3 consumes only that M4.2 projection;
+3. duplicate-retailer validation remains fail-closed;
+4. final architecture has no direct M4.3 dependency on `comparison` or `retailer` at all.
+
+This hardening changes only dependency direction, not optimizer selection semantics or accepted M4.2 state semantics.
+
 ## Non-goals
 
 - HTTP/OpenAPI/browser UX;
@@ -200,5 +216,6 @@ The service and result share one package-private deterministic evaluation helper
 8. Public result rejects forged status/optimal sets.
 9. Freshness differences never break a monetary tie.
 10. Candidate list/order is preserved and no input object is mutated.
-11. Architecture allows only accepted M4.2 + neutral total/retailer identity and has no reverse/provider/matching/API/database coupling.
-12. Existing M1/M4.1/M4.2 tests remain unchanged and green.
+11. Architecture allows only accepted M4.2 plus neutral `BasketTotal`, with no direct `comparison`/`retailer` and no reverse/provider/matching/API/database coupling.
+12. M4.2 identity projection returns the embedded accepted retailer identity without changing M4.2 semantics.
+13. Existing M1/M4.1/M4.2 tests remain unchanged and green except for the additive M4.2 identity-projection regression.


### PR DESCRIPTION
Implements M4.3 from #139 as a pure deterministic selection layer over accepted M4.2 checkout assessments.

Final semantics:
- input is a non-empty ordered candidate set with unique retailer identities;
- all original candidates remain visible in original order;
- only M4.2 `COMPARABLE` candidates compete;
- comparable candidates must use one currency;
- exact `BigDecimal.compareTo` ordering, no rounding/rescaling;
- numeric-equal minima are explicit `TIE`, including differing decimal scales;
- every tied minimum is preserved in original input order;
- no retailer order/id, freshness, provider timestamp, SKU/package data or iteration order breaks a tie;
- cheaper ineligible/unknown/uncertain/incomplete/unavailable candidates never win;
- M1 package/SKU selections are immutable inputs; M4.3 does no substitution/package recomputation;
- no freshness/confidence monetary penalty is invented;
- no provider/network/API/UI/multi-store scope.

TDD/evidence:
- core RED `e6923b46...`; API CI failed exactly on missing optimizer symbols;
- production implementation `0df063bd...`;
- behavior GREEN `6ccf4296...`, API CI SUCCESS;
- invariant hardening `567261da...`;
- initial architecture proof `0c607f12...` found a real direct M4.3→comparison abstraction leak while behavior 8/8 and invariant 10/10 remained green;
- targeted identity-seam RED `06b55b1f...`, API CI failed exactly on missing M4.2 `retailerId()` projection;
- corrective chain `187b7f41...` → `d24604e7...` → `f410d175...` → `cab385ff...` removes all direct M4.3 comparison/retailer dependency; API CI SUCCESS;
- the additive M4.2 `retailerId()` projection changes no M4.2 eligibility/comparability semantics.

Design: `docs/superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md`
Plan: `docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md`
Shipping evidence: `docs/superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md`

Closes #139 after accepted merge.