### PR TITLE
test(web): make keyboard focus acceptance deterministic

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -213,9 +213,21 @@ test("WeeklyPlan journey fails closed when API is unavailable", async ({ page })
 test("WeeklyPlan Pantry controls expose a visible keyboard focus path", async ({ page }) => {
   await page.goto("/");
   const form = weeklyForm(page);
+  const clearDraft = form.getByRole("button", { name: "Очистить форму и локальный черновик" });
   const locality = form.getByRole("textbox", { name: "Населённый пункт", exact: true });
+
+  await expect(clearDraft).toBeEnabled();
+  await page.evaluate(() => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+  });
+  await expect(page.locator("body")).toBeFocused();
+
+  await page.keyboard.press("Tab");
+  await expect(clearDraft).toBeFocused();
   await page.keyboard.press("Tab");
   await expect(locality).toBeFocused();
+
   const localityVisible = await locality.evaluate((element) => {
     const style = window.getComputedStyle(element);
     return (style.outlineStyle !== "none" && style.outlineWidth !== "0px") || style.boxShadow !== "none";


### PR DESCRIPTION
Fixes a pre-existing Web E2E race exposed while validating PR #153.

## Evidence

On PR #153 head `c7258db89afb6930c37a84a57d76b7dc850bedee`, Web E2E ran 26 tests: 25 passed and only mobile `WeeklyPlan Pantry controls expose a visible keyboard focus path` failed because locality was not focused after the first `Tab`. Re-running the exact failed job on the same SHA passed, confirming nondeterminism.

Root cause is test drift after accepted M5.1: `Очистить форму и локальный черновик` now precedes locality in DOM/tab order and becomes enabled asynchronously when browser-local draft restore finishes. The old test pressed `Tab` immediately after `page.goto()` and assumed locality was always the first tabbable element, so timing relative to `draftReady` decided the result.

## Fix

- wait until the local-draft clear control is enabled;
- establish an explicit document-start focus origin in the browser test only;
- verify the actual accepted keyboard order: `Tab → Clear draft → Tab → Locality`;
- keep the existing visible-focus assertion and Pantry keyboard activation check;
- no Web runtime or product behavior changes.