### PR TITLE
docs(m4): finalize basket optimizer acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M4.2 public assessment/result records self-validate subtotal, eligibility, comparability, comparable-total and comparison identity relationships.
 - M4.2 architecture limits the new layer to accepted basket/comparison types plus finite `RetailerId`, with no provider/network/API/UI/ranking dependency.
 - M4.2 acceptance records final reviewed head `1d6dae470c04ab1d8279f891766fc16698286edb`, squash merge `69f9cb1afd1b16af938052bbca570cbd4ce52557`, issue #136 closure and 8/8 successful post-merge `main` workflows.
+- M4.3 adds a pure deterministic `basketoptimization` layer over accepted M4.2 checkout assessments; only explicit `COMPARABLE` candidates enter cheapest-basket selection while every input candidate remains inspectable in original order.
+- Optimizer outcomes are explicit `NO_COMPARABLE_CANDIDATES / UNIQUE_WINNER / TIE`; exact numeric minima are compared with `BigDecimal.compareTo` and all equal minima remain tied without hidden retailer-order, retailer-ID, freshness, timestamp, SKU/package or iteration-order tie-breaks.
+- Comparable candidates must use one currency; mixed comparable currencies fail closed, while a non-comparable candidate in another currency cannot poison a valid comparable set.
+- Accepted M1 package/basket decisions are immutable optimizer inputs; M4.3 does not search substitutes, change package counts, split across stores or fabricate freshness/confidence pricing policy.
+- `BasketOptimizationResult` recomputes deterministic evaluation from its candidates and rejects forged status/minimum sets; architecture keeps M4.3 behind the accepted M4.2 result boundary with no direct `comparison`/`retailer`, provider, API, UI or persistence coupling.
+- M4.3 acceptance records final reviewed head `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5`, squash merge `c854526c30a1b0b1b6b435ae37608da0d9501955`, issue #139 closure and 8/8 successful post-merge `main` workflows.
 
 #### Product and shopping core
 
@@ -193,7 +199,8 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 - M3 Weekly Planning / Pantry is **COMPLETE / ACCEPTED**.
 - M4.1 Basket economics foundation is **COMPLETE / ACCEPTED** after final reviewed head `a0fcd626017f93e49fc6a70c4403b68404efe6d7`, squash merge `3ccaa7b2acc1e81d7360c55872882a4252c96cae`, issue #133 closure and 8/8 successful post-merge `main` workflows.
 - M4.2 One-retailer truthful total comparison is **COMPLETE / ACCEPTED** after final reviewed head `1d6dae470c04ab1d8279f891766fc16698286edb`, squash merge `69f9cb1afd1b16af938052bbca570cbd4ce52557`, issue #136 closure and 8/8 successful post-merge `main` workflows.
-- The current deterministic target is **M4.3 Basket optimizer**; only explicit M4.2 `COMPARABLE` candidates may compete, and deterministic ordering/tie plus package/substitution/confidence/freshness policy must be defined before any cheapest/winner claim.
+- M4.3 deterministic basket optimizer is **COMPLETE / ACCEPTED** after final reviewed head `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5`, squash merge `c854526c30a1b0b1b6b435ae37608da0d9501955`, issue #139 closure and 8/8 successful post-merge `main` workflows.
+- The current deterministic target is **M4.4 Optimization UX**; browser code must project accepted server-owned economics/comparability/optimizer decisions without recomputing totals, eligibility, winner or tie semantics.
 - Recipe → ShoppingList merging is intentionally stricter than product matching: only exact normalized requirements with the same canonical unit merge; no case-folding/synonym/AI equivalence is introduced.
 - Recipe provenance remains conversion metadata rather than an optional Recipe field added to neutral `ShoppingItem`; M2.2 projects that provenance publicly as self-contained source ingredient IDs instead of modifying Shopping Core types.
 - Recipe lifecycle and Weekly Planning/Pantry composition remain stateless by default; persistence stays deferred until reusable saved plans/history demonstrate product value.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -31,8 +31,9 @@ Milestone status:
 - M3 Weekly Planning / Pantry deterministic product slice — **COMPLETE / ACCEPTED**.
 - M4.1 Basket economics foundation — **COMPLETE / ACCEPTED** (#133 / #134).
 - M4.2 One-retailer truthful total comparison — **COMPLETE / ACCEPTED** (#136 / #137).
+- M4.3 Deterministic basket optimizer — **COMPLETE / ACCEPTED** (#139 / #140).
 
-Current deterministic target: **M4.3 — Basket optimizer**.
+Current deterministic target: **M4.4 — Optimization UX**.
 
 ## Permanent connectivity rule
 
@@ -244,9 +245,37 @@ Acceptance proof:
 - issue #136 closed `completed`;
 - exact implementation merge — **8/8 normal push workflows SUCCESS**, including CodeQL Java and JavaScript/TypeScript.
 
-## Next deterministic target — M4.3 Basket optimizer
+## M4.3 — Deterministic basket optimizer — COMPLETE / ACCEPTED
 
-Define deterministic optimizer eligibility over accepted M4.2 checkout assessments. Only `COMPARABLE` candidates may compete for a winner. M4.3 must define deterministic candidate ordering and tie semantics, keep `INELIGIBLE / UNKNOWN / NOT_COMPARABLE / INCOMPLETE / UNAVAILABLE` candidates out of winner selection, and explicitly define package/substitution plus confidence/freshness policy before exposing any cheapest/winner claim. Deterministic acceptance remains supplied-evidence-only with no live retailer request.
+Acceptance: [`m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md`](m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md).  
+Accepted implementation merge: `c854526c30a1b0b1b6b435ae37608da0d9501955`.
+
+Accepted semantics:
+
+- optimizer input is a non-empty ordered set of accepted M4.2 checkout results with unique retailer identity;
+- all input candidates remain visible in original order, but input order is never a winner/tie-break rule;
+- only explicit M4.2 `COMPARABLE` candidates compete;
+- comparable candidates must use one currency; mixed comparable currencies fail closed;
+- exact `BigDecimal.compareTo` ordering adds no rounding or rescaling;
+- numeric-equal minima are explicit `TIE`, including differing decimal scales, and every tied minimum remains visible in original order;
+- no retailer order/ID, freshness, provider timestamp, package/SKU identity or arbitrary iteration order breaks a tie;
+- accepted M1 package/basket selections are immutable optimizer inputs; no substitute/package recomputation or multi-store split occurs;
+- freshness remains inspectable evidence but is not converted into a monetary penalty or fabricated confidence score;
+- public optimization result recomputes expected status/minimum set and rejects forged state;
+- M4.3 consumes retailer identity through the M4.2-owned result projection and has no direct `comparison` / `retailer` dependency;
+- no provider acquisition, HTTP/OpenAPI/UI, persistence or live retailer request is introduced.
+
+Acceptance proof:
+
+- final reviewed feature head `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5` — **9/9 PR workflow groups SUCCESS**, 0 failure/skipped/cancelled;
+- read-only review **Looks good**, no P0/P1/P2/P3/nitpicks and no unresolved threads;
+- squash merge `c854526c30a1b0b1b6b435ae37608da0d9501955` with expected-head protection;
+- issue #139 closed `completed`;
+- exact implementation merge — **8/8 normal push workflows SUCCESS**.
+
+## Next deterministic target — M4.4 Optimization UX
+
+Project accepted M4.1–M4.3 evidence into responsive browser flows. The browser must render server-owned merchandise subtotal, known/unknown fees, minimum-order state, eligibility/comparability and `NO_COMPARABLE_CANDIDATES / UNIQUE_WINNER / TIE` outcomes without recomputing economics or choosing a winner client-side. Browser acceptance remains deterministic and must make no live retailer requests.
 
 ## Magnit production state
 
@@ -296,7 +325,10 @@ Continue without blocking deterministic M4 work unless evidence invalidates acce
 22. Merchandise subtotal, checkout-total knowledge, checkout eligibility and optimizer comparability are separate facts; one must never be silently substituted for another.
 23. Retailer checkout economics must be bound to the same `RetailerId` as the retailer comparison before arithmetic; cross-retailer economics evidence fails closed.
 24. A known arithmetic checkout total does not imply an eligible or comparable candidate.
-25. Future winner selection may consider only explicit M4.2 `COMPARABLE` candidates; uncertain, ineligible, incomplete or unavailable evidence cannot become a hidden winner.
+25. Only explicit M4.2 `COMPARABLE` candidates may participate in M4.3 cheapest-basket selection; all other candidate states remain inspectable but cannot win.
+26. Exact numeric minimum ties remain explicit ties; retailer order/ID, freshness, timestamps and package/SKU metadata never select a hidden winner.
+27. M4.3 never recomputes accepted package/SKU selections or converts freshness into a monetary penalty/confidence score.
+28. Browser optimization UX must render server-owned economics and optimizer decisions rather than recomputing them client-side.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,7 +75,7 @@ Accepted merge: `1201030aed45075c676f796920b6268cdcf8e036`.
 
 Weekly Planning is the primary browser journey. It supports `1..35` ordered occurrences, day/serving/Recipe editing, canonical weekly-shopping rendering before comparison, fail-closed transport and deterministic desktop/mobile/accessibility Playwright. Browser acceptance makes no live retailer request.
 
-### M3.5 — Pantry / exclusions semantics — IN PROGRESS
+### M3.5 — Pantry / exclusions semantics — COMPLETE / ACCEPTED
 
 Goal: subtract explicitly known-at-home requirements from accepted weekly shopping demand with inspectable evidence and without hidden ingredient loss, then compose the remaining demand into retailer comparison and responsive controls.
 
@@ -206,7 +206,7 @@ Continue without blocking deterministic M4 work unless evidence invalidates acce
 
 Goal: optimize real checkout cost rather than naive SKU sums while preserving truthful eligibility, completeness, uncertainty, retailer visibility and production-access semantics.
 
-Scope: explicit checkout economics, one-retailer truthful totals, richer package/substitute optimization, single-store convenience, future multi-store lowest-total-cost mode and confidence/freshness penalties.
+Scope: explicit checkout economics, one-retailer truthful totals, deterministic cheapest-candidate selection, responsive optimization UX, richer future package/substitute optimization, future multi-store lowest-total-cost mode and any future confidence/freshness policy only after separate explicit design.
 
 ### M4.1 — Basket economics foundation — COMPLETE / ACCEPTED
 
@@ -247,13 +247,39 @@ Acceptance proof:
 - issue #136 closed `completed`;
 - exact merge — **8/8 normal push workflows SUCCESS**.
 
-### M4.3 — Basket optimizer — NEXT
+### M4.3 — Deterministic basket optimizer — COMPLETE / ACCEPTED
 
-Define deterministic optimizer behavior over accepted M4.2 assessments. Only `COMPARABLE` candidates may compete. Specify candidate ordering, exact tie semantics, package/substitution policy and confidence/freshness handling before producing a winner. `INELIGIBLE / UNKNOWN / NOT_COMPARABLE / INCOMPLETE / UNAVAILABLE` candidates must remain visible but cannot become a hidden winner. Deterministic acceptance uses supplied/sanitized evidence only and makes no live retailer requests.
+Authoritative design: [`superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md`](superpowers/specs/2026-08-15-m4-3-deterministic-basket-optimizer-design.md)  
+Implementation plan: [`superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md`](superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer.md)  
+Shipping evidence: [`superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md`](superpowers/plans/2026-08-15-m4-3-deterministic-basket-optimizer-shipping.md)  
+Acceptance: [`m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md`](m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md)  
+Accepted implementation merge: `c854526c30a1b0b1b6b435ae37608da0d9501955`.
 
-### M4.4 — Optimization UX
+Accepted result:
 
-Project accepted optimizer evidence into responsive browser flows with explainable subtotal/fees/minimum-order/eligibility/total states. Browser code must render server-owned decisions rather than recomputing economics or winners.
+- ordered non-empty M4.2 candidate input with unique retailer identity and defensive-copy semantics;
+- only M4.2 `COMPARABLE` candidates compete, while all candidates remain inspectable in original order;
+- explicit `NO_COMPARABLE_CANDIDATES / UNIQUE_WINNER / TIE` outcomes;
+- mixed currencies among comparable candidates fail closed;
+- exact `BigDecimal.compareTo` selection with no rounding/rescaling;
+- every exact minimum remains in an explicit tie; input/canonical retailer order, retailer ID, freshness, provider timestamps and package/SKU metadata never break the tie;
+- accepted M1 package/basket choices are never recomputed and no substitute or multi-store optimization occurs;
+- freshness is not converted into a hidden monetary penalty or fabricated confidence score;
+- public optimization results self-validate against the deterministic rules;
+- M4.3 consumes retailer identity through the accepted M4.2 result boundary and has no direct `comparison` / `retailer` dependency;
+- deterministic acceptance remains supplied-evidence-only and makes no live retailer request.
+
+Acceptance proof:
+
+- final reviewed head `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5` — **9/9 PR workflows SUCCESS**;
+- clean read-only review, no P0/P1/P2/P3/nitpicks and no unresolved threads;
+- squash merge `c854526c30a1b0b1b6b435ae37608da0d9501955` with expected-head protection;
+- issue #139 closed `completed`;
+- exact merge — **8/8 normal push workflows SUCCESS**.
+
+### M4.4 — Optimization UX — NEXT
+
+Project accepted M4.1–M4.3 evidence into responsive browser flows with explainable merchandise subtotal, known/unknown fees, minimum-order state, eligibility/comparability and optimizer outcome. Browser code must consume server-owned decisions through generated contracts rather than recomputing economics, comparability or winner/tie semantics. `NO_COMPARABLE_CANDIDATES`, `UNIQUE_WINNER` and `TIE` must remain distinct and user-explainable. Deterministic browser acceptance must not make live retailer requests.
 
 ## M5 — Productization
 

--- a/docs/m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md
+++ b/docs/m4-3-deterministic-basket-optimizer-acceptance-2026-08-15.md
@@ -1,0 +1,88 @@
+# M4.3 Deterministic Basket Optimizer — Acceptance
+
+**Date:** 2026-08-15  
+**Issue:** #139  
+**Implementation PR:** #140  
+**Baseline:** `b32c461eb49eefa5ab37f23d45491e9f46356c10`  
+**Final reviewed feature head:** `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5`  
+**Accepted implementation merge:** `c854526c30a1b0b1b6b435ae37608da0d9501955`
+
+## Decision
+
+M4.3 is **COMPLETE / ACCEPTED**.
+
+The project now has a pure deterministic selection layer over accepted M4.2 retailer checkout assessments. It can truthfully expose no comparable candidates, one unique cheapest comparable retailer, or an exact monetary tie without recomputing accepted baskets or inventing hidden confidence/freshness policy.
+
+## Accepted semantics
+
+- input is an ordered, non-empty set of M4.2 `RetailerCheckoutAssessmentResult` values with unique retailer identities;
+- all original candidates remain visible in their original order for inspectability;
+- only M4.2 `COMPARABLE` candidates compete for the optimum;
+- `INELIGIBLE`, eligibility `UNKNOWN`, `NOT_COMPARABLE`, upstream `UNCERTAIN`, `INCOMPLETE` and `UNAVAILABLE` candidates never become hidden winners;
+- comparable candidates in one optimization must use one currency; mixed comparable currencies fail closed;
+- monetary ordering uses exact `BigDecimal.compareTo` semantics with no rounding or rescaling;
+- numerically equal minima remain an explicit `TIE`, including amounts that differ only in decimal scale;
+- every tied minimum is retained in original input order; no retailer-order, retailer-ID, freshness, provider timestamp, package/SKU or iteration-order tie-break exists;
+- accepted M1 matching/package/basket selections are immutable inputs; M4.3 performs no substitute search, package-count recomputation or multi-store split;
+- freshness remains inspectable upstream evidence and is not converted into a monetary penalty or confidence score;
+- result objects recompute the deterministic evaluation and reject forged status/optimal-candidate sets;
+- M4.3 has no provider acquisition, HTTP/OpenAPI/UI, persistence or live-retailer behavior.
+
+## Architecture acceptance
+
+The accepted `basketoptimization` package consumes M4.2 checkout results plus neutral `BasketTotal` only. Retailer identity is projected by the M4.2-owned `RetailerCheckoutAssessmentResult.retailerId()` boundary, so M4.3 has no direct dependency on `comparison` or `retailer` internals.
+
+The additive M4.2 identity projection does not change M4.2 eligibility, comparability or checkout-total semantics.
+
+Reverse dependencies from accepted basket/comparison/retailer/retailercheckout layers into `basketoptimization` remain forbidden.
+
+## TDD and hardening evidence
+
+Core behavior:
+
+- RED: `e6923b46…` — API CI failed at test compilation on missing `BasketOptimizer` / `BasketOptimizationStatus` symbols;
+- initial production implementation: `0df063bd…`;
+- compile-only correction: `6ccf4296…` candidate reached full GREEN;
+- behavior GREEN: full API verification SUCCESS.
+
+Invariant / architecture hardening:
+
+- invariant suite: `567261da…`;
+- initial architecture proof: `0c607f12…` exposed a real direct M4.3 → `comparison` abstraction leak while behavior and result invariants remained green;
+- targeted identity-seam RED: `06b55b1f…` failed only because M4.2 did not yet expose `retailerId()`;
+- corrective chain `187b7f41…` → `d24604e7…` → `f410d175…` → `cab385ff…` introduced the M4.2-owned identity projection and removed direct M4.3 `comparison` / `retailer` dependencies;
+- exact corrective API gate on `cab385ff…` — SUCCESS;
+- design/plan/shipping evidence synchronized before final freeze.
+
+## Final implementation gate
+
+Exact final feature head `ddc5fed0d3bb98d9c17e5f1ec739ffad9ba77ad5`:
+
+- exactly **9 normal PR workflow groups**;
+- **9/9 SUCCESS**;
+- 0 failure / skipped / cancelled;
+- read-only review: **Looks good**;
+- no P0/P1/P2/P3 findings or nitpicks;
+- unresolved review threads: **0**;
+- mergeable: true;
+- squash merged with expected-head protection.
+
+## Post-merge acceptance gate
+
+Exact implementation merge `c854526c30a1b0b1b6b435ae37608da0d9501955`:
+
+- `main` points to the merge SHA;
+- issue #139 is closed with state reason `completed`;
+- exactly **8 normal push workflows**;
+- **8/8 SUCCESS**;
+- no failed post-merge workflow.
+
+Therefore M4.3 status is:
+
+**implemented → tested → reviewed → merged → accepted**
+
+## Next deterministic target
+
+**M4.4 — Optimization UX**.
+
+The browser should project server-owned optimizer/economics evidence into the primary shopping flow without recomputing eligibility, checkout totals or winner/tie decisions client-side. The UX must keep no-comparable, unique-winner and tie states explicit and explain subtotal/fees/minimum-order/eligibility/comparability truthfully.


### PR DESCRIPTION
Documents accepted M4.3 after implementation PR #140 merged as `c854526c30a1b0b1b6b435ae37608da0d9501955` and the exact merge passed 8/8 normal push workflows.

Docs-only scope:
- add M4.3 acceptance record;
- mark M4.3 COMPLETE / ACCEPTED in PROJECT_STATE and ROADMAP;
- record accepted deterministic optimizer semantics in CHANGELOG;
- advance the current deterministic target to M4.4 Optimization UX;
- correct the stale M3.5 roadmap status to COMPLETE / ACCEPTED.

No runtime/API/Web/OpenAPI behavior changes.