### PR TITLE
feat(retailer-bridge): add Chizhik Phase B discovery support

### DIFF
--- a/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
@@ -1,0 +1,47 @@
+import type {
+  AdapterResult,
+  RetailerBrowserAdapter,
+} from "./retailer-browser-adapter";
+
+const RETAILER_ID = "chizhik";
+const OFFICIAL_PAGE_HOST = "chizhik.club";
+const PUBLIC_CATALOG_ORIGIN = "https://app.chizhik.club";
+const PUBLIC_CATALOG_PATH = /^\/api\/v1\/catalog\/unauthorized\/(?:categories|products)\/?$/;
+
+function isOfficialPageUrl(url: URL): boolean {
+  return url.protocol === "https:" && url.hostname === OFFICIAL_PAGE_HOST;
+}
+
+function hasObservedPublicCatalogResource(resourceUrls: readonly string[]): boolean {
+  return resourceUrls.some((rawUrl) => {
+    try {
+      const resourceUrl = new URL(rawUrl);
+      return (
+        resourceUrl.origin === PUBLIC_CATALOG_ORIGIN &&
+        PUBLIC_CATALOG_PATH.test(resourceUrl.pathname)
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+export const chizhikBrowserAdapter: RetailerBrowserAdapter = {
+  adapterId: "chizhik-browser-discovery-v1",
+  retailerId: RETAILER_ID,
+
+  supports(url: URL): boolean {
+    return isOfficialPageUrl(url);
+  },
+
+  collect({ resourceUrls = [] }): AdapterResult {
+    if (!hasObservedPublicCatalogResource(resourceUrls)) {
+      return { status: "missing-context", observations: [] };
+    }
+
+    // Phase B is intentionally observation-only: a sanitized catalog pathname proves
+    // browser-side reachability but carries neither a trusted fulfillment context nor
+    // enough product evidence to create an offer observation.
+    return { status: "observation-only", observations: [] };
+  },
+};

--- a/apps/retailer-bridge/src/adapters/retailer-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/retailer-browser-adapter.ts
@@ -2,7 +2,8 @@ export type AdapterFailureStatus =
   | "unsupported-page"
   | "missing-context"
   | "missing-product"
-  | "malformed-state";
+  | "malformed-state"
+  | "observation-only";
 
 export type AdapterResult =
   | { status: "ok"; observations: ReadonlyArray<Record<string, unknown>> }

--- a/apps/retailer-bridge/src/adapters/retailer-browser-adapters.ts
+++ b/apps/retailer-bridge/src/adapters/retailer-browser-adapters.ts
@@ -1,7 +1,9 @@
+import { chizhikBrowserAdapter } from "./chizhik-browser-adapter";
 import { perekrestokBrowserAdapter } from "./perekrestok-browser-adapter";
 import { pyaterochkaBrowserAdapter } from "./pyaterochka-browser-adapter";
 
 export const retailerBrowserAdapters = [
   perekrestokBrowserAdapter,
   pyaterochkaBrowserAdapter,
+  chizhikBrowserAdapter,
 ] as const;

--- a/apps/retailer-bridge/src/collector/browser-observation-collector.ts
+++ b/apps/retailer-bridge/src/collector/browser-observation-collector.ts
@@ -1,4 +1,7 @@
-import type { RetailerBrowserAdapter } from "../adapters/retailer-browser-adapter";
+import type {
+  AdapterFailureStatus,
+  RetailerBrowserAdapter,
+} from "../adapters/retailer-browser-adapter";
 import type {
   BrowserAvailability,
   BrowserObservation,
@@ -6,13 +9,7 @@ import type {
 
 export type ObservationSink = (observations: BrowserObservation[]) => Promise<void>;
 
-export type CollectorStatus =
-  | "ok"
-  | "unsupported-page"
-  | "missing-context"
-  | "missing-product"
-  | "malformed-state"
-  | "invalid-observation";
+export type CollectorStatus = "ok" | AdapterFailureStatus | "invalid-observation";
 
 export type CollectorResult = Readonly<{
   status: CollectorStatus;

--- a/apps/retailer-bridge/src/resource-observation-policy.ts
+++ b/apps/retailer-bridge/src/resource-observation-policy.ts
@@ -3,6 +3,9 @@ const PEREKRESTOK_SHOP_RESOURCE_PATH = /^\/api\/customer\/[^/]+\/shop\/(\d+)\/?$
 const PYATEROCHKA_PAGE_HOSTS = new Set(["5ka.ru", "www.5ka.ru"]);
 const PYATEROCHKA_SERVICE_ORIGIN = "https://5d.5ka.ru";
 const PYATEROCHKA_STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/([A-Za-z0-9_-]+)(?:\/|$)/;
+const CHIZHIK_PAGE_HOST = "chizhik.club";
+const CHIZHIK_CATALOG_ORIGIN = "https://app.chizhik.club";
+const CHIZHIK_PUBLIC_CATALOG_RESOURCE_PATH = /^\/api\/v1\/catalog\/unauthorized\/(?:categories|products)\/?$/;
 
 export type FulfillmentContextResource = Readonly<{
   contextKey: string;
@@ -17,6 +20,10 @@ function isOfficialPyaterochkaPage(pageUrl: URL): boolean {
   return pageUrl.protocol === "https:" && PYATEROCHKA_PAGE_HOSTS.has(pageUrl.hostname);
 }
 
+function isOfficialChizhikPage(pageUrl: URL): boolean {
+  return pageUrl.protocol === "https:" && pageUrl.hostname === CHIZHIK_PAGE_HOST;
+}
+
 export function canonicalObservedResourceUrl(rawUrl: string, pageUrl: URL): string | null {
   try {
     const resourceUrl = new URL(rawUrl, pageUrl);
@@ -29,6 +36,14 @@ export function canonicalObservedResourceUrl(rawUrl: string, pageUrl: URL): stri
       isOfficialPyaterochkaPage(pageUrl) &&
       resourceUrl.origin === PYATEROCHKA_SERVICE_ORIGIN &&
       PYATEROCHKA_STORE_RESOURCE_PATH.test(resourceUrl.pathname)
+    ) {
+      return `${resourceUrl.origin}${resourceUrl.pathname}`;
+    }
+
+    if (
+      isOfficialChizhikPage(pageUrl) &&
+      resourceUrl.origin === CHIZHIK_CATALOG_ORIGIN &&
+      CHIZHIK_PUBLIC_CATALOG_RESOURCE_PATH.test(resourceUrl.pathname)
     ) {
       return `${resourceUrl.origin}${resourceUrl.pathname}`;
     }
@@ -66,6 +81,8 @@ export function fulfillmentContextResource(
         : null;
     }
 
+    // Chizhik Phase B deliberately does not infer fulfillment context from
+    // catalog query parameters because they are stripped before retention.
     return null;
   } catch {
     return null;

--- a/apps/retailer-bridge/static/manifest.json
+++ b/apps/retailer-bridge/static/manifest.json
@@ -12,7 +12,8 @@
       "matches": [
         "https://www.perekrestok.ru/*",
         "https://5ka.ru/*",
-        "https://www.5ka.ru/*"
+        "https://www.5ka.ru/*",
+        "https://chizhik.club/*"
       ],
       "js": ["content.js"],
       "run_at": "document_idle",

--- a/apps/retailer-bridge/test/browser-observation-collector.test.ts
+++ b/apps/retailer-bridge/test/browser-observation-collector.test.ts
@@ -121,22 +121,25 @@ describe("BrowserObservationCollector", () => {
     expect(sink).not.toHaveBeenCalled();
   });
 
-  it("propagates a fail-closed adapter status without persisting data", async () => {
-    const sink = vi.fn();
-    const adapter = {
-      adapterId: "fixture",
-      retailerId: "perekrestok",
-      supports: () => true,
-      collect: () => ({ status: "missing-context", observations: [] }),
-    } as RetailerBrowserAdapter;
+  it.each(["missing-context", "observation-only"] as const)(
+    "propagates fail-closed adapter status %s without persisting data",
+    async (status) => {
+      const sink = vi.fn();
+      const adapter = {
+        adapterId: "fixture",
+        retailerId: "perekrestok",
+        supports: () => true,
+        collect: () => ({ status, observations: [] }),
+      } as RetailerBrowserAdapter;
 
-    const result = await new BrowserObservationCollector([adapter], sink).collect(
-      document.implementation.createHTMLDocument(),
-      new URL("https://www.perekrestok.ru/cat/1"),
-      OBSERVED_AT,
-    );
+      const result = await new BrowserObservationCollector([adapter], sink).collect(
+        document.implementation.createHTMLDocument(),
+        new URL("https://www.perekrestok.ru/cat/1"),
+        OBSERVED_AT,
+      );
 
-    expect(result).toEqual({ status: "missing-context", observationCount: 0 });
-    expect(sink).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({ status, observationCount: 0 });
+      expect(sink).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
+++ b/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { chizhikBrowserAdapter } from "../src/adapters/chizhik-browser-adapter";
+
+const OBSERVED_AT = "2026-08-17T00:15:00Z";
+const PAGE_URL = new URL("https://chizhik.club/deeplink?action_type=to_screen#fragment");
+
+function documentWithGuessedProduct(): Document {
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><body>
+      <article data-product-id="123" data-price="99.99">
+        <a href="/product/123">Guessed product</a>
+        <span>99 ₽</span>
+      </article>
+    </body></html>`,
+    "text/html",
+  );
+}
+
+describe("chizhikBrowserAdapter", () => {
+  it("supports only the explicit official Chizhik HTTPS page origin", () => {
+    expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club/"))).toBe(true);
+    expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club/deeplink"))).toBe(true);
+
+    expect(chizhikBrowserAdapter.supports(new URL("http://chizhik.club/"))).toBe(false);
+    expect(chizhikBrowserAdapter.supports(new URL("https://www.chizhik.club/"))).toBe(false);
+    expect(chizhikBrowserAdapter.supports(new URL("https://app.chizhik.club/"))).toBe(false);
+    expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club.evil.example/"))).toBe(false);
+  });
+
+  it("reports observation-only when a sanitized public catalog resource was browser-observed", () => {
+    expect(
+      chizhikBrowserAdapter.collect({
+        document: documentWithGuessedProduct(),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: [
+          "https://app.chizhik.club/api/v1/catalog/unauthorized/categories/",
+          "https://app.chizhik.club/api/v1/catalog/unauthorized/products/",
+        ],
+      }),
+    ).toEqual({ status: "observation-only", observations: [] });
+  });
+
+  it("does not fabricate offers from guessed DOM fields or unrelated resource URLs", () => {
+    expect(
+      chizhikBrowserAdapter.collect({
+        document: documentWithGuessedProduct(),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: ["https://analytics.example.test/api/v1/catalog/unauthorized/products/"],
+      }),
+    ).toEqual({ status: "missing-context", observations: [] });
+  });
+});

--- a/apps/retailer-bridge/test/manifest-security.test.ts
+++ b/apps/retailer-bridge/test/manifest-security.test.ts
@@ -16,6 +16,7 @@ describe("retailer bridge manifest", () => {
           "https://www.perekrestok.ru/*",
           "https://5ka.ru/*",
           "https://www.5ka.ru/*",
+          "https://chizhik.club/*",
         ],
         js: ["content.js"],
         run_at: "document_idle",

--- a/apps/retailer-bridge/test/resource-observation-policy.test.ts
+++ b/apps/retailer-bridge/test/resource-observation-policy.test.ts
@@ -40,6 +40,42 @@ describe("canonicalObservedResourceUrl", () => {
       ),
     ).toBeNull();
   });
+
+  it("allows only path-only Chizhik unauthorized catalog evidence on an official Chizhik page", () => {
+    const page = new URL("https://chizhik.club/deeplink?action_type=to_screen");
+
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/api/v1/catalog/unauthorized/categories/?store=SECRET#fragment",
+        page,
+      ),
+    ).toBe("https://app.chizhik.club/api/v1/catalog/unauthorized/categories/");
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/api/v1/catalog/unauthorized/products/?lat=SECRET&lon=SECRET",
+        page,
+      ),
+    ).toBe("https://app.chizhik.club/api/v1/catalog/unauthorized/products/");
+
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/api/v1/profile/me",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/api/v1/catalog/unauthorized/products/",
+        new URL("https://chizhik.club.evil.example/"),
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club.evil.example/api/v1/catalog/unauthorized/products/",
+        page,
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("fulfillmentContextResource", () => {
@@ -74,6 +110,17 @@ describe("fulfillmentContextResource", () => {
     });
     expect(
       fulfillmentContextResource("https://5d.5ka.ru/api/profile/v1/me", page),
+    ).toBeNull();
+  });
+
+  it("does not promote Chizhik catalog resource paths into a guessed fulfillment context", () => {
+    const page = new URL("https://chizhik.club/");
+
+    expect(
+      fulfillmentContextResource(
+        "https://app.chizhik.club/api/v1/catalog/unauthorized/products/?store=SECRET",
+        page,
+      ),
     ).toBeNull();
   });
 });

--- a/apps/retailer-bridge/test/retailer-browser-adapters.test.ts
+++ b/apps/retailer-bridge/test/retailer-browser-adapters.test.ts
@@ -6,6 +6,7 @@ describe("retailerBrowserAdapters", () => {
     expect(retailerBrowserAdapters.map((adapter) => adapter.retailerId)).toEqual([
       "perekrestok",
       "pyaterochka",
+      "chizhik",
     ]);
 
     expect(new Set(retailerBrowserAdapters.map((adapter) => adapter.retailerId)).size).toBe(


### PR DESCRIPTION
Implements the code portion of #157. Keep #157 open until the manual user-controlled browser canary is recorded.

## What changed
- registers an exact-origin `chizhik.club` browser adapter;
- adds an explicit `observation-only` fail-closed status for discovery evidence that must never persist as an offer;
- allow-lists only the known unauthenticated Chizhik catalog `categories` / `products` resource paths from `app.chizhik.club` when observed from the official page;
- strips query strings and fragments before those resource names reach the adapter;
- does not infer a fulfillment context from stripped parameters;
- ignores guessed DOM product/price fields and emits zero observations;
- extends the content-script match only to `https://chizhik.club/*` while keeping `host_permissions` empty.

## TDD evidence
- RED head `bf678bddb4f32f6a0c7e66c56d3a84bb6a94b066`: Retailer Bridge CI failed exactly because Chizhik was not registered, its catalog resource path was not allow-listed, and the manifest did not include the official origin.
- First GREEN tests passed, then typecheck exposed a duplicated `CollectorStatus` union. The collector now derives failure states from `AdapterFailureStatus`, and coverage explicitly proves `observation-only` never reaches the persistence sink.

## Non-goals
No production activation, response-body parsing, credential/session capture, API replay, or inferred product economics. A manual user-controlled browser canary remains required before moving beyond discovery.