### PR TITLE
ci(bridge): publish verified canary artifact from main

### DIFF
--- a/.github/workflows/retailer-bridge-ci.yml
+++ b/.github/workflows/retailer-bridge-ci.yml
@@ -49,3 +49,12 @@ jobs:
 
       - name: Run bridge Chromium E2E
         run: pnpm --dir apps/retailer-bridge test:e2e
+
+      - name: Upload verified bridge artifact
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: retailer-bridge-${{ github.sha }}
+          path: apps/retailer-bridge/dist
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/retailer-bridge/test/ci-artifact-contract.test.ts
+++ b/apps/retailer-bridge/test/ci-artifact-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const workflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/retailer-bridge-ci.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+
+describe("Retailer Bridge CI canary artifact", () => {
+  it("uploads the verified dist only after Chromium E2E on trusted main pushes", () => {
+    const e2eStep = workflow.indexOf("- name: Run bridge Chromium E2E");
+    const uploadStep = workflow.indexOf("- name: Upload verified bridge artifact");
+
+    expect(e2eStep).toBeGreaterThanOrEqual(0);
+    expect(uploadStep).toBeGreaterThan(e2eStep);
+    expect(workflow).toContain(
+      "if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
+    );
+    expect(workflow).toContain(
+      "uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4",
+    );
+    expect(workflow).toContain("name: retailer-bridge-${{ github.sha }}");
+    expect(workflow).toContain("path: apps/retailer-bridge/dist");
+    expect(workflow).toContain("if-no-files-found: error");
+    expect(workflow).toContain("retention-days: 14");
+  });
+
+  it("does not widen workflow permissions for artifact publication", () => {
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(workflow).not.toMatch(/(?:actions|contents|packages|id-token):\s*write/);
+  });
+});


### PR DESCRIPTION
Implements #159.

## What changed
- uploads the already-built `apps/retailer-bridge/dist` only after bridge Chromium E2E succeeds;
- publication is gated to trusted `push` events on `refs/heads/main` only;
- artifact name includes the exact `github.sha`;
- official `actions/upload-artifact` is pinned to commit `ea165f8d65b6e75b540449e92b4886f43607fa02` (current `v4` ref at implementation time);
- missing `dist` is an error and retention is 14 days;
- workflow permissions remain `contents: read` only.

## TDD evidence
- RED head `41718e15099555a84b600be1da1e5195db491e77`: Retailer Bridge CI failed exactly because the required upload step was absent.
- GREEN head `341a64b200b3f207d487f3b0ef69be7e13999fcd`: bridge unit tests, contract test, typecheck, build and Chromium E2E pass; artifact publication is correctly skipped on the pull_request event.

The final acceptance step after merge is to verify that the exact `main` merge commit produces the named artifact and then update Chizhik #157 canary instructions to consume it.