### PR TITLE
ci(provider): wire Chizhik Phase C live probe

### DIFF
--- a/.github/workflows/provider-live-probe-chizhik-catalog.yml
+++ b/.github/workflows/provider-live-probe-chizhik-catalog.yml
@@ -1,0 +1,113 @@
+name: Provider Live Probe / Chizhik Phase C
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: provider-live-probe-chizhik-catalog-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  chizhik_catalog:
+    name: Chizhik Public Catalog Phase C
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 163 &&
+      github.actor == 'True-Ruslan' &&
+      github.event.comment.body == '/provider-probe chizhik-catalog'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: apps/api/pom.xml
+
+      - name: Verify pinned toolchain
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | grep -Eq 'version "25([.\"])'
+          ./mvnw --version | grep -F 'Apache Maven 3.9.16'
+
+      - name: Run Chizhik public catalog Phase C
+        working-directory: apps/api
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          ./mvnw --batch-mode --no-transfer-progress \
+            -Dtest=ChizhikPublicCatalogDocumentLiveProbeTest \
+            -Dzakup.live.chizhik.catalog=true \
+            '-Dzakup.live.chizhik.catalog.url=https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/%D0%BA%D0%B0%D1%82%D0%B0%D0%BB%D0%BE%D0%B3_CHIZHIK_2125_mobile_.pdf' \
+            test 2>&1 | tee "$RUNNER_TEMP/chizhik-phase-c-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Chizhik public catalog Phase C' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/chizhik-phase-c-live-probe.log" ]]; then
+            evidence="$(grep -F 'CHIZHIK_PHASE_C' "$RUNNER_TEMP/chizhik-phase-c-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='CHIZHIK_PHASE_C no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            status="$(sed -n 's/.*status=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            http_status="$(sed -n 's/.*http_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            content_type="$(sed -n 's/.*content_type=\([^ ]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$status" == 'REACHABLE_PDF' \
+               && "$http_status" == '200' \
+               && "$content_type" == 'application/pdf' ]]; then
+              state='success'
+              outcome='pass'
+            elif [[ "$status" == 'HTTP_UNAVAILABLE' ]]; then
+              outcome="http-${http_status:-unknown}"
+            elif [[ "$status" == 'UNEXPECTED_CONTENT_TYPE' ]]; then
+              outcome='content-type'
+            elif [[ "$status" == 'REDIRECT_LIMIT_EXCEEDED' ]]; then
+              outcome='redirect-limit'
+            elif [[ "$status" == 'TRANSPORT_ERROR' ]]; then
+              outcome='transport-error'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Phase C evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Chizhik Phase C / ${outcome}"
+          description="${description:0:140}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$state" \
+            -f context="$context" \
+            -f description="$description" >/dev/null

--- a/.github/workflows/provider-live-probe-chizhik-catalog.yml
+++ b/.github/workflows/provider-live-probe-chizhik-catalog.yml
@@ -79,9 +79,9 @@ jobs:
             description="$evidence"
             printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
 
-            status="$(sed -n 's/.*status=\([^ ]*\).*/\1/p' <<<"$evidence")"
-            http_status="$(sed -n 's/.*http_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
-            content_type="$(sed -n 's/.*content_type=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            status="$(sed -n 's/^CHIZHIK_PHASE_C status=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            http_status="$(sed -n 's/.* http_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            content_type="$(sed -n 's/.* content_type=\([^ ]*\).*/\1/p' <<<"$evidence")"
 
             if [[ "$status" == 'REACHABLE_PDF' \
                && "$http_status" == '200' \

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
@@ -1,0 +1,42 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class ChizhikPublicCatalogDocumentLiveProbeTest {
+
+    @Test
+    void probesOnlyWhenExplicitlyEnabledAndEmitsSanitizedEvidence() {
+        assumeTrue(Boolean.getBoolean("zakup.live.chizhik.catalog"));
+
+        var rawCandidate = System.getProperty("zakup.live.chizhik.catalog.url", "").trim();
+        assertThat(rawCandidate).isNotBlank();
+        var candidate = ChizhikPublicCatalogDocumentUriPolicy.requireAllowed(URI.create(rawCandidate));
+
+        ChizhikPublicCatalogDocumentObservation observation;
+        try {
+            observation = ChizhikPublicCatalogDocumentProbe.live().probe(candidate);
+        } catch (RuntimeException exception) {
+            System.out.println("CHIZHIK_PHASE_C status=TRANSPORT_ERROR");
+            fail("Chizhik Phase C live probe transport failed");
+            return;
+        }
+
+        var contentType = observation.contentType().isBlank() ? "none" : observation.contentType();
+        System.out.printf(
+                "CHIZHIK_PHASE_C status=%s http_status=%d content_type=%s path=%s observed_at=%s%n",
+                observation.status(),
+                observation.httpStatus(),
+                contentType,
+                observation.path(),
+                observation.observedAt());
+
+        assertThat(observation.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.REACHABLE_PDF);
+        assertThat(observation.httpStatus()).isEqualTo(200);
+        assertThat(observation.contentType()).isEqualTo("application/pdf");
+    }
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
@@ -35,8 +35,7 @@ class ChizhikPublicCatalogDocumentLiveProbeTest {
                 observation.path(),
                 observation.observedAt());
 
-        assertThat(observation.status()).isEqualTo(ChizhikPublicCatalogDocumentStatus.REACHABLE_PDF);
-        assertThat(observation.httpStatus()).isEqualTo(200);
-        assertThat(observation.contentType()).isEqualTo("application/pdf");
+        assertThat(observation.uri().getHost()).isEqualTo("media.chizhik.club");
+        assertThat(observation.path()).startsWith("/media/backendprod-dpro/catalog/pdf_file/");
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
@@ -34,6 +34,14 @@ class ChizhikPublicCatalogLiveProbeWorkflowContractTest {
         assertThat(WORKFLOW).doesNotContain("Cookie");
     }
 
+    @Test
+    void parsesStatusWithoutConfusingItWithHttpStatus() {
+        assertThat(WORKFLOW).contains(
+                "status=\"$(sed -n 's/^CHIZHIK_PHASE_C status=\\([^ ]*\\).*/\\1/p' <<<\"$evidence\")\"");
+        assertThat(WORKFLOW).contains(
+                "http_status=\"$(sed -n 's/.* http_status=\\([-0-9]*\\).*/\\1/p' <<<\"$evidence\")\"");
+    }
+
     private static String readWorkflow() {
         Path workflow = Path.of("..", "..", ".github", "workflows", "provider-live-probe-chizhik-catalog.yml").normalize();
         try {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
@@ -12,7 +12,7 @@ class ChizhikPublicCatalogLiveProbeWorkflowContractTest {
     private static final String WORKFLOW = readWorkflow();
 
     @Test
-    void routesPhaseCThroughExistingOptInProviderProbeWorkflow() {
+    void routesPhaseCThroughOptInProviderProbeMechanism() {
         assertThat(WORKFLOW).contains("  chizhik_catalog:");
         assertThat(WORKFLOW).contains("github.event.issue.number == 163");
         assertThat(WORKFLOW).contains("github.actor == 'True-Ruslan'");
@@ -30,14 +30,16 @@ class ChizhikPublicCatalogLiveProbeWorkflowContractTest {
         assertThat(WORKFLOW).contains("contents: read");
         assertThat(WORKFLOW).contains("statuses: write");
         assertThat(WORKFLOW).doesNotContain("secrets:");
+        assertThat(WORKFLOW).doesNotContain("Authorization");
+        assertThat(WORKFLOW).doesNotContain("Cookie");
     }
 
     private static String readWorkflow() {
-        Path workflow = Path.of("..", "..", ".github", "workflows", "provider-live-probe.yml").normalize();
+        Path workflow = Path.of("..", "..", ".github", "workflows", "provider-live-probe-chizhik-catalog.yml").normalize();
         try {
             return Files.readString(workflow);
         } catch (IOException exception) {
-            throw new IllegalStateException("Unable to read provider live probe workflow", exception);
+            throw new IllegalStateException("Unable to read Chizhik Phase C provider live probe workflow", exception);
         }
     }
 }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
@@ -1,0 +1,43 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ChizhikPublicCatalogLiveProbeWorkflowContractTest {
+
+    private static final String WORKFLOW = readWorkflow();
+
+    @Test
+    void routesPhaseCThroughExistingOptInProviderProbeWorkflow() {
+        assertThat(WORKFLOW).contains("  chizhik_catalog:");
+        assertThat(WORKFLOW).contains("github.event.issue.number == 163");
+        assertThat(WORKFLOW).contains("github.actor == 'True-Ruslan'");
+        assertThat(WORKFLOW).contains("github.event.comment.body == '/provider-probe chizhik-catalog'");
+        assertThat(WORKFLOW).contains("-Dtest=ChizhikPublicCatalogDocumentLiveProbeTest");
+        assertThat(WORKFLOW).contains("-Dzakup.live.chizhik.catalog=true");
+        assertThat(WORKFLOW).contains("CHIZHIK_PHASE_C");
+        assertThat(WORKFLOW).contains("Provider Live Probe / Chizhik Phase C / ${outcome}");
+    }
+
+    @Test
+    void keepsThePhaseCCandidateAndPermissionsNarrow() {
+        assertThat(WORKFLOW).contains(
+                "-Dzakup.live.chizhik.catalog.url=https://media.chizhik.club/media/backendprod-dpro/catalog/pdf_file/");
+        assertThat(WORKFLOW).contains("contents: read");
+        assertThat(WORKFLOW).contains("statuses: write");
+        assertThat(WORKFLOW).doesNotContain("secrets:");
+    }
+
+    private static String readWorkflow() {
+        Path workflow = Path.of("..", "..", ".github", "workflows", "provider-live-probe.yml").normalize();
+        try {
+            return Files.readString(workflow);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Unable to read provider live probe workflow", exception);
+        }
+    }
+}


### PR DESCRIPTION
Extends #163.

## What changed
- adds a sibling issue-comment live workflow dedicated to Chizhik Phase C instead of widening the existing multi-retailer probe workflow;
- trigger is exact: issue #163, actor `True-Ruslan`, comment `/provider-probe chizhik-catalog`;
- workflow permissions remain only `contents: read` and `statuses: write`; no secrets are introduced;
- uses the accepted body-less Phase C probe against one fixed search-discovered official `media.chizhik.club` historical catalog PDF candidate;
- ordinary CI does not issue the live request; the JUnit live probe is assumption-gated behind `-Dzakup.live.chizhik.catalog=true`;
- valid negative HTTP evidence such as 403/non-PDF remains a successful measurement and emits a sanitized `CHIZHIK_PHASE_C` line; transport failure remains explicit;
- sanitized evidence is projected to a commit status without response bodies, cookies, Authorization, session state or private headers.

## TDD evidence
- initial RED head `ad7ad6ab848ea6722fc072a4578767eb42226f9c`: API verification ran 500 tests and only the two new workflow-contract assertions failed because the Phase C live workflow did not yet exist;
- review discovered an evidence-parser ambiguity where greedy `status=` parsing could consume `http_status=403`;
- regression RED head `bb464ccffe868e4fdf41a5310c72306da0f652a3`: API CI failed after locking an unambiguous parser contract;
- current GREEN head `b52bc4e332acbb1e4d5f733f2fc2d1294ce79fc2` anchors `status` to the `CHIZHIK_PHASE_C` prefix and parses `http_status` as a separate field.

## Boundary
This workflow proves only reproducible live document reachability evidence. It does not parse PDF bodies, create product/price offers, alter comparison behavior, use protected APIs or activate Chizhik in production.