### PR TITLE
feat(bridge): refresh persistent sessions across SPA and store changes

### DIFF
--- a/apps/retailer-bridge/e2e/in-flight-navigation.spec.ts
+++ b/apps/retailer-bridge/e2e/in-flight-navigation.spec.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test, type Page, type Worker } from "@playwright/test";
+
+const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
+const extensionPath = resolve(bridgeRoot, "dist-e2e");
+const fixtureDir = resolve(bridgeRoot, "test/fixtures");
+const observationsKey = "zg.latestObservations";
+const delayNextStoreKey = "zg.e2e.delayNextObservationStore";
+const storePendingKey = "zg.e2e.observationStorePending";
+const releaseStoreKey = "zg.e2e.releaseObservationStore";
+
+async function storedObservations(worker: Worker): Promise<unknown[]> {
+  return worker.evaluate(async (key) => {
+    const current = await chrome.storage.local.get(key);
+    return current[key] ?? [];
+  }, observationsKey);
+}
+
+async function replaceCatalogProduct(
+  page: Page,
+  sku: string,
+  name: string,
+  price: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ productSku, productName, productPrice }) => {
+      const catalog = document.querySelector(".catalog-content");
+      if (!catalog) throw new Error("catalog fixture is missing");
+      catalog.innerHTML = `<article class="product-card">
+        <a class="product-card__link" href="/cat/1768/p/sanitized-product-${productSku}"></a>
+        <div class="product-card__content">
+          <div class="product-card__title-wrapper">
+            <div class="product-card__title">
+              <a class="product-card__title-link" href="/cat/1768/p/sanitized-product-${productSku}">${productName}</a>
+            </div>
+          </div>
+          <div class="product-card__pricing">
+            <div class="product-card__price"><span class="price-new">${productPrice} ₽</span></div>
+          </div>
+        </div>
+      </article>`;
+    },
+    { productSku: sku, productName: name, productPrice: price },
+  );
+}
+
+test("does not republish an obsolete collection after a newer SPA boundary", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-inflight-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  try {
+    const liveFixture = await readFile(
+      resolve(fixtureDir, "perekrestok-live-dom-async-state.html"),
+      "utf8",
+    );
+
+    await context.route("https://www.perekrestok.ru/**", async (route) => {
+      const pathname = new URL(route.request().url()).pathname;
+      if (/^\/api\/customer\/1\.4\.1\.0\/shop\/(656|777)$/.test(pathname)) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json; charset=utf-8",
+          body: "{}",
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: liveFixture,
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://www.perekrestok.ru/cat/fixture-live-dom");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
+
+    await worker.evaluate(
+      async ({ delayKey, pendingKey, releaseKey }) => {
+        await chrome.storage.local.remove([pendingKey, releaseKey]);
+        await chrome.storage.local.set({ [delayKey]: true });
+      },
+      { delayKey: delayNextStoreKey, pendingKey: storePendingKey, releaseKey: releaseStoreKey },
+    );
+
+    await page.evaluate(async () => {
+      history.pushState({}, "", "/cat/inflight-old-route");
+      document.querySelector(".catalog-content")?.replaceChildren();
+      await fetch("/api/customer/1.4.1.0/shop/656?session=SECRET_OLD_COLLECTION#fragment");
+    });
+    await expect.poll(() => storedObservations(worker)).toEqual([]);
+
+    await replaceCatalogProduct(page, "9912345", "Устаревший in-flight продукт", "619,90");
+    await expect.poll(() =>
+      worker.evaluate(async (key) => {
+        const state = await chrome.storage.local.get(key);
+        return state[key] === true;
+      }, storePendingKey),
+    ).toBe(true);
+
+    await page.evaluate(() => {
+      history.pushState({}, "", "/cat/inflight-latest-route");
+      document.querySelector(".catalog-content")?.replaceChildren();
+    });
+    await replaceCatalogProduct(page, "9923456", "Актуальный in-flight продукт", "729,90");
+
+    await worker.evaluate(async (key) => {
+      await chrome.storage.local.set({ [key]: true });
+    }, releaseStoreKey);
+    await expect.poll(() =>
+      worker.evaluate(async (key) => {
+        const state = await chrome.storage.local.get(key);
+        return state[key] === true;
+      }, storePendingKey),
+    ).toBe(false);
+
+    // The collection that started for the previous route must never become current
+    // after the newer SPA lifecycle boundary has already invalidated it.
+    expect(await storedObservations(worker)).toEqual([]);
+    expect(await page.locator("html").getAttribute("data-zg-bridge-status")).toBe("refreshing");
+
+    await page.evaluate(async () => {
+      await fetch("/api/customer/1.4.1.0/shop/777?session=SECRET_LATEST_COLLECTION#fragment");
+    });
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    await expect.poll(() => storedObservations(worker)).toHaveLength(1);
+
+    const serialized = JSON.stringify(await storedObservations(worker));
+    expect(serialized).toContain('"fulfillmentContextId":"777"');
+    expect(serialized).toContain('"sku":"9923456"');
+    expect(serialized).toContain('"priceMinor":72990');
+    expect(serialized).toContain('"sourceReference":"https://www.perekrestok.ru/cat/inflight-latest-route"');
+    expect(serialized).not.toContain('"sku":"9912345"');
+    expect(serialized).not.toContain("SECRET_OLD_COLLECTION");
+    expect(serialized).not.toContain("SECRET_LATEST_COLLECTION");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/e2e/persistent-session.spec.ts
+++ b/apps/retailer-bridge/e2e/persistent-session.spec.ts
@@ -104,8 +104,7 @@ test("refreshes observations after same-document SPA catalog navigation", async 
     await insertProduct(page, "5512345", "Новый SPA продукт", "249,50");
 
     await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
-    const refreshed = JSON.stringify(await expect.poll(() => storedObservations(worker)).toHaveLength(1));
-    void refreshed;
+    await expect.poll(() => storedObservations(worker)).toHaveLength(1);
 
     const serialized = JSON.stringify(await storedObservations(worker));
     expect(serialized).toContain('"fulfillmentContextId":"656"');

--- a/apps/retailer-bridge/e2e/persistent-session.spec.ts
+++ b/apps/retailer-bridge/e2e/persistent-session.spec.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test, type BrowserContext, type Page, type Worker } from "@playwright/test";
+
+const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
+const extensionPath = resolve(bridgeRoot, "dist");
+const fixtureDir = resolve(bridgeRoot, "test/fixtures");
+
+async function openPerekrestokFixture(): Promise<{
+  context: BrowserContext;
+  page: Page;
+  worker: Worker;
+  userDataDir: string;
+}> {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-persistent-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  const liveFixture = await readFile(
+    resolve(fixtureDir, "perekrestok-live-dom-async-state.html"),
+    "utf8",
+  );
+
+  await context.route("https://www.perekrestok.ru/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (/^\/api\/customer\/1\.4\.1\.0\/shop\/(656|777)$/.test(pathname)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json; charset=utf-8",
+        body: "{}",
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: liveFixture,
+    });
+  });
+
+  const page = await context.newPage();
+  await page.goto("https://www.perekrestok.ru/cat/fixture-live-dom");
+  await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+  await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("1");
+
+  const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+  return { context, page, worker, userDataDir };
+}
+
+async function storedObservations(worker: Worker): Promise<unknown[]> {
+  return worker.evaluate(async () => {
+    const current = await chrome.storage.local.get("zg.latestObservations");
+    return current["zg.latestObservations"] ?? [];
+  });
+}
+
+async function insertProduct(page: Page, sku: string, name: string, price: string): Promise<void> {
+  await page.evaluate(
+    ({ productSku, productName, productPrice }) => {
+      const catalog = document.querySelector(".catalog-content");
+      if (!catalog) throw new Error("catalog fixture is missing");
+      catalog.insertAdjacentHTML(
+        "beforeend",
+        `<article class="product-card">
+          <a class="product-card__link" href="/cat/1768/p/sanitized-product-${productSku}"></a>
+          <div class="product-card__content">
+            <div class="product-card__title-wrapper">
+              <div class="product-card__title">
+                <a class="product-card__title-link" href="/cat/1768/p/sanitized-product-${productSku}">${productName}</a>
+              </div>
+            </div>
+            <div class="product-card__pricing">
+              <div class="product-card__price"><span class="price-new">${productPrice} ₽</span></div>
+            </div>
+          </div>
+        </article>`,
+      );
+    },
+    { productSku: sku, productName: name, productPrice: price },
+  );
+}
+
+test("refreshes observations after same-document SPA catalog navigation", async () => {
+  const { context, page, worker, userDataDir } = await openPerekrestokFixture();
+
+  try {
+    expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
+
+    await page.evaluate(() => {
+      history.pushState({}, "", "/cat/fixture-spa-second");
+      document.querySelector(".catalog-content")?.replaceChildren();
+    });
+
+    await expect.poll(() => storedObservations(worker)).toEqual([]);
+
+    await insertProduct(page, "5512345", "Новый SPA продукт", "249,50");
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    const refreshed = JSON.stringify(await expect.poll(() => storedObservations(worker)).toHaveLength(1));
+    void refreshed;
+
+    const serialized = JSON.stringify(await storedObservations(worker));
+    expect(serialized).toContain('"fulfillmentContextId":"656"');
+    expect(serialized).toContain('"sku":"5512345"');
+    expect(serialized).toContain('"priceMinor":24950');
+    expect(serialized).toContain('"sourceReference":"https://www.perekrestok.ru/cat/fixture-spa-second"');
+    expect(serialized).not.toContain('"sku":"4408829"');
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("invalidates old store observations before recollecting a new fulfillment context", async () => {
+  const { context, page, worker, userDataDir } = await openPerekrestokFixture();
+
+  try {
+    expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
+
+    await page.evaluate(async () => {
+      document.querySelector(".catalog-content")?.replaceChildren();
+      await fetch("/api/customer/1.4.1.0/shop/777?session=SECRET_SECOND_CONTEXT#fragment");
+    });
+
+    await expect.poll(() => storedObservations(worker)).toEqual([]);
+
+    await insertProduct(page, "6612345", "Продукт нового магазина", "349,90");
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    await expect.poll(() => storedObservations(worker)).toHaveLength(1);
+
+    const serialized = JSON.stringify(await storedObservations(worker));
+    expect(serialized).toContain('"fulfillmentContextId":"777"');
+    expect(serialized).toContain('"sku":"6612345"');
+    expect(serialized).toContain('"priceMinor":34990');
+    expect(serialized).not.toContain('"fulfillmentContextId":"656"');
+    expect(serialized).not.toContain('"sku":"4408829"');
+    expect(serialized).not.toContain("SECRET_SECOND_CONTEXT");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/e2e/persistent-session.spec.ts
+++ b/apps/retailer-bridge/e2e/persistent-session.spec.ts
@@ -94,9 +94,10 @@ test("refreshes observations after same-document SPA catalog navigation", async 
   try {
     expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
 
-    await page.evaluate(() => {
+    await page.evaluate(async () => {
       history.pushState({}, "", "/cat/fixture-spa-second");
       document.querySelector(".catalog-content")?.replaceChildren();
+      await fetch("/api/customer/1.4.1.0/shop/656?session=SECRET_SAME_CONTEXT#fragment");
     });
 
     await expect.poll(() => storedObservations(worker)).toEqual([]);
@@ -112,6 +113,7 @@ test("refreshes observations after same-document SPA catalog navigation", async 
     expect(serialized).toContain('"priceMinor":24950');
     expect(serialized).toContain('"sourceReference":"https://www.perekrestok.ru/cat/fixture-spa-second"');
     expect(serialized).not.toContain('"sku":"4408829"');
+    expect(serialized).not.toContain("SECRET_SAME_CONTEXT");
   } finally {
     await context.close();
     await rm(userDataDir, { recursive: true, force: true });

--- a/apps/retailer-bridge/e2e/persistent-session.spec.ts
+++ b/apps/retailer-bridge/e2e/persistent-session.spec.ts
@@ -148,3 +148,34 @@ test("invalidates old store observations before recollecting a new fulfillment c
     await rm(userDataDir, { recursive: true, force: true });
   }
 });
+
+test("keeps only the new context when SPA navigation and store change overlap", async () => {
+  const { context, page, worker, userDataDir } = await openPerekrestokFixture();
+
+  try {
+    expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
+
+    await page.evaluate(async () => {
+      history.pushState({}, "", "/cat/fixture-spa-new-store");
+      document.querySelector(".catalog-content")?.replaceChildren();
+      await fetch("/api/customer/1.4.1.0/shop/777?session=SECRET_COMBINED_CONTEXT#fragment");
+    });
+
+    await expect.poll(() => storedObservations(worker)).toEqual([]);
+    await insertProduct(page, "7712345", "SPA продукт нового магазина", "459,90");
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    await expect.poll(() => storedObservations(worker)).toHaveLength(1);
+
+    const serialized = JSON.stringify(await storedObservations(worker));
+    expect(serialized).toContain('"fulfillmentContextId":"777"');
+    expect(serialized).toContain('"sku":"7712345"');
+    expect(serialized).toContain('"sourceReference":"https://www.perekrestok.ru/cat/fixture-spa-new-store"');
+    expect(serialized).not.toContain('"fulfillmentContextId":"656"');
+    expect(serialized).not.toContain('"sku":"4408829"');
+    expect(serialized).not.toContain("SECRET_COMBINED_CONTEXT");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/e2e/rapid-navigation.spec.ts
+++ b/apps/retailer-bridge/e2e/rapid-navigation.spec.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test, type Worker } from "@playwright/test";
+
+const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
+const extensionPath = resolve(bridgeRoot, "dist");
+const fixtureDir = resolve(bridgeRoot, "test/fixtures");
+
+async function storedObservations(worker: Worker): Promise<unknown[]> {
+  return worker.evaluate(async () => {
+    const current = await chrome.storage.local.get("zg.latestObservations");
+    return current["zg.latestObservations"] ?? [];
+  });
+}
+
+test("ignores a fulfillment response that started before the latest SPA boundary", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-rapid-navigation-"));
+  let releaseDelayedShopResponse: () => void = () => undefined;
+  const delayedShopResponse = new Promise<void>((resolve) => {
+    releaseDelayedShopResponse = resolve;
+  });
+
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  try {
+    const liveFixture = await readFile(
+      resolve(fixtureDir, "perekrestok-live-dom-async-state.html"),
+      "utf8",
+    );
+
+    await context.route("https://www.perekrestok.ru/**", async (route) => {
+      const url = new URL(route.request().url());
+      if (/^\/api\/customer\/1\.4\.1\.0\/shop\/(656|777)$/.test(url.pathname)) {
+        if (url.searchParams.get("delayed") === "true") {
+          await delayedShopResponse;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json; charset=utf-8",
+          body: "{}",
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: liveFixture,
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://www.perekrestok.ru/cat/fixture-live-dom");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    expect(JSON.stringify(await storedObservations(worker))).toContain('"fulfillmentContextId":"656"');
+
+    await page.evaluate(() => {
+      history.pushState({}, "", "/cat/fixture-first-transition");
+      void fetch(
+        "/api/customer/1.4.1.0/shop/656?delayed=true&session=SECRET_OLD_ROUTE#fragment",
+      ).then(() => {
+        document.documentElement.dataset.zgDelayedShopDone = "true";
+      });
+    });
+
+    await expect.poll(() => storedObservations(worker)).toEqual([]);
+
+    await page.evaluate(() => {
+      history.pushState({}, "", "/cat/fixture-latest-transition");
+      const catalog = document.querySelector(".catalog-content");
+      if (!catalog) throw new Error("catalog fixture is missing");
+      catalog.innerHTML = `<article class="product-card">
+        <a class="product-card__link" href="/cat/1768/p/sanitized-product-8812345"></a>
+        <div class="product-card__content">
+          <div class="product-card__title-wrapper">
+            <div class="product-card__title">
+              <a class="product-card__title-link" href="/cat/1768/p/sanitized-product-8812345">Продукт последнего SPA route</a>
+            </div>
+          </div>
+          <div class="product-card__pricing">
+            <div class="product-card__price"><span class="price-new">569,90 ₽</span></div>
+          </div>
+        </div>
+      </article>`;
+    });
+
+    releaseDelayedShopResponse();
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-delayed-shop-done")).toBe("true");
+    await page.waitForTimeout(300);
+
+    expect(await storedObservations(worker)).toEqual([]);
+    expect(await page.locator("html").getAttribute("data-zg-bridge-status")).toBe("refreshing");
+
+    await page.evaluate(async () => {
+      await fetch("/api/customer/1.4.1.0/shop/777?session=SECRET_FRESH_ROUTE#fragment");
+    });
+
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-status")).toBe("ok");
+    await expect.poll(() => storedObservations(worker)).toHaveLength(1);
+
+    const serialized = JSON.stringify(await storedObservations(worker));
+    expect(serialized).toContain('"fulfillmentContextId":"777"');
+    expect(serialized).toContain('"sku":"8812345"');
+    expect(serialized).toContain('"priceMinor":56990');
+    expect(serialized).toContain('"sourceReference":"https://www.perekrestok.ru/cat/fixture-latest-transition"');
+    expect(serialized).not.toContain('"fulfillmentContextId":"656"');
+    expect(serialized).not.toContain("SECRET_OLD_ROUTE");
+    expect(serialized).not.toContain("SECRET_FRESH_ROUTE");
+  } finally {
+    releaseDelayedShopResponse();
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/package.json
+++ b/apps/retailer-bridge/package.json
@@ -8,7 +8,7 @@
     "build:e2e": "node scripts/build.mjs --e2e",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "vitest run --config vitest.config.mjs",
-    "test:e2e": "playwright test --config playwright.config.ts"
+    "test:e2e": "pnpm build && pnpm build:e2e && playwright test --config playwright.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",

--- a/apps/retailer-bridge/scripts/build.mjs
+++ b/apps/retailer-bridge/scripts/build.mjs
@@ -109,4 +109,7 @@ await copyFile(
   resolve(root, e2e ? "static/manifest.e2e.json" : "static/manifest.json"),
   resolve(outDir, "manifest.json"),
 );
-await copyFile(resolve(root, "static/service-worker.js"), resolve(outDir, "service-worker.js"));
+await copyFile(
+  resolve(root, e2e ? "static/service-worker.e2e.js" : "static/service-worker.js"),
+  resolve(outDir, "service-worker.js"),
+);

--- a/apps/retailer-bridge/src/collector/chrome-observation-sink.ts
+++ b/apps/retailer-bridge/src/collector/chrome-observation-sink.ts
@@ -1,14 +1,22 @@
 import type { BrowserObservation } from "../model/browser-observation";
-import type { ObservationSink } from "./browser-observation-collector";
 
 export type RuntimeSendMessage = (message: unknown) => Promise<unknown> | unknown;
+export type ObservationRevision = number;
+
+function requireRevision(revision: ObservationRevision): void {
+  if (!Number.isSafeInteger(revision) || revision <= 0) {
+    throw new Error("observation revision must be a positive safe integer");
+  }
+}
 
 export function createChromeObservationSink(
   sendMessage: RuntimeSendMessage,
-): ObservationSink {
-  return async (observations: BrowserObservation[]) => {
+): (observations: BrowserObservation[], revision: ObservationRevision) => Promise<void> {
+  return async (observations: BrowserObservation[], revision: ObservationRevision) => {
+    requireRevision(revision);
     await sendMessage({
       type: "ZG_STORE_OBSERVATIONS",
+      revision,
       observations,
     });
   };
@@ -16,10 +24,12 @@ export function createChromeObservationSink(
 
 export function createChromeObservationClearer(
   sendMessage: RuntimeSendMessage,
-): () => Promise<void> {
-  return async () => {
+): (revision: ObservationRevision) => Promise<void> {
+  return async (revision: ObservationRevision) => {
+    requireRevision(revision);
     await sendMessage({
       type: "ZG_STORE_OBSERVATIONS",
+      revision,
       observations: [],
     });
   };

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -224,7 +224,7 @@ function requestCollection(): void {
 }
 
 function handleSameDocumentNavigation(event: Event): void {
-  if (!collectionSucceeded) return;
+  if (!collectionSucceeded && !awaitingFreshContext && !refreshInFlight) return;
 
   const navigationEvent = event as Event & {
     destination?: { readonly sameDocument?: boolean; readonly url?: string };

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -84,6 +84,10 @@ function rememberAllowedResource(rawUrl: string): ResourceMemoryResult {
   if (!canonical) return { changed: false, contextChanged: false };
 
   const context = fulfillmentContextResource(rawUrl, pageUrl);
+  if (currentFulfillmentContextKey && !context) {
+    return { changed: false, contextChanged: false };
+  }
+
   if (
     collectionSucceeded &&
     currentFulfillmentContextKey &&
@@ -118,6 +122,18 @@ function rememberResourceEntries(entries: readonly PerformanceEntry[]): Resource
   return { changed, contextChanged };
 }
 
+function retainCurrentFulfillmentResource(pageUrl: URL): void {
+  const currentContext = currentFulfillmentContextKey;
+  const retained = currentContext
+    ? [...observedResourceUrls].filter(
+        (url) => fulfillmentContextResource(url, pageUrl)?.contextKey === currentContext,
+      )
+    : [];
+
+  observedResourceUrls.clear();
+  retained.forEach((url) => observedResourceUrls.add(url));
+}
+
 async function collectCurrentPage(): Promise<void> {
   if (collectionSucceeded) return;
   if (refreshInFlight) {
@@ -140,6 +156,7 @@ async function collectCurrentPage(): Promise<void> {
 
     if (result.status === "ok") {
       collectionSucceeded = true;
+      retainCurrentFulfillmentResource(new URL(location.href));
       domObserver?.disconnect();
     } else {
       await clearObservations();
@@ -164,18 +181,6 @@ function requestCollection(): void {
     return;
   }
   void collectCurrentPage();
-}
-
-function retainCurrentFulfillmentResource(pageUrl: URL): void {
-  const currentContext = currentFulfillmentContextKey;
-  const retained = currentContext
-    ? [...observedResourceUrls].filter(
-        (url) => fulfillmentContextResource(url, pageUrl)?.contextKey === currentContext,
-      )
-    : [];
-
-  observedResourceUrls.clear();
-  retained.forEach((url) => observedResourceUrls.add(url));
 }
 
 function handleSameDocumentNavigation(event: Event): void {

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -14,10 +14,11 @@ const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
 const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const observedResourceUrls = new Set<string>();
-const fulfillmentContextSignalStartTimes = new Map<string, number>();
 
 let currentFulfillmentContextKey: string | null = null;
-let currentFulfillmentContextSignalStartTime = Number.NEGATIVE_INFINITY;
+let contextSignalFloorStartTime = Number.NEGATIVE_INFINITY;
+let awaitingFreshContext = false;
+
 const sink = async (observations: BrowserObservation[]): Promise<void> => {
   await storeObservations(observations);
 
@@ -27,15 +28,8 @@ const sink = async (observations: BrowserObservation[]): Promise<void> => {
     ),
   );
   currentFulfillmentContextKey = contexts.size === 1 ? [...contexts][0] : null;
-  currentFulfillmentContextSignalStartTime = currentFulfillmentContextKey
-    ? (fulfillmentContextSignalStartTimes.get(currentFulfillmentContextKey) ?? Number.NEGATIVE_INFINITY)
-    : Number.NEGATIVE_INFINITY;
-
-  if (currentFulfillmentContextKey) {
-    const retainedSignalTime = currentFulfillmentContextSignalStartTime;
-    fulfillmentContextSignalStartTimes.clear();
-    fulfillmentContextSignalStartTimes.set(currentFulfillmentContextKey, retainedSignalTime);
-  }
+  contextSignalFloorStartTime = performance.now();
+  awaitingFreshContext = false;
 };
 const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
 
@@ -63,15 +57,23 @@ function finishRefresh(reset: Promise<void>): void {
   if (refreshInFlight !== reset) return;
   refreshInFlight = null;
 
-  if (collectionPending && !collectionSucceeded) {
+  if (collectionPending && !collectionSucceeded && !awaitingFreshContext) {
     collectionPending = false;
     void collectCurrentPage();
   }
 }
 
-function startLifecycleRefresh(): void {
+function startLifecycleRefresh(options: {
+  awaitFreshContext: boolean;
+  collectAfterReset: boolean;
+  signalFloorStartTime?: number;
+}): void {
   collectionSucceeded = false;
-  collectionPending = false;
+  collectionPending = options.collectAfterReset;
+  awaitingFreshContext = options.awaitFreshContext;
+  if (options.signalFloorStartTime !== undefined) {
+    contextSignalFloorStartTime = options.signalFloorStartTime;
+  }
   observeDomChanges();
   publishDiagnostics("refreshing", 0);
 
@@ -99,36 +101,34 @@ function rememberAllowedResource(rawUrl: string, startTime: number): ResourceMem
     return { changed: false, contextChanged: false };
   }
 
-  if (context) {
-    const previousSignalTime = fulfillmentContextSignalStartTimes.get(context.contextKey);
-    if (previousSignalTime === undefined || startTime > previousSignalTime) {
-      fulfillmentContextSignalStartTimes.set(context.contextKey, startTime);
-    }
+  if (context && startTime < contextSignalFloorStartTime) {
+    return { changed: false, contextChanged: false };
+  }
 
-    if (
-      currentFulfillmentContextKey &&
-      context.contextKey !== currentFulfillmentContextKey
-    ) {
-      if (startTime <= currentFulfillmentContextSignalStartTime) {
-        return { changed: false, contextChanged: false };
-      }
+  if (context && awaitingFreshContext) {
+    observedResourceUrls.clear();
+    observedResourceUrls.add(context.canonicalUrl);
+    currentFulfillmentContextKey = context.contextKey;
+    contextSignalFloorStartTime = startTime;
+    awaitingFreshContext = false;
+    collectionPending = true;
+    return { changed: true, contextChanged: false };
+  }
 
-      observedResourceUrls.clear();
-      observedResourceUrls.add(context.canonicalUrl);
-      currentFulfillmentContextKey = context.contextKey;
-      currentFulfillmentContextSignalStartTime = startTime;
-      fulfillmentContextSignalStartTimes.clear();
-      fulfillmentContextSignalStartTimes.set(context.contextKey, startTime);
-      startLifecycleRefresh();
-      return { changed: true, contextChanged: true };
-    }
-
-    if (context.contextKey === currentFulfillmentContextKey) {
-      currentFulfillmentContextSignalStartTime = Math.max(
-        currentFulfillmentContextSignalStartTime,
-        startTime,
-      );
-    }
+  if (
+    context &&
+    currentFulfillmentContextKey &&
+    context.contextKey !== currentFulfillmentContextKey
+  ) {
+    observedResourceUrls.clear();
+    observedResourceUrls.add(context.canonicalUrl);
+    currentFulfillmentContextKey = context.contextKey;
+    contextSignalFloorStartTime = startTime;
+    startLifecycleRefresh({
+      awaitFreshContext: false,
+      collectAfterReset: true,
+    });
+    return { changed: true, contextChanged: true };
   }
 
   const previousSize = observedResourceUrls.size;
@@ -166,6 +166,10 @@ function retainCurrentFulfillmentResource(pageUrl: URL): void {
 
 async function collectCurrentPage(): Promise<void> {
   if (collectionSucceeded) return;
+  if (awaitingFreshContext) {
+    collectionPending = true;
+    return;
+  }
   if (refreshInFlight) {
     collectionPending = true;
     return;
@@ -187,6 +191,7 @@ async function collectCurrentPage(): Promise<void> {
     if (result.status === "ok") {
       collectionSucceeded = true;
       retainCurrentFulfillmentResource(new URL(location.href));
+      contextSignalFloorStartTime = performance.now();
       domObserver?.disconnect();
     } else {
       await clearObservations();
@@ -197,7 +202,12 @@ async function collectCurrentPage(): Promise<void> {
     publishDiagnostics("internal-error", 0);
   } finally {
     collectionInFlight = false;
-    if (collectionPending && !collectionSucceeded && !refreshInFlight) {
+    if (
+      collectionPending &&
+      !collectionSucceeded &&
+      !refreshInFlight &&
+      !awaitingFreshContext
+    ) {
       collectionPending = false;
       void collectCurrentPage();
     }
@@ -206,7 +216,7 @@ async function collectCurrentPage(): Promise<void> {
 
 function requestCollection(): void {
   if (collectionSucceeded) return;
-  if (refreshInFlight || collectionInFlight) {
+  if (awaitingFreshContext || refreshInFlight || collectionInFlight) {
     collectionPending = true;
     return;
   }
@@ -226,8 +236,12 @@ function handleSameDocumentNavigation(event: Event): void {
     const destinationUrl = new URL(navigationEvent.destination.url, currentUrl);
     if (canonicalPageReference(currentUrl) === canonicalPageReference(destinationUrl)) return;
 
-    retainCurrentFulfillmentResource(destinationUrl);
-    startLifecycleRefresh();
+    observedResourceUrls.clear();
+    startLifecycleRefresh({
+      awaitFreshContext: true,
+      collectAfterReset: false,
+      signalFloorStartTime: performance.now(),
+    });
   } catch {
     // Ignore malformed navigation metadata; the existing page snapshot remains bounded.
   }

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -14,8 +14,10 @@ const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
 const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const observedResourceUrls = new Set<string>();
+const fulfillmentContextSignalStartTimes = new Map<string, number>();
 
 let currentFulfillmentContextKey: string | null = null;
+let currentFulfillmentContextSignalStartTime = Number.NEGATIVE_INFINITY;
 const sink = async (observations: BrowserObservation[]): Promise<void> => {
   await storeObservations(observations);
 
@@ -25,6 +27,15 @@ const sink = async (observations: BrowserObservation[]): Promise<void> => {
     ),
   );
   currentFulfillmentContextKey = contexts.size === 1 ? [...contexts][0] : null;
+  currentFulfillmentContextSignalStartTime = currentFulfillmentContextKey
+    ? (fulfillmentContextSignalStartTimes.get(currentFulfillmentContextKey) ?? Number.NEGATIVE_INFINITY)
+    : Number.NEGATIVE_INFINITY;
+
+  if (currentFulfillmentContextKey) {
+    const retainedSignalTime = currentFulfillmentContextSignalStartTime;
+    fulfillmentContextSignalStartTimes.clear();
+    fulfillmentContextSignalStartTimes.set(currentFulfillmentContextKey, retainedSignalTime);
+  }
 };
 const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
 
@@ -78,7 +89,7 @@ type ResourceMemoryResult = Readonly<{
   contextChanged: boolean;
 }>;
 
-function rememberAllowedResource(rawUrl: string): ResourceMemoryResult {
+function rememberAllowedResource(rawUrl: string, startTime: number): ResourceMemoryResult {
   const pageUrl = new URL(location.href);
   const canonical = canonicalObservedResourceUrl(rawUrl, pageUrl);
   if (!canonical) return { changed: false, contextChanged: false };
@@ -88,17 +99,36 @@ function rememberAllowedResource(rawUrl: string): ResourceMemoryResult {
     return { changed: false, contextChanged: false };
   }
 
-  if (
-    collectionSucceeded &&
-    currentFulfillmentContextKey &&
-    context &&
-    context.contextKey !== currentFulfillmentContextKey
-  ) {
-    observedResourceUrls.clear();
-    observedResourceUrls.add(context.canonicalUrl);
-    currentFulfillmentContextKey = context.contextKey;
-    startLifecycleRefresh();
-    return { changed: true, contextChanged: true };
+  if (context) {
+    const previousSignalTime = fulfillmentContextSignalStartTimes.get(context.contextKey);
+    if (previousSignalTime === undefined || startTime > previousSignalTime) {
+      fulfillmentContextSignalStartTimes.set(context.contextKey, startTime);
+    }
+
+    if (
+      currentFulfillmentContextKey &&
+      context.contextKey !== currentFulfillmentContextKey
+    ) {
+      if (startTime <= currentFulfillmentContextSignalStartTime) {
+        return { changed: false, contextChanged: false };
+      }
+
+      observedResourceUrls.clear();
+      observedResourceUrls.add(context.canonicalUrl);
+      currentFulfillmentContextKey = context.contextKey;
+      currentFulfillmentContextSignalStartTime = startTime;
+      fulfillmentContextSignalStartTimes.clear();
+      fulfillmentContextSignalStartTimes.set(context.contextKey, startTime);
+      startLifecycleRefresh();
+      return { changed: true, contextChanged: true };
+    }
+
+    if (context.contextKey === currentFulfillmentContextKey) {
+      currentFulfillmentContextSignalStartTime = Math.max(
+        currentFulfillmentContextSignalStartTime,
+        startTime,
+      );
+    }
   }
 
   const previousSize = observedResourceUrls.size;
@@ -114,7 +144,7 @@ function rememberResourceEntries(entries: readonly PerformanceEntry[]): Resource
   let contextChanged = false;
 
   entries.forEach((entry) => {
-    const result = rememberAllowedResource(entry.name);
+    const result = rememberAllowedResource(entry.name, entry.startTime);
     changed = result.changed || changed;
     contextChanged = result.contextChanged || contextChanged;
   });

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -4,17 +4,34 @@ import {
   createChromeObservationClearer,
   createChromeObservationSink,
 } from "./collector/chrome-observation-sink";
-import { canonicalObservedResourceUrl } from "./resource-observation-policy";
+import type { BrowserObservation } from "./model/browser-observation";
+import {
+  canonicalObservedResourceUrl,
+  fulfillmentContextResource,
+} from "./resource-observation-policy";
 
 const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
-const sink = createChromeObservationSink(sendMessage);
+const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
-const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
 const observedResourceUrls = new Set<string>();
+
+let currentFulfillmentContextKey: string | null = null;
+const sink = async (observations: BrowserObservation[]): Promise<void> => {
+  await storeObservations(observations);
+
+  const contexts = new Set(
+    observations.map(
+      (observation) => `${observation.retailerId}:${observation.fulfillmentContextId}`,
+    ),
+  );
+  currentFulfillmentContextKey = contexts.size === 1 ? [...contexts][0] : null;
+};
+const collector = new BrowserObservationCollector(retailerBrowserAdapters, sink);
 
 let collectionInFlight = false;
 let collectionPending = false;
 let collectionSucceeded = false;
+let refreshInFlight: Promise<void> | null = null;
 let resourceObserver: PerformanceObserver | null = null;
 let domObserver: MutationObserver | null = null;
 
@@ -23,25 +40,90 @@ function publishDiagnostics(status: string, observationCount: number): void {
   document.documentElement.dataset.zgBridgeCount = String(observationCount);
 }
 
-function rememberAllowedResource(rawUrl: string): boolean {
-  const canonical = canonicalObservedResourceUrl(rawUrl, new URL(location.href));
-  if (!canonical) return false;
+function canonicalPageReference(url: URL): string {
+  return `${url.origin}${url.pathname}`;
+}
+
+function observeDomChanges(): void {
+  domObserver?.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+function finishRefresh(reset: Promise<void>): void {
+  if (refreshInFlight !== reset) return;
+  refreshInFlight = null;
+
+  if (collectionPending && !collectionSucceeded) {
+    collectionPending = false;
+    void collectCurrentPage();
+  }
+}
+
+function startLifecycleRefresh(): void {
+  collectionSucceeded = false;
+  collectionPending = false;
+  observeDomChanges();
+  publishDiagnostics("refreshing", 0);
+
+  if (refreshInFlight) return;
+
+  const reset = clearObservations().catch(() => {
+    publishDiagnostics("internal-error", 0);
+  });
+  refreshInFlight = reset;
+  void reset.finally(() => finishRefresh(reset));
+}
+
+type ResourceMemoryResult = Readonly<{
+  changed: boolean;
+  contextChanged: boolean;
+}>;
+
+function rememberAllowedResource(rawUrl: string): ResourceMemoryResult {
+  const pageUrl = new URL(location.href);
+  const canonical = canonicalObservedResourceUrl(rawUrl, pageUrl);
+  if (!canonical) return { changed: false, contextChanged: false };
+
+  const context = fulfillmentContextResource(rawUrl, pageUrl);
+  if (
+    collectionSucceeded &&
+    currentFulfillmentContextKey &&
+    context &&
+    context.contextKey !== currentFulfillmentContextKey
+  ) {
+    observedResourceUrls.clear();
+    observedResourceUrls.add(context.canonicalUrl);
+    currentFulfillmentContextKey = context.contextKey;
+    startLifecycleRefresh();
+    return { changed: true, contextChanged: true };
+  }
 
   const previousSize = observedResourceUrls.size;
   observedResourceUrls.add(canonical);
-  return observedResourceUrls.size !== previousSize;
+  return {
+    changed: observedResourceUrls.size !== previousSize,
+    contextChanged: false,
+  };
 }
 
-function rememberResourceEntries(entries: readonly PerformanceEntry[]): boolean {
+function rememberResourceEntries(entries: readonly PerformanceEntry[]): ResourceMemoryResult {
   let changed = false;
+  let contextChanged = false;
+
   entries.forEach((entry) => {
-    changed = rememberAllowedResource(entry.name) || changed;
+    const result = rememberAllowedResource(entry.name);
+    changed = result.changed || changed;
+    contextChanged = result.contextChanged || contextChanged;
   });
-  return changed;
+
+  return { changed, contextChanged };
 }
 
 async function collectCurrentPage(): Promise<void> {
   if (collectionSucceeded) return;
+  if (refreshInFlight) {
+    collectionPending = true;
+    return;
+  }
   if (collectionInFlight) {
     collectionPending = true;
     return;
@@ -58,7 +140,6 @@ async function collectCurrentPage(): Promise<void> {
 
     if (result.status === "ok") {
       collectionSucceeded = true;
-      resourceObserver?.disconnect();
       domObserver?.disconnect();
     } else {
       await clearObservations();
@@ -69,7 +150,7 @@ async function collectCurrentPage(): Promise<void> {
     publishDiagnostics("internal-error", 0);
   } finally {
     collectionInFlight = false;
-    if (collectionPending && !collectionSucceeded) {
+    if (collectionPending && !collectionSucceeded && !refreshInFlight) {
       collectionPending = false;
       void collectCurrentPage();
     }
@@ -78,17 +159,49 @@ async function collectCurrentPage(): Promise<void> {
 
 function requestCollection(): void {
   if (collectionSucceeded) return;
-  if (collectionInFlight) {
+  if (refreshInFlight || collectionInFlight) {
     collectionPending = true;
     return;
   }
   void collectCurrentPage();
 }
 
-resourceObserver = new PerformanceObserver((list) => {
-  if (rememberResourceEntries(list.getEntries())) {
-    requestCollection();
+function retainCurrentFulfillmentResource(pageUrl: URL): void {
+  const currentContext = currentFulfillmentContextKey;
+  const retained = currentContext
+    ? [...observedResourceUrls].filter(
+        (url) => fulfillmentContextResource(url, pageUrl)?.contextKey === currentContext,
+      )
+    : [];
+
+  observedResourceUrls.clear();
+  retained.forEach((url) => observedResourceUrls.add(url));
+}
+
+function handleSameDocumentNavigation(event: Event): void {
+  if (!collectionSucceeded) return;
+
+  const navigationEvent = event as Event & {
+    destination?: { readonly sameDocument?: boolean; readonly url?: string };
+  };
+  if (!navigationEvent.destination?.sameDocument || !navigationEvent.destination.url) return;
+
+  try {
+    const currentUrl = new URL(location.href);
+    const destinationUrl = new URL(navigationEvent.destination.url, currentUrl);
+    if (canonicalPageReference(currentUrl) === canonicalPageReference(destinationUrl)) return;
+
+    retainCurrentFulfillmentResource(destinationUrl);
+    startLifecycleRefresh();
+  } catch {
+    // Ignore malformed navigation metadata; the existing page snapshot remains bounded.
   }
+}
+
+resourceObserver = new PerformanceObserver((list) => {
+  const result = rememberResourceEntries(list.getEntries());
+  if (result.contextChanged) return;
+  if (result.changed) requestCollection();
 });
 resourceObserver.observe({ type: "resource", buffered: true });
 
@@ -97,7 +210,10 @@ domObserver = new MutationObserver((mutations) => {
     requestCollection();
   }
 });
-domObserver.observe(document.documentElement, { childList: true, subtree: true });
+observeDomChanges();
+
+const navigationTarget = (window as Window & { readonly navigation?: EventTarget }).navigation;
+navigationTarget?.addEventListener("navigate", handleSameDocumentNavigation);
 
 rememberResourceEntries(performance.getEntriesByType("resource"));
 requestCollection();

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -15,12 +15,30 @@ const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const observedResourceUrls = new Set<string>();
 
+function nextObservationRevision(previous: number): number {
+  const clockRevision = Math.floor((performance.timeOrigin + performance.now()) * 1_000);
+  if (!Number.isSafeInteger(clockRevision) || clockRevision <= 0) {
+    return previous + 1;
+  }
+  return Math.max(previous + 1, clockRevision);
+}
+
+let observationRevision = nextObservationRevision(0);
+let activeCollectionRevision: number | null = null;
 let currentFulfillmentContextKey: string | null = null;
 let contextSignalFloorStartTime = Number.NEGATIVE_INFINITY;
 let awaitingFreshContext = false;
 
 const sink = async (observations: BrowserObservation[]): Promise<void> => {
-  await storeObservations(observations);
+  const revision = activeCollectionRevision;
+  if (revision === null || revision !== observationRevision) {
+    return;
+  }
+
+  await storeObservations(observations, revision);
+  if (revision !== observationRevision) {
+    return;
+  }
 
   const contexts = new Set(
     observations.map(
@@ -68,6 +86,7 @@ function startLifecycleRefresh(options: {
   collectAfterReset: boolean;
   signalFloorStartTime?: number;
 }): void {
+  observationRevision = nextObservationRevision(observationRevision);
   collectionSucceeded = false;
   collectionPending = options.collectAfterReset;
   awaitingFreshContext = options.awaitFreshContext;
@@ -77,10 +96,11 @@ function startLifecycleRefresh(options: {
   observeDomChanges();
   publishDiagnostics("refreshing", 0);
 
-  if (refreshInFlight) return;
-
-  const reset = clearObservations().catch(() => {
-    publishDiagnostics("internal-error", 0);
+  const revision = observationRevision;
+  const reset = clearObservations(revision).catch(() => {
+    if (revision === observationRevision) {
+      publishDiagnostics("internal-error", 0);
+    }
   });
   refreshInFlight = reset;
   void reset.finally(() => finishRefresh(reset));
@@ -179,7 +199,9 @@ async function collectCurrentPage(): Promise<void> {
     return;
   }
 
+  const revision = observationRevision;
   collectionInFlight = true;
+  activeCollectionRevision = revision;
   try {
     const result = await collector.collect(
       document,
@@ -188,19 +210,28 @@ async function collectCurrentPage(): Promise<void> {
       [...observedResourceUrls],
     );
 
+    if (revision !== observationRevision) {
+      return;
+    }
+
     if (result.status === "ok") {
       collectionSucceeded = true;
       retainCurrentFulfillmentResource(new URL(location.href));
       contextSignalFloorStartTime = performance.now();
       domObserver?.disconnect();
     } else {
-      await clearObservations();
+      await clearObservations(revision);
     }
     publishDiagnostics(result.status, result.observationCount);
   } catch {
-    await clearObservations();
-    publishDiagnostics("internal-error", 0);
+    if (revision === observationRevision) {
+      await clearObservations(revision);
+      publishDiagnostics("internal-error", 0);
+    }
   } finally {
+    if (activeCollectionRevision === revision) {
+      activeCollectionRevision = null;
+    }
     collectionInFlight = false;
     if (
       collectionPending &&
@@ -224,7 +255,14 @@ function requestCollection(): void {
 }
 
 function handleSameDocumentNavigation(event: Event): void {
-  if (!collectionSucceeded && !awaitingFreshContext && !refreshInFlight) return;
+  if (
+    !collectionSucceeded &&
+    !awaitingFreshContext &&
+    !refreshInFlight &&
+    !collectionInFlight
+  ) {
+    return;
+  }
 
   const navigationEvent = event as Event & {
     destination?: { readonly sameDocument?: boolean; readonly url?: string };
@@ -265,4 +303,10 @@ const navigationTarget = (window as Window & { readonly navigation?: EventTarget
 navigationTarget?.addEventListener("navigate", handleSameDocumentNavigation);
 
 rememberResourceEntries(performance.getEntriesByType("resource"));
-requestCollection();
+collectionPending = true;
+publishDiagnostics("refreshing", 0);
+const initialReset = clearObservations(observationRevision).catch(() => {
+  publishDiagnostics("internal-error", 0);
+});
+refreshInFlight = initialReset;
+void initialReset.finally(() => finishRefresh(initialReset));

--- a/apps/retailer-bridge/src/resource-observation-policy.ts
+++ b/apps/retailer-bridge/src/resource-observation-policy.ts
@@ -1,6 +1,17 @@
+const PEREKRESTOK_PAGE_HOST = "www.perekrestok.ru";
+const PEREKRESTOK_SHOP_RESOURCE_PATH = /^\/api\/customer\/[^/]+\/shop\/(\d+)\/?$/;
 const PYATEROCHKA_PAGE_HOSTS = new Set(["5ka.ru", "www.5ka.ru"]);
 const PYATEROCHKA_SERVICE_ORIGIN = "https://5d.5ka.ru";
-const PYATEROCHKA_STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/[A-Za-z0-9_-]+(?:\/|$)/;
+const PYATEROCHKA_STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/([A-Za-z0-9_-]+)(?:\/|$)/;
+
+export type FulfillmentContextResource = Readonly<{
+  contextKey: string;
+  canonicalUrl: string;
+}>;
+
+function isOfficialPerekrestokPage(pageUrl: URL): boolean {
+  return pageUrl.protocol === "https:" && pageUrl.hostname === PEREKRESTOK_PAGE_HOST;
+}
 
 function isOfficialPyaterochkaPage(pageUrl: URL): boolean {
   return pageUrl.protocol === "https:" && PYATEROCHKA_PAGE_HOSTS.has(pageUrl.hostname);
@@ -20,6 +31,39 @@ export function canonicalObservedResourceUrl(rawUrl: string, pageUrl: URL): stri
       PYATEROCHKA_STORE_RESOURCE_PATH.test(resourceUrl.pathname)
     ) {
       return `${resourceUrl.origin}${resourceUrl.pathname}`;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function fulfillmentContextResource(
+  rawUrl: string,
+  pageUrl: URL,
+): FulfillmentContextResource | null {
+  const canonicalUrl = canonicalObservedResourceUrl(rawUrl, pageUrl);
+  if (!canonicalUrl) return null;
+
+  try {
+    const resourceUrl = new URL(canonicalUrl);
+
+    if (isOfficialPerekrestokPage(pageUrl) && resourceUrl.origin === pageUrl.origin) {
+      const contextId = resourceUrl.pathname.match(PEREKRESTOK_SHOP_RESOURCE_PATH)?.[1];
+      return contextId
+        ? { contextKey: `perekrestok:${contextId}`, canonicalUrl }
+        : null;
+    }
+
+    if (
+      isOfficialPyaterochkaPage(pageUrl) &&
+      resourceUrl.origin === PYATEROCHKA_SERVICE_ORIGIN
+    ) {
+      const contextId = resourceUrl.pathname.match(PYATEROCHKA_STORE_RESOURCE_PATH)?.[1];
+      return contextId
+        ? { contextKey: `pyaterochka:${contextId}`, canonicalUrl }
+        : null;
     }
 
     return null;

--- a/apps/retailer-bridge/static/service-worker.e2e.js
+++ b/apps/retailer-bridge/static/service-worker.e2e.js
@@ -3,17 +3,37 @@ const DELAY_NEXT_STORE_KEY = "zg.e2e.delayNextObservationStore";
 const STORE_PENDING_KEY = "zg.e2e.observationStorePending";
 const RELEASE_STORE_KEY = "zg.e2e.releaseObservationStore";
 
+let latestRevision = 0;
+let latestObservations = [];
+
+function validRevision(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
 chrome.runtime.onMessage.addListener((message) => {
-  if (message?.type !== "ZG_STORE_OBSERVATIONS" || !Array.isArray(message.observations)) {
+  if (
+    message?.type !== "ZG_STORE_OBSERVATIONS" ||
+    !Array.isArray(message.observations) ||
+    !validRevision(message.revision)
+  ) {
     return;
   }
 
+  const revision = message.revision;
+  if (revision < latestRevision) {
+    return Promise.resolve();
+  }
+
+  latestRevision = revision;
+  latestObservations = message.observations;
+
   return (async () => {
     const controls = await chrome.storage.local.get(DELAY_NEXT_STORE_KEY);
-    if (
+    const delayed =
       message.observations.length > 0 &&
-      controls[DELAY_NEXT_STORE_KEY] === true
-    ) {
+      controls[DELAY_NEXT_STORE_KEY] === true;
+
+    if (delayed) {
       await chrome.storage.local.remove([DELAY_NEXT_STORE_KEY, RELEASE_STORE_KEY]);
       await chrome.storage.local.set({ [STORE_PENDING_KEY]: true });
 
@@ -27,16 +47,22 @@ chrome.runtime.onMessage.addListener((message) => {
         };
         chrome.storage.onChanged.addListener(listener);
       });
+    }
 
+    if (revision === latestRevision) {
       await chrome.storage.local.set({
         [OBSERVATIONS_KEY]: message.observations,
       });
-      await chrome.storage.local.remove([STORE_PENDING_KEY, RELEASE_STORE_KEY]);
-      return;
     }
 
-    await chrome.storage.local.set({
-      [OBSERVATIONS_KEY]: message.observations,
-    });
+    if (delayed) {
+      await chrome.storage.local.remove([STORE_PENDING_KEY, RELEASE_STORE_KEY]);
+    }
+
+    if (revision !== latestRevision) {
+      await chrome.storage.local.set({
+        [OBSERVATIONS_KEY]: latestObservations,
+      });
+    }
   })();
 });

--- a/apps/retailer-bridge/static/service-worker.e2e.js
+++ b/apps/retailer-bridge/static/service-worker.e2e.js
@@ -28,7 +28,11 @@ chrome.runtime.onMessage.addListener((message) => {
         chrome.storage.onChanged.addListener(listener);
       });
 
+      await chrome.storage.local.set({
+        [OBSERVATIONS_KEY]: message.observations,
+      });
       await chrome.storage.local.remove([STORE_PENDING_KEY, RELEASE_STORE_KEY]);
+      return;
     }
 
     await chrome.storage.local.set({

--- a/apps/retailer-bridge/static/service-worker.e2e.js
+++ b/apps/retailer-bridge/static/service-worker.e2e.js
@@ -3,14 +3,6 @@ const DELAY_NEXT_STORE_KEY = "zg.e2e.delayNextObservationStore";
 const STORE_PENDING_KEY = "zg.e2e.observationStorePending";
 const RELEASE_STORE_KEY = "zg.e2e.releaseObservationStore";
 
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName !== "local" || changes[RELEASE_STORE_KEY]?.newValue !== true) {
-    return;
-  }
-
-  void chrome.storage.local.remove(RELEASE_STORE_KEY);
-});
-
 chrome.runtime.onMessage.addListener((message) => {
   if (message?.type !== "ZG_STORE_OBSERVATIONS" || !Array.isArray(message.observations)) {
     return;
@@ -22,7 +14,7 @@ chrome.runtime.onMessage.addListener((message) => {
       message.observations.length > 0 &&
       controls[DELAY_NEXT_STORE_KEY] === true
     ) {
-      await chrome.storage.local.remove(DELAY_NEXT_STORE_KEY);
+      await chrome.storage.local.remove([DELAY_NEXT_STORE_KEY, RELEASE_STORE_KEY]);
       await chrome.storage.local.set({ [STORE_PENDING_KEY]: true });
 
       await new Promise((resolve) => {

--- a/apps/retailer-bridge/static/service-worker.e2e.js
+++ b/apps/retailer-bridge/static/service-worker.e2e.js
@@ -1,0 +1,46 @@
+const OBSERVATIONS_KEY = "zg.latestObservations";
+const DELAY_NEXT_STORE_KEY = "zg.e2e.delayNextObservationStore";
+const STORE_PENDING_KEY = "zg.e2e.observationStorePending";
+const RELEASE_STORE_KEY = "zg.e2e.releaseObservationStore";
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== "local" || changes[RELEASE_STORE_KEY]?.newValue !== true) {
+    return;
+  }
+
+  void chrome.storage.local.remove(RELEASE_STORE_KEY);
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type !== "ZG_STORE_OBSERVATIONS" || !Array.isArray(message.observations)) {
+    return;
+  }
+
+  return (async () => {
+    const controls = await chrome.storage.local.get(DELAY_NEXT_STORE_KEY);
+    if (
+      message.observations.length > 0 &&
+      controls[DELAY_NEXT_STORE_KEY] === true
+    ) {
+      await chrome.storage.local.remove(DELAY_NEXT_STORE_KEY);
+      await chrome.storage.local.set({ [STORE_PENDING_KEY]: true });
+
+      await new Promise((resolve) => {
+        const listener = (changes, areaName) => {
+          if (areaName !== "local" || changes[RELEASE_STORE_KEY]?.newValue !== true) {
+            return;
+          }
+          chrome.storage.onChanged.removeListener(listener);
+          resolve();
+        };
+        chrome.storage.onChanged.addListener(listener);
+      });
+
+      await chrome.storage.local.remove([STORE_PENDING_KEY, RELEASE_STORE_KEY]);
+    }
+
+    await chrome.storage.local.set({
+      [OBSERVATIONS_KEY]: message.observations,
+    });
+  })();
+});

--- a/apps/retailer-bridge/static/service-worker.js
+++ b/apps/retailer-bridge/static/service-worker.js
@@ -1,9 +1,45 @@
+const OBSERVATIONS_KEY = "zg.latestObservations";
+
+let latestRevision = 0;
+let latestObservations = [];
+
+function validRevision(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
 chrome.runtime.onMessage.addListener((message) => {
-  if (message?.type !== "ZG_STORE_OBSERVATIONS" || !Array.isArray(message.observations)) {
+  if (
+    message?.type !== "ZG_STORE_OBSERVATIONS" ||
+    !Array.isArray(message.observations) ||
+    !validRevision(message.revision)
+  ) {
     return;
   }
 
-  return chrome.storage.local.set({
-    "zg.latestObservations": message.observations,
-  });
+  const revision = message.revision;
+  if (revision < latestRevision) {
+    return Promise.resolve();
+  }
+
+  latestRevision = revision;
+  latestObservations = message.observations;
+
+  return (async () => {
+    if (revision !== latestRevision) {
+      return;
+    }
+
+    await chrome.storage.local.set({
+      [OBSERVATIONS_KEY]: message.observations,
+    });
+
+    // A newer lifecycle message may have arrived while the storage write was
+    // in flight. Repair the key to the newest accepted payload before this
+    // older handler resolves.
+    if (revision !== latestRevision) {
+      await chrome.storage.local.set({
+        [OBSERVATIONS_KEY]: latestObservations,
+      });
+    }
+  })();
 });

--- a/apps/retailer-bridge/test/chrome-observation-sink.test.ts
+++ b/apps/retailer-bridge/test/chrome-observation-sink.test.ts
@@ -21,28 +21,45 @@ const observation: BrowserObservation = {
   adapterVersion: "1",
 };
 
+const revision = 1_786_880_000_000_001;
+
 describe("Chrome observation messaging", () => {
-  it("sends only the normalized observation message contract", async () => {
+  it("sends normalized observations with their lifecycle revision", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const sink = createChromeObservationSink(sendMessage);
 
-    await sink([observation]);
+    await sink([observation], revision);
 
     expect(sendMessage).toHaveBeenCalledExactlyOnceWith({
       type: "ZG_STORE_OBSERVATIONS",
+      revision,
       observations: [observation],
     });
   });
 
-  it("replaces stale observations with an empty normalized payload", async () => {
+  it("invalidates stale observations at the same lifecycle revision boundary", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const clear = createChromeObservationClearer(sendMessage);
 
-    await clear();
+    await clear(revision);
 
     expect(sendMessage).toHaveBeenCalledExactlyOnceWith({
       type: "ZG_STORE_OBSERVATIONS",
+      revision,
       observations: [],
     });
   });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    "rejects invalid observation revision %s before messaging",
+    async (invalidRevision) => {
+      const sendMessage = vi.fn().mockResolvedValue(undefined);
+      const sink = createChromeObservationSink(sendMessage);
+
+      await expect(sink([observation], invalidRevision)).rejects.toThrow(
+        "observation revision must be a positive safe integer",
+      );
+      expect(sendMessage).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/retailer-bridge/test/resource-observation-policy.test.ts
+++ b/apps/retailer-bridge/test/resource-observation-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canonicalObservedResourceUrl } from "../src/resource-observation-policy";
+import {
+  canonicalObservedResourceUrl,
+  fulfillmentContextResource,
+} from "../src/resource-observation-policy";
 
 describe("canonicalObservedResourceUrl", () => {
   it("keeps same-origin pathname evidence and strips query/hash", () => {
@@ -35,6 +38,42 @@ describe("canonicalObservedResourceUrl", () => {
         "https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products",
         new URL("https://www.perekrestok.ru/cat/1"),
       ),
+    ).toBeNull();
+  });
+});
+
+describe("fulfillmentContextResource", () => {
+  it("projects only the Perekrestok shop id and sanitized canonical URL", () => {
+    const page = new URL("https://www.perekrestok.ru/cat/1");
+
+    expect(
+      fulfillmentContextResource(
+        "https://www.perekrestok.ru/api/customer/1.4.1.0/shop/656?session=SECRET#fragment",
+        page,
+      ),
+    ).toEqual({
+      contextKey: "perekrestok:656",
+      canonicalUrl: "https://www.perekrestok.ru/api/customer/1.4.1.0/shop/656",
+    });
+    expect(
+      fulfillmentContextResource("https://www.perekrestok.ru/api/catalog/products", page),
+    ).toBeNull();
+  });
+
+  it("projects only the official Pyaterochka store path without query/hash", () => {
+    const page = new URL("https://5ka.ru/catalog/fixture");
+
+    expect(
+      fulfillmentContextResource(
+        "https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products?token=SECRET#fragment",
+        page,
+      ),
+    ).toEqual({
+      contextKey: "pyaterochka:ZG001",
+      canonicalUrl: "https://5d.5ka.ru/api/catalog/v2/stores/ZG001/products",
+    });
+    expect(
+      fulfillmentContextResource("https://5d.5ka.ru/api/profile/v1/me", page),
     ).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #54 after the accepted browser bridge proved correct for bounded page snapshots but unsafe for long-lived sessions after post-success SPA/store changes.

## RED evidence

1. `2854649c4b94a1f2f18b13ebf9fb83a9bde42982`: bridge unit/type/build PASS; 3 accepted Chromium scenarios PASS; exactly 2 new lifecycle scenarios FAIL because both `history.pushState` and `/shop/777` left old context `656` / SKU `4408829` in storage.
2. `ff9bdf32c8616babba551935444f6f508ab96780`: 5/6 Chromium PASS; overlapping SPA + store change exposed a truthfulness race where new SKU `7712345` was stored under old fulfillment context `656` instead of `777`.
3. `3aa426224c7f2edaad964f08666d0821e81bec9a`: first start-time watermark approach was rejected by exact-head CI; 8/9 workflow groups were green but the combined Chromium scenario still reproduced the wrong-store snapshot.
4. `a5d23d9ff8dbd7d561a52fc0cb48c35e4aab524e`: deterministic E2E-only delayed storage exposed another race; 7/8 Chromium PASS and only the new test FAIL because an obsolete in-flight collection republished SKU `9912345` / `inflight-old-route` after a newer SPA boundary.

## Final lifecycle model

- keep only the lightweight `PerformanceObserver` alive after a successful snapshot; broad `MutationObserver` reconnects only while refresh is unresolved and disconnects again after success;
- use Navigation API same-document `navigate` signals instead of polling or monkey-patching page history;
- clear stale observations at every SPA lifecycle boundary and never assume the previous store remains authoritative;
- require a fresh allow-listed fulfillment-context resource before recollecting a new SPA DOM;
- use `PerformanceEntry.startTime` only as an epoch floor so responses from requests started before the latest navigation boundary cannot validate the new route;
- replace old fulfillment context immediately on a fresh post-success context change and bound retained resource evidence to that context;
- use a monotonic high-resolution lifecycle revision for internal content-script → service-worker store/clear messages;
- content script ignores obsolete async collection results; service worker rejects older revisions and repairs the storage key if an older write finishes after a newer lifecycle message;
- the public `zg.latestObservations` storage value remains the same observation array; only the internal runtime-message envelope gains `revision`;
- production extension permissions remain unchanged (`storage` only); no `webRequest`, new host permissions, cookies, tokens, headers or response bodies;
- E2E-only delayed service worker is built only into `dist-e2e` and never replaces the production worker.

## Acceptance evidence

Final synchronized head `f79df8cfa645760a5b1704efb7fd144481adca5d`:

- 30 bridge unit tests PASS;
- bridge typecheck PASS;
- production extension build PASS;
- 8/8 Chromium bridge E2E PASS, covering baseline Perekrestok/Pyaterochka behavior, same-store SPA refresh, store `656 → 777`, overlap SPA+store change, rapid consecutive SPA boundaries with delayed old resource, and obsolete in-flight collection rejection;
- all 9 repository PR workflow groups SUCCESS;
- Web production-build E2E SUCCESS with the deterministic focus gate accepted separately in #154;
- read-only review clean: no remaining P0/P1/P2/P3 findings and no unresolved review threads;
- branch synchronized with accepted `main` (`behind = 0`), and PR diff remains limited to 12 retailer-bridge files.

A separate pre-existing Web focus E2E race exposed during validation was fixed independently in #154 and accepted on `main` as `33b208649101cee5ddcb1b9c0efd6436ee431ca3`; it changes tests only, not Web runtime.