### PR TITLE
feat(provider): add Chizhik Phase C public catalog probe

### DIFF
--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentObservation.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentObservation.java
@@ -1,0 +1,28 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Objects;
+
+public record ChizhikPublicCatalogDocumentObservation(
+        ChizhikPublicCatalogDocumentStatus status,
+        URI uri,
+        String path,
+        int httpStatus,
+        String contentType,
+        Instant observedAt) {
+
+    public ChizhikPublicCatalogDocumentObservation {
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(uri, "uri");
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(contentType, "contentType");
+        Objects.requireNonNull(observedAt, "observedAt");
+        if (path.isBlank()) {
+            throw new IllegalArgumentException("path must not be blank");
+        }
+        if (httpStatus < 100 || httpStatus > 599) {
+            throw new IllegalArgumentException("httpStatus must be an HTTP status");
+        }
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentProbe.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentProbe.java
@@ -1,0 +1,106 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.net.URI;
+import java.time.Clock;
+import java.util.Locale;
+import java.util.Objects;
+
+/** Explicit opt-in probe for public Chizhik catalog documents. */
+public final class ChizhikPublicCatalogDocumentProbe {
+
+    private static final int DEFAULT_MAX_REDIRECTS = 3;
+
+    private final ChizhikPublicCatalogDocumentTransport transport;
+    private final Clock clock;
+    private final int maxRedirects;
+
+    ChizhikPublicCatalogDocumentProbe(
+            ChizhikPublicCatalogDocumentTransport transport,
+            Clock clock,
+            int maxRedirects) {
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.clock = Objects.requireNonNull(clock, "clock");
+        if (maxRedirects < 0) {
+            throw new IllegalArgumentException("maxRedirects must be non-negative");
+        }
+        this.maxRedirects = maxRedirects;
+    }
+
+    public static ChizhikPublicCatalogDocumentProbe live() {
+        return new ChizhikPublicCatalogDocumentProbe(
+                ChizhikPublicCatalogHttpTransport.create(),
+                Clock.systemUTC(),
+                DEFAULT_MAX_REDIRECTS);
+    }
+
+    public ChizhikPublicCatalogDocumentObservation probe(URI candidate) {
+        var current = ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(candidate);
+        var redirectsFollowed = 0;
+
+        while (true) {
+            var response = Objects.requireNonNull(transport.head(current), "transport response");
+            var contentType = normalizeContentType(response.contentType());
+
+            if (isRedirect(response.statusCode()) && response.redirectLocation() != null) {
+                if (redirectsFollowed >= maxRedirects) {
+                    return observation(
+                            ChizhikPublicCatalogDocumentStatus.REDIRECT_LIMIT_EXCEEDED,
+                            current,
+                            response,
+                            contentType);
+                }
+                var target = current.resolve(response.redirectLocation());
+                current = ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(target);
+                redirectsFollowed++;
+                continue;
+            }
+
+            if (response.statusCode() != 200) {
+                return observation(
+                        ChizhikPublicCatalogDocumentStatus.HTTP_UNAVAILABLE,
+                        current,
+                        response,
+                        contentType);
+            }
+            if (!"application/pdf".equals(contentType)) {
+                return observation(
+                        ChizhikPublicCatalogDocumentStatus.UNEXPECTED_CONTENT_TYPE,
+                        current,
+                        response,
+                        contentType);
+            }
+            return observation(
+                    ChizhikPublicCatalogDocumentStatus.REACHABLE_PDF,
+                    current,
+                    response,
+                    contentType);
+        }
+    }
+
+    private ChizhikPublicCatalogDocumentObservation observation(
+            ChizhikPublicCatalogDocumentStatus status,
+            URI uri,
+            ChizhikPublicCatalogDocumentResponse response,
+            String contentType) {
+        return new ChizhikPublicCatalogDocumentObservation(
+                status,
+                uri,
+                uri.getPath(),
+                response.statusCode(),
+                contentType,
+                clock.instant());
+    }
+
+    private static boolean isRedirect(int statusCode) {
+        return statusCode >= 300 && statusCode <= 399;
+    }
+
+    private static String normalizeContentType(String rawContentType) {
+        if (rawContentType == null || rawContentType.isBlank()) {
+            return "";
+        }
+        var separator = rawContentType.indexOf(';');
+        var mediaType = separator >= 0 ? rawContentType.substring(0, separator) : rawContentType;
+        return mediaType.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentResponse.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentResponse.java
@@ -1,0 +1,16 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.net.URI;
+
+record ChizhikPublicCatalogDocumentResponse(
+        int statusCode,
+        String contentType,
+        URI redirectLocation) {
+
+    ChizhikPublicCatalogDocumentResponse {
+        if (statusCode < 100 || statusCode > 599) {
+            throw new IllegalArgumentException("statusCode must be an HTTP status");
+        }
+        contentType = contentType == null ? "" : contentType.trim();
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentStatus.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentStatus.java
@@ -1,0 +1,8 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+public enum ChizhikPublicCatalogDocumentStatus {
+    REACHABLE_PDF,
+    HTTP_UNAVAILABLE,
+    UNEXPECTED_CONTENT_TYPE,
+    REDIRECT_LIMIT_EXCEEDED
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentTransport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentTransport.java
@@ -1,0 +1,7 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.net.URI;
+
+interface ChizhikPublicCatalogDocumentTransport {
+    ChizhikPublicCatalogDocumentResponse head(URI uri);
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentUriPolicy.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentUriPolicy.java
@@ -1,0 +1,59 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class ChizhikPublicCatalogDocumentUriPolicy {
+
+    private static final String HOST = "media.chizhik.club";
+    private static final String PATH_PREFIX = "/media/backendprod-dpro/catalog/pdf_file/";
+
+    private ChizhikPublicCatalogDocumentUriPolicy() {}
+
+    public static URI requireAllowed(URI candidate) {
+        Objects.requireNonNull(candidate, "candidate");
+
+        if (!"https".equalsIgnoreCase(candidate.getScheme())) {
+            throw rejected();
+        }
+        if (candidate.getHost() == null || !HOST.equalsIgnoreCase(candidate.getHost())) {
+            throw rejected();
+        }
+        if (candidate.getPort() != -1 && candidate.getPort() != 443) {
+            throw rejected();
+        }
+        if (candidate.getRawUserInfo() != null || candidate.getRawQuery() != null || candidate.getRawFragment() != null) {
+            throw rejected();
+        }
+
+        var rawPath = candidate.getRawPath();
+        if (rawPath == null || !rawPath.startsWith(PATH_PREFIX)) {
+            throw rejected();
+        }
+
+        var normalizedPath = candidate.normalize().getRawPath();
+        if (!rawPath.equals(normalizedPath)) {
+            throw rejected();
+        }
+
+        var lowerPath = rawPath.toLowerCase(Locale.ROOT);
+        var fileName = rawPath.substring(PATH_PREFIX.length());
+        var lowerFileName = fileName.toLowerCase(Locale.ROOT);
+        if (fileName.isBlank()
+                || fileName.contains("/")
+                || fileName.contains("\\")
+                || lowerFileName.contains("%2e")
+                || lowerFileName.contains("%2f")
+                || lowerFileName.contains("%5c")
+                || !lowerPath.endsWith(".pdf")) {
+            throw rejected();
+        }
+
+        return candidate;
+    }
+
+    private static IllegalArgumentException rejected() {
+        return new IllegalArgumentException("URI is outside the allowed Chizhik public catalog document scope");
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogHttpTransport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogHttpTransport.java
@@ -1,0 +1,52 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+final class ChizhikPublicCatalogHttpTransport implements ChizhikPublicCatalogDocumentTransport {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final HttpClient client;
+
+    private ChizhikPublicCatalogHttpTransport(HttpClient client) {
+        this.client = client;
+    }
+
+    static ChizhikPublicCatalogHttpTransport create() {
+        return new ChizhikPublicCatalogHttpTransport(HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
+    }
+
+    @Override
+    public ChizhikPublicCatalogDocumentResponse head(URI uri) {
+        var request = HttpRequest.newBuilder(uri)
+                .timeout(REQUEST_TIMEOUT)
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+        try {
+            var response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            var contentType = response.headers().firstValue("Content-Type").orElse("");
+            var redirectLocation = response.headers()
+                    .firstValue("Location")
+                    .map(URI::create)
+                    .orElse(null);
+            return new ChizhikPublicCatalogDocumentResponse(
+                    response.statusCode(),
+                    contentType,
+                    redirectLocation);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Chizhik public catalog document request failed", exception);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Chizhik public catalog document request was interrupted", exception);
+        }
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentProbeTest.java
@@ -1,0 +1,144 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ChizhikPublicCatalogDocumentProbeTest {
+
+    private static final URI DOCUMENT = URI.create(
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf");
+    private static final Instant OBSERVED_AT = Instant.parse("2026-08-17T16:45:00Z");
+    private static final Clock CLOCK = Clock.fixed(OBSERVED_AT, ZoneOffset.UTC);
+
+    @Test
+    void acceptsOnlyExactOfficialPublicCatalogPdfScope() {
+        assertThat(ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(DOCUMENT)).isEqualTo(DOCUMENT);
+        assertThat(ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(URI.create(
+                "https://media.chizhik.club:443/media/backendprod-dpro/catalog/pdf_file/CATALOG.PDF")))
+                .isEqualTo(URI.create(
+                        "https://media.chizhik.club:443/media/backendprod-dpro/catalog/pdf_file/CATALOG.PDF"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://app.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://media.chizhik.club.evil.example/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://media.chizhik.club:8443/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://user@media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf?store=secret",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.pdf#fragment",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/other/catalog.pdf",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/catalog.html",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/../secret.pdf",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/%2e%2e/secret.pdf",
+            "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/%2Fsecret.pdf"
+    })
+    void rejectsUrisOutsideNarrowPublicDocumentScope(String candidate) {
+        assertThatThrownBy(() -> ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(URI.create(candidate)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void recordsReachablePdfWithoutReadingABody() {
+        var transport = new FakeTransport(new ChizhikPublicCatalogDocumentResponse(200, "Application/PDF; charset=binary", null));
+        var probe = new ChizhikPublicCatalogDocumentProbe(transport, CLOCK, 3);
+
+        var observation = probe.probe(DOCUMENT);
+
+        assertThat(observation.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.REACHABLE_PDF);
+        assertThat(observation.uri()).isEqualTo(DOCUMENT);
+        assertThat(observation.path()).isEqualTo("/media/backendprod-dpro/catalog/pdf_file/catalog.pdf");
+        assertThat(observation.httpStatus()).isEqualTo(200);
+        assertThat(observation.contentType()).isEqualTo("application/pdf");
+        assertThat(observation.observedAt()).isEqualTo(OBSERVED_AT);
+        assertThat(transport.requested()).containsExactly(DOCUMENT);
+    }
+
+    @Test
+    void keepsNonPdfAndHttpFailuresTruthful() {
+        var nonPdf = new ChizhikPublicCatalogDocumentProbe(
+                new FakeTransport(new ChizhikPublicCatalogDocumentResponse(200, "text/html", null)), CLOCK, 3)
+                .probe(DOCUMENT);
+        assertThat(nonPdf.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.UNEXPECTED_CONTENT_TYPE);
+        assertThat(nonPdf.contentType()).isEqualTo("text/html");
+
+        var unavailable = new ChizhikPublicCatalogDocumentProbe(
+                new FakeTransport(new ChizhikPublicCatalogDocumentResponse(403, "text/html", null)), CLOCK, 3)
+                .probe(DOCUMENT);
+        assertThat(unavailable.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.HTTP_UNAVAILABLE);
+        assertThat(unavailable.httpStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void followsOnlyBoundedRedirectsWithinTheSamePublicScope() {
+        var redirected = URI.create(
+                "https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/redirected.pdf");
+        var transport = new FakeTransport(
+                new ChizhikPublicCatalogDocumentResponse(302, "", redirected),
+                new ChizhikPublicCatalogDocumentResponse(200, "application/pdf", null));
+
+        var observation = new ChizhikPublicCatalogDocumentProbe(transport, CLOCK, 3).probe(DOCUMENT);
+
+        assertThat(observation.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.REACHABLE_PDF);
+        assertThat(observation.uri()).isEqualTo(redirected);
+        assertThat(transport.requested()).containsExactly(DOCUMENT, redirected);
+    }
+
+    @Test
+    void rejectsRedirectThatLeavesOfficialPublicScopeBeforeFollowingIt() {
+        var transport = new FakeTransport(new ChizhikPublicCatalogDocumentResponse(
+                302,
+                "",
+                URI.create("https://example.com/catalog.pdf")));
+
+        assertThatThrownBy(() -> new ChizhikPublicCatalogDocumentProbe(transport, CLOCK, 3).probe(DOCUMENT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(transport.requested()).containsExactly(DOCUMENT);
+    }
+
+    @Test
+    void stopsAfterConfiguredRedirectLimit() {
+        var next = URI.create("https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/next.pdf");
+        var transport = new FakeTransport(
+                new ChizhikPublicCatalogDocumentResponse(302, "", next),
+                new ChizhikPublicCatalogDocumentResponse(302, "", DOCUMENT));
+
+        var observation = new ChizhikPublicCatalogDocumentProbe(transport, CLOCK, 1).probe(DOCUMENT);
+
+        assertThat(observation.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.REDIRECT_LIMIT_EXCEEDED);
+        assertThat(transport.requested()).containsExactly(DOCUMENT, next);
+    }
+
+    private static final class FakeTransport implements ChizhikPublicCatalogDocumentTransport {
+        private final Deque<ChizhikPublicCatalogDocumentResponse> responses = new ArrayDeque<>();
+        private final List<URI> requested = new ArrayList<>();
+
+        private FakeTransport(ChizhikPublicCatalogDocumentResponse... responses) {
+            this.responses.addAll(List.of(responses));
+        }
+
+        @Override
+        public ChizhikPublicCatalogDocumentResponse head(URI uri) {
+            requested.add(uri);
+            return responses.removeFirst();
+        }
+
+        private List<URI> requested() {
+            return List.copyOf(requested);
+        }
+    }
+}


### PR DESCRIPTION
Implements #163.

## What changed
- adds an explicit-live Chizhik public catalog document probe that is intentionally separate from `ProviderLiveProbe.search()` / `ObservedOffer` semantics;
- accepts only exact HTTPS `media.chizhik.club` catalog PDF paths on the default port;
- rejects user-info, query, fragment, lookalike hosts, alternate subdomains, non-default ports and traversal/encoded-separator candidates;
- follows only bounded redirects and validates every redirect target against the same URI policy before issuing the next request;
- production transport uses JDK `HttpClient` with redirects disabled, finite timeouts and `HEAD` + `BodyHandlers.discarding()`; no cookies, Authorization, body parsing or header imitation are added;
- distinguishes `REACHABLE_PDF`, `HTTP_UNAVAILABLE`, `UNEXPECTED_CONTENT_TYPE` and `REDIRECT_LIMIT_EXCEEDED` without inventing product/price evidence;
- retained observation contains only sanitized URI/path, HTTP status, normalized content type and observation time.

## TDD evidence
- RED head `649175dac2b3678769d534cbce71e5758a604523`: API CI run `32046645228` failed at test compilation only on the intentionally absent Phase C symbols (`cannot find symbol`).
- GREEN head `c3af3e8555db660528e98d525af22d92f5ca5aaa`: API CI and all other required workflow groups pass; deterministic fake-transport tests cover exact URI scope, 200 PDF, non-PDF, HTTP failure, bounded redirect, redirect escape rejection and redirect-limit behavior.
- exact GREEN head: 9/9 pull-request workflow groups SUCCESS, 0 failures.

## Review boundary
This PR proves a safe document-level probe only. It does not parse PDFs, create SKUs/offers, provide fulfillment context, alter comparison behavior or activate Chizhik in production. A separately accepted source contract is still required before Chizhik can count as product/price connectivity.