### PR TITLE
feat(provider): add Chizhik plain HTTP Phase A probe

### DIFF
--- a/.github/workflows/provider-live-probe.yml
+++ b/.github/workflows/provider-live-probe.yml
@@ -298,6 +298,7 @@ jobs:
             search_outcome="$(sed -n 's/.*search_outcome=\([^ ]*\).*/\1/p' <<<"$evidence")"
             search_status="$(sed -n 's/.*search_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
             product_id="$(sed -n 's/.*product_id_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            product_plu="$(sed -n 's/.*product_plu_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
             product_title="$(sed -n 's/.*product_title_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
             price_evidence="$(sed -n 's/.*price_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
 
@@ -307,6 +308,7 @@ jobs:
                && "$search_outcome" == 'ACCESSIBLE' \
                && "$search_status" =~ ^2[0-9][0-9]$ \
                && "$product_id" == 'true' \
+               && "$product_plu" == 'true' \
                && "$product_title" == 'true' \
                && "$price_evidence" == 'true' ]]; then
               state='success'
@@ -317,7 +319,7 @@ jobs:
               outcome='categories-shape'
             elif [[ "$search_outcome" != 'ACCESSIBLE' ]]; then
               outcome="search-${search_outcome:-unknown}"
-            elif [[ "$product_id" != 'true' || "$product_title" != 'true' ]]; then
+            elif [[ "$product_id" != 'true' || "$product_plu" != 'true' || "$product_title" != 'true' ]]; then
               outcome='search-shape'
             elif [[ "$price_evidence" != 'true' ]]; then
               outcome='price-missing'

--- a/.github/workflows/provider-live-probe.yml
+++ b/.github/workflows/provider-live-probe.yml
@@ -226,3 +226,113 @@ jobs:
             -f state="$state" \
             -f context="$context" \
             -f description="$description" >/dev/null
+
+  chizhik:
+    name: Chizhik Plain HTTP Phase A
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 155 &&
+      github.actor == 'True-Ruslan' &&
+      github.event.comment.body == '/provider-probe chizhik'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Chizhik plain HTTP Phase A
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=ChizhikPlainHttpProbeTest \
+            -Dzakup.live.chizhik=true \
+            test 2>&1 | tee "$RUNNER_TEMP/chizhik-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Chizhik plain HTTP Phase A' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/chizhik-live-probe.log" ]]; then
+            evidence="$(grep -F 'CHIZHIK_PHASE_A' "$RUNNER_TEMP/chizhik-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='CHIZHIK_PHASE_A no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            categories_outcome="$(sed -n 's/.*categories_outcome=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            categories_status="$(sed -n 's/.*categories_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            categories_shape="$(sed -n 's/.*categories_shape=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            search_outcome="$(sed -n 's/.*search_outcome=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            search_status="$(sed -n 's/.*search_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            product_id="$(sed -n 's/.*product_id_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            product_title="$(sed -n 's/.*product_title_present=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            price_evidence="$(sed -n 's/.*price_evidence=\([^ ]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$categories_outcome" == 'ACCESSIBLE' \
+               && "$categories_status" =~ ^2[0-9][0-9]$ \
+               && "$categories_shape" == 'true' \
+               && "$search_outcome" == 'ACCESSIBLE' \
+               && "$search_status" =~ ^2[0-9][0-9]$ \
+               && "$product_id" == 'true' \
+               && "$product_title" == 'true' \
+               && "$price_evidence" == 'true' ]]; then
+              state='success'
+              outcome='pass'
+            elif [[ "$categories_outcome" != 'ACCESSIBLE' ]]; then
+              outcome="categories-${categories_outcome:-unknown}"
+            elif [[ "$categories_shape" != 'true' ]]; then
+              outcome='categories-shape'
+            elif [[ "$search_outcome" != 'ACCESSIBLE' ]]; then
+              outcome="search-${search_outcome:-unknown}"
+            elif [[ "$product_id" != 'true' || "$product_title" != 'true' ]]; then
+              outcome='search-shape'
+            elif [[ "$price_evidence" != 'true' ]]; then
+              outcome='price-missing'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Phase A evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Chizhik / ${outcome}"
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$state" \
+            -f context="$context" \
+            -f description="$description" >/dev/null

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbe.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbe.java
@@ -1,0 +1,224 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+final class ChizhikPlainHttpProbe {
+
+    private static final String API_BASE = "https://app.chizhik.club/api";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
+    private static final Map<String, String> REQUEST_HEADERS = Map.of(
+            "Accept", "application/json",
+            "User-Agent", "ZakupGotov-M0B-PlainHttpProbe/0.1 (+https://github.com/True-Ruslan/zakup-gotov)");
+
+    private static final Pattern ID_FIELD = Pattern.compile("\\\"id\\\"\\s*:\\s*\\d+");
+    private static final Pattern CATEGORY_NAME_FIELD = Pattern.compile("\\\"name\\\"\\s*:\\s*\\\"[^\\\"]+\\\"");
+    private static final Pattern PLU_FIELD = Pattern.compile("\\\"plu\\\"\\s*:\\s*\\\"[^\\\"]+\\\"");
+    private static final Pattern TITLE_FIELD = Pattern.compile("\\\"title\\\"\\s*:\\s*\\\"[^\\\"]+\\\"");
+    private static final Pattern PRICE_FIELD = Pattern.compile("\\\"price\\\"\\s*:\\s*-?\\d+(?:\\.\\d+)?");
+
+    private final Transport transport;
+
+    private ChizhikPlainHttpProbe(Transport transport) {
+        this.transport = transport;
+    }
+
+    static ChizhikPlainHttpProbe create() {
+        var client = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+        return new ChizhikPlainHttpProbe(uri -> {
+            var builder = HttpRequest.newBuilder(uri)
+                    .GET()
+                    .timeout(REQUEST_TIMEOUT);
+            REQUEST_HEADERS.forEach(builder::header);
+            var response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            return new ProbeResponse(response.statusCode(), response.body());
+        });
+    }
+
+    static ChizhikPlainHttpProbe forTransport(Transport transport) {
+        if (transport == null) {
+            throw new IllegalArgumentException("transport must not be null");
+        }
+        return new ChizhikPlainHttpProbe(transport);
+    }
+
+    Map<String, String> requestHeaders() {
+        return REQUEST_HEADERS;
+    }
+
+    URI categoriesUri() {
+        return URI.create(API_BASE + "/v1/catalog/unauthorized/categories/");
+    }
+
+    URI searchUri(String query, int page) {
+        if (query == null || query.isBlank()) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
+        if (page < 1) {
+            throw new IllegalArgumentException("page must be positive");
+        }
+        var encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8).replace("+", "%20");
+        return URI.create(API_BASE + "/v1/catalog/unauthorized/products/?page=" + page + "&term=" + encodedQuery);
+    }
+
+    PhaseAResult runPhaseA(String query) throws InterruptedException {
+        var categories = safeGet(categoriesUri());
+        if (categories.outcome() != Outcome.ACCESSIBLE) {
+            return PhaseAResult.categoriesGateFailed(categories);
+        }
+
+        var categoriesShape = hasCategoryShape(categories.body());
+        if (!categoriesShape) {
+            return PhaseAResult.categoriesShapeFailed(categories);
+        }
+
+        var search = safeGet(searchUri(query, 1));
+        if (search.outcome() != Outcome.ACCESSIBLE) {
+            return PhaseAResult.searchGateFailed(categories, categoriesShape, search);
+        }
+
+        var body = search.body();
+        return new PhaseAResult(
+                categories.outcome(),
+                categories.status(),
+                categoriesShape,
+                search.outcome(),
+                search.status(),
+                ID_FIELD.matcher(body).find(),
+                PLU_FIELD.matcher(body).find(),
+                TITLE_FIELD.matcher(body).find(),
+                PRICE_FIELD.matcher(body).find());
+    }
+
+    private ProbeAttempt safeGet(URI uri) throws InterruptedException {
+        try {
+            var response = transport.get(uri);
+            return new ProbeAttempt(classifyStatus(response.status()), response.status(), body(response.body()));
+        } catch (HttpTimeoutException exception) {
+            return new ProbeAttempt(Outcome.TIMEOUT, -1, "");
+        } catch (IOException exception) {
+            return new ProbeAttempt(Outcome.NETWORK_ERROR, -1, "");
+        }
+    }
+
+    static Outcome classifyStatus(int status) {
+        if (status >= 200 && status < 300) {
+            return Outcome.ACCESSIBLE;
+        }
+        if (status >= 300 && status < 400) {
+            return Outcome.REDIRECTED;
+        }
+        if (status == 401 || status == 403) {
+            return Outcome.BLOCKED;
+        }
+        if (status == 429) {
+            return Outcome.RATE_LIMITED;
+        }
+        return Outcome.HTTP_ERROR;
+    }
+
+    private static boolean hasCategoryShape(String body) {
+        return ID_FIELD.matcher(body).find() && CATEGORY_NAME_FIELD.matcher(body).find();
+    }
+
+    private static String body(String body) {
+        return body == null ? "" : body;
+    }
+
+    enum Outcome {
+        ACCESSIBLE,
+        REDIRECTED,
+        BLOCKED,
+        RATE_LIMITED,
+        HTTP_ERROR,
+        TIMEOUT,
+        NETWORK_ERROR,
+        NOT_ATTEMPTED
+    }
+
+    @FunctionalInterface
+    interface Transport {
+        ProbeResponse get(URI uri) throws IOException, InterruptedException;
+    }
+
+    record ProbeResponse(int status, String body) {}
+
+    private record ProbeAttempt(Outcome outcome, int status, String body) {}
+
+    record PhaseAResult(
+            Outcome categoriesOutcome,
+            int categoriesStatus,
+            boolean categoriesShape,
+            Outcome searchOutcome,
+            int searchStatus,
+            boolean productIdPresent,
+            boolean productPluPresent,
+            boolean productTitlePresent,
+            boolean priceEvidence) {
+
+        static PhaseAResult categoriesGateFailed(ProbeAttempt categories) {
+            return new PhaseAResult(
+                    categories.outcome(),
+                    categories.status(),
+                    false,
+                    Outcome.NOT_ATTEMPTED,
+                    -1,
+                    false,
+                    false,
+                    false,
+                    false);
+        }
+
+        static PhaseAResult categoriesShapeFailed(ProbeAttempt categories) {
+            return new PhaseAResult(
+                    categories.outcome(),
+                    categories.status(),
+                    false,
+                    Outcome.NOT_ATTEMPTED,
+                    -1,
+                    false,
+                    false,
+                    false,
+                    false);
+        }
+
+        static PhaseAResult searchGateFailed(ProbeAttempt categories, boolean categoriesShape, ProbeAttempt search) {
+            return new PhaseAResult(
+                    categories.outcome(),
+                    categories.status(),
+                    categoriesShape,
+                    search.outcome(),
+                    search.status(),
+                    false,
+                    false,
+                    false,
+                    false);
+        }
+
+        String toEvidenceLine() {
+            return "CHIZHIK_PHASE_A"
+                    + " categories_outcome=" + categoriesOutcome
+                    + " categories_status=" + categoriesStatus
+                    + " categories_shape=" + categoriesShape
+                    + " search_outcome=" + searchOutcome
+                    + " search_status=" + searchStatus
+                    + " product_id_present=" + productIdPresent
+                    + " product_plu_present=" + productPluPresent
+                    + " product_title_present=" + productTitlePresent
+                    + " price_evidence=" + priceEvidence;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbeTest.java
@@ -1,0 +1,175 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpTimeoutException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ChizhikPlainHttpProbeTest {
+
+    @Test
+    void buildsOnlyUnauthenticatedCatalogRequests() {
+        var probe = ChizhikPlainHttpProbe.create();
+
+        assertThat(probe.categoriesUri().toString())
+                .isEqualTo("https://app.chizhik.club/api/v1/catalog/unauthorized/categories/");
+        assertThat(probe.searchUri("молоко", 1).toString())
+                .isEqualTo("https://app.chizhik.club/api/v1/catalog/unauthorized/products/"
+                        + "?page=1&term=%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE");
+    }
+
+    @Test
+    void rejectsInvalidSearchInput() {
+        var probe = ChizhikPlainHttpProbe.create();
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> probe.searchUri(" ", 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("query");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> probe.searchUri("молоко", 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("page");
+    }
+
+    @Test
+    void plainHttpPolicyUsesNoCapturedBrowserHeadersOrCredentials() {
+        var probe = ChizhikPlainHttpProbe.create();
+
+        assertThat(probe.requestHeaders()).containsOnlyKeys("Accept", "User-Agent");
+        assertThat(probe.requestHeaders().keySet())
+                .doesNotContainAnyElementsOf(Set.of(
+                        "Cookie",
+                        "Authorization",
+                        "Referer",
+                        "Origin",
+                        "x-app-version",
+                        "x-device-id",
+                        "x-platform"));
+    }
+
+    @Test
+    void classifiesHttpStatusesFailClosed() {
+        assertThat(ChizhikPlainHttpProbe.classifyStatus(200)).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
+        assertThat(ChizhikPlainHttpProbe.classifyStatus(302)).isEqualTo(ChizhikPlainHttpProbe.Outcome.REDIRECTED);
+        assertThat(ChizhikPlainHttpProbe.classifyStatus(403)).isEqualTo(ChizhikPlainHttpProbe.Outcome.BLOCKED);
+        assertThat(ChizhikPlainHttpProbe.classifyStatus(429)).isEqualTo(ChizhikPlainHttpProbe.Outcome.RATE_LIMITED);
+        assertThat(ChizhikPlainHttpProbe.classifyStatus(500)).isEqualTo(ChizhikPlainHttpProbe.Outcome.HTTP_ERROR);
+    }
+
+    @Test
+    void recordsOnlySanitizedShapeEvidenceForAccessibleCatalog() throws Exception {
+        var transport = new QueueTransport()
+                .respond(200, "[{\"id\":1,\"name\":\"Молочные продукты\",\"slug\":\"milk\"}]")
+                .respond(200, "{\"count\":1,\"items\":[{\"id\":42,\"plu\":\"secret-plu\","
+                        + "\"title\":\"Молоко тестовое\",\"price\":99.9}]}");
+        var probe = ChizhikPlainHttpProbe.forTransport(transport);
+
+        var result = probe.runPhaseA("молоко");
+
+        assertThat(result.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
+        assertThat(result.categoriesStatus()).isEqualTo(200);
+        assertThat(result.categoriesShape()).isTrue();
+        assertThat(result.searchOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
+        assertThat(result.searchStatus()).isEqualTo(200);
+        assertThat(result.productIdPresent()).isTrue();
+        assertThat(result.productPluPresent()).isTrue();
+        assertThat(result.productTitlePresent()).isTrue();
+        assertThat(result.priceEvidence()).isTrue();
+
+        assertThat(result.toEvidenceLine())
+                .contains("CHIZHIK_PHASE_A")
+                .contains("categories_outcome=ACCESSIBLE")
+                .contains("search_outcome=ACCESSIBLE")
+                .contains("product_plu_present=true")
+                .doesNotContain("secret-plu")
+                .doesNotContain("Молоко тестовое")
+                .doesNotContain("молоко");
+    }
+
+    @Test
+    void redirectStopsBeforeSearch() throws Exception {
+        var transport = new QueueTransport().respond(302, "redirect-body-secret");
+        var result = ChizhikPlainHttpProbe.forTransport(transport).runPhaseA("молоко");
+
+        assertThat(result.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.REDIRECTED);
+        assertThat(result.categoriesStatus()).isEqualTo(302);
+        assertThat(result.searchOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.NOT_ATTEMPTED);
+        assertThat(transport.requests()).isEqualTo(1);
+        assertThat(result.toEvidenceLine()).doesNotContain("redirect-body-secret");
+    }
+
+    @Test
+    void blockedAndRateLimitedResponsesRemainExplicit() throws Exception {
+        var blocked = ChizhikPlainHttpProbe.forTransport(new QueueTransport().respond(403, "blocked-secret"))
+                .runPhaseA("молоко");
+        var rateLimited = ChizhikPlainHttpProbe.forTransport(new QueueTransport().respond(429, "rate-secret"))
+                .runPhaseA("молоко");
+
+        assertThat(blocked.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.BLOCKED);
+        assertThat(rateLimited.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.RATE_LIMITED);
+        assertThat(blocked.toEvidenceLine()).doesNotContain("blocked-secret");
+        assertThat(rateLimited.toEvidenceLine()).doesNotContain("rate-secret");
+    }
+
+    @Test
+    void timeoutAndNetworkFailureBecomeSanitizedOutcomes() throws Exception {
+        var timeout = ChizhikPlainHttpProbe.forTransport(new QueueTransport().fail(new HttpTimeoutException("token=secret")))
+                .runPhaseA("молоко");
+        var network = ChizhikPlainHttpProbe.forTransport(new QueueTransport().fail(new IOException("host secret")))
+                .runPhaseA("молоко");
+
+        assertThat(timeout.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.TIMEOUT);
+        assertThat(network.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.NETWORK_ERROR);
+        assertThat(timeout.toEvidenceLine()).doesNotContain("secret");
+        assertThat(network.toEvidenceLine()).doesNotContain("host");
+    }
+
+    @Test
+    void livePhaseAProbeRunsOnlyWhenExplicitlyEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("zakup.live.chizhik"));
+
+        var result = ChizhikPlainHttpProbe.create().runPhaseA("молоко");
+        System.out.println(result.toEvidenceLine());
+
+        assertThat(result.categoriesOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
+        assertThat(result.categoriesShape()).isTrue();
+        assertThat(result.searchOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
+        assertThat(result.productIdPresent()).isTrue();
+        assertThat(result.productTitlePresent()).isTrue();
+        assertThat(result.priceEvidence()).isTrue();
+    }
+
+    private static final class QueueTransport implements ChizhikPlainHttpProbe.Transport {
+        private final Queue<Object> outcomes = new ArrayDeque<>();
+        private int requests;
+
+        QueueTransport respond(int status, String body) {
+            outcomes.add(new ChizhikPlainHttpProbe.ProbeResponse(status, body));
+            return this;
+        }
+
+        QueueTransport fail(IOException exception) {
+            outcomes.add(exception);
+            return this;
+        }
+
+        int requests() {
+            return requests;
+        }
+
+        @Override
+        public ChizhikPlainHttpProbe.ProbeResponse get(URI uri) throws IOException {
+            requests++;
+            var outcome = outcomes.remove();
+            if (outcome instanceof IOException exception) {
+                throw exception;
+            }
+            return (ChizhikPlainHttpProbe.ProbeResponse) outcome;
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPlainHttpProbeTest.java
@@ -140,6 +140,7 @@ class ChizhikPlainHttpProbeTest {
         assertThat(result.categoriesShape()).isTrue();
         assertThat(result.searchOutcome()).isEqualTo(ChizhikPlainHttpProbe.Outcome.ACCESSIBLE);
         assertThat(result.productIdPresent()).isTrue();
+        assertThat(result.productPluPresent()).isTrue();
         assertThat(result.productTitlePresent()).isTrue();
         assertThat(result.priceEvidence()).isTrue();
     }


### PR DESCRIPTION
Implements #155 as a tightly scoped technical-feasibility slice.

## What changed
- added deterministic `ChizhikPlainHttpProbeTest` and test-source probe implementation;
- probes only the publicly observable unauthenticated catalog URLs under `https://app.chizhik.club/api/v1/catalog/unauthorized/...`;
- uses direct `java.net.http.HttpClient` with fixed timeouts, `Redirect.NEVER`, zero retries, and only transparent `Accept` + `User-Agent` headers;
- classifies redirect/block/rate-limit/HTTP/timeout/network outcomes explicitly;
- emits only sanitized response-shape evidence (`id`, `plu`, `title`, price presence), never response bodies or raw identifiers;
- adds an explicit `/provider-probe chizhik` issue-comment path to `Provider Live Probe` for issue #155;
- live execution remains disabled in normal CI.

## TDD evidence
- RED: `da413f26a60f4cb69f305a54438f1f71701641c5` failed API `testCompile` because `ChizhikPlainHttpProbe` intentionally did not exist yet;
- GREEN: implementation added and normal PR CI passed on `d7eb92208cb27714436bae08b1ccfaf51a0ca5df`;
- review hardening: live acceptance now also requires observed `plu` presence; exact-head CI is rerunning on `048d8e9f3ecb30f2594f056ce0d146ba61e63cf2`.

## Explicit non-goals
- no browser emulation, stealth, proxying, captured cookies/tokens, or fingerprint spoofing;
- no production Chizhik provider activation;
- no assertion that technical reachability grants production/right-to-operate permission.

After merge, issue #155 is the controlled trigger/evidence record for the one explicit live Phase A probe.