### PR TITLE
fix(provider): harden Chizhik Phase C live evidence

### DIFF
--- a/.github/workflows/provider-live-probe-chizhik-catalog.yml
+++ b/.github/workflows/provider-live-probe-chizhik-catalog.yml
@@ -105,9 +105,24 @@ jobs:
 
           context="Provider Live Probe / Chizhik Phase C / ${outcome}"
           description="${description:0:140}"
-          gh api \
-            --method POST \
-            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-            -f state="$state" \
-            -f context="$context" \
-            -f description="$description" >/dev/null
+
+          published='false'
+          for attempt in 1 2 3; do
+            if gh api \
+                --method POST \
+                "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+                -f state="$state" \
+                -f context="$context" \
+                -f description="$description" >/dev/null; then
+              published='true'
+              break
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 2))
+            fi
+          done
+
+          if [[ "$published" != 'true' ]]; then
+            echo 'Commit-status publication failed after 3 attempts.' >> "$GITHUB_STEP_SUMMARY"
+            echo '::warning::Unable to publish Phase C commit status after retries'
+          fi

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogHttpTransport.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogHttpTransport.java
@@ -43,10 +43,12 @@ final class ChizhikPublicCatalogHttpTransport implements ChizhikPublicCatalogDoc
                     contentType,
                     redirectLocation);
         } catch (IOException exception) {
-            throw new IllegalStateException("Chizhik public catalog document request failed", exception);
+            throw new ChizhikPublicCatalogTransportException(
+                    ChizhikPublicCatalogTransportException.classify(exception), exception);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("Chizhik public catalog document request was interrupted", exception);
+            throw new ChizhikPublicCatalogTransportException(
+                    ChizhikPublicCatalogTransportFailureKind.INTERRUPTED, exception);
         }
     }
 }

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportException.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportException.java
@@ -1,0 +1,54 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.net.http.HttpTimeoutException;
+import java.util.Objects;
+import javax.net.ssl.SSLException;
+
+final class ChizhikPublicCatalogTransportException extends IllegalStateException {
+
+    private final ChizhikPublicCatalogTransportFailureKind failureKind;
+
+    ChizhikPublicCatalogTransportException(
+            ChizhikPublicCatalogTransportFailureKind failureKind,
+            Throwable cause) {
+        super("Chizhik public catalog transport failed", cause);
+        this.failureKind = Objects.requireNonNull(failureKind, "failureKind");
+    }
+
+    ChizhikPublicCatalogTransportFailureKind failureKind() {
+        return failureKind;
+    }
+
+    static ChizhikPublicCatalogTransportFailureKind classify(Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable");
+
+        for (var current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof UnknownHostException) {
+                return ChizhikPublicCatalogTransportFailureKind.DNS;
+            }
+            if (current instanceof HttpTimeoutException) {
+                return ChizhikPublicCatalogTransportFailureKind.TIMEOUT;
+            }
+            if (current instanceof SSLException) {
+                return ChizhikPublicCatalogTransportFailureKind.TLS;
+            }
+            if (current instanceof ConnectException) {
+                return ChizhikPublicCatalogTransportFailureKind.CONNECT;
+            }
+            if (current instanceof InterruptedException) {
+                return ChizhikPublicCatalogTransportFailureKind.INTERRUPTED;
+            }
+        }
+
+        for (var current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof IOException) {
+                return ChizhikPublicCatalogTransportFailureKind.IO;
+            }
+        }
+
+        return ChizhikPublicCatalogTransportFailureKind.IO;
+    }
+}

--- a/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportFailureKind.java
+++ b/apps/api/src/main/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportFailureKind.java
@@ -1,0 +1,10 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+enum ChizhikPublicCatalogTransportFailureKind {
+    DNS,
+    CONNECT,
+    TIMEOUT,
+    TLS,
+    IO,
+    INTERRUPTED
+}

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogDocumentLiveProbeTest.java
@@ -20,8 +20,10 @@ class ChizhikPublicCatalogDocumentLiveProbeTest {
         ChizhikPublicCatalogDocumentObservation observation;
         try {
             observation = ChizhikPublicCatalogDocumentProbe.live().probe(candidate);
-        } catch (RuntimeException exception) {
-            System.out.println("CHIZHIK_PHASE_C status=TRANSPORT_ERROR");
+        } catch (ChizhikPublicCatalogTransportException exception) {
+            System.out.printf(
+                    "CHIZHIK_PHASE_C status=TRANSPORT_ERROR failure_kind=%s%n",
+                    exception.failureKind());
             fail("Chizhik Phase C live probe transport failed");
             return;
         }

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogLiveProbeWorkflowContractTest.java
@@ -42,6 +42,14 @@ class ChizhikPublicCatalogLiveProbeWorkflowContractTest {
                 "http_status=\"$(sed -n 's/.* http_status=\\([-0-9]*\\).*/\\1/p' <<<\"$evidence\")\"");
     }
 
+    @Test
+    void retriesSecondaryStatusPublicationWithoutReplacingProbeOutcome() {
+        assertThat(WORKFLOW).contains("for attempt in 1 2 3; do");
+        assertThat(WORKFLOW).contains("sleep $((attempt * 2))");
+        assertThat(WORKFLOW).contains("Commit-status publication failed after 3 attempts");
+        assertThat(WORKFLOW).contains("::warning::Unable to publish Phase C commit status after retries");
+    }
+
     private static String readWorkflow() {
         Path workflow = Path.of("..", "..", ".github", "workflows", "provider-live-probe-chizhik-catalog.yml").normalize();
         try {

--- a/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportFailureTest.java
+++ b/apps/api/src/test/java/io/github/trueruslan/zakupgotov/provider/chizhik/ChizhikPublicCatalogTransportFailureTest.java
@@ -1,0 +1,32 @@
+package io.github.trueruslan.zakupgotov.provider.chizhik;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.net.http.HttpTimeoutException;
+import javax.net.ssl.SSLHandshakeException;
+import org.junit.jupiter.api.Test;
+
+class ChizhikPublicCatalogTransportFailureTest {
+
+    @Test
+    void classifiesFiniteSanitizedTransportFailureKindsAcrossCauseChains() {
+        assertThat(ChizhikPublicCatalogTransportException.classify(new UnknownHostException("private-host")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.DNS);
+        assertThat(ChizhikPublicCatalogTransportException.classify(new ConnectException("private-address")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.CONNECT);
+        assertThat(ChizhikPublicCatalogTransportException.classify(new HttpTimeoutException("private-uri")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.TIMEOUT);
+        assertThat(ChizhikPublicCatalogTransportException.classify(new SSLHandshakeException("private-tls")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.TLS);
+        assertThat(ChizhikPublicCatalogTransportException.classify(new IOException("private-io")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.IO);
+        assertThat(ChizhikPublicCatalogTransportException.classify(new InterruptedException("private-interrupt")))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.INTERRUPTED);
+        assertThat(ChizhikPublicCatalogTransportException.classify(
+                        new IllegalStateException("wrapper", new UnknownHostException("private-host"))))
+                .isEqualTo(ChizhikPublicCatalogTransportFailureKind.DNS);
+    }
+}


### PR DESCRIPTION
Hardens #163 after live run `32049148448` exposed two operational gaps: transport failures were only `TRANSPORT_ERROR` without a safe category, and secondary commit-status publication independently hit GitHub API HTTP 503.

## What changed
- classifies transport failures into the finite sanitized vocabulary `DNS / CONNECT / TIMEOUT / TLS / IO / INTERRUPTED` across cause chains;
- wraps only transport failures in a typed package-private exception carrying the enum, while preserving interrupted-thread state;
- live output becomes `CHIZHIK_PHASE_C status=TRANSPORT_ERROR failure_kind=<enum>` and never prints exception messages, request URLs, headers or bodies;
- keeps negative HTTP/non-PDF results as ordinary measured observations;
- retries secondary GitHub commit-status publication at most three times with 2s/4s backoff;
- if GitHub status publication still fails, emits a warning/summary but does not replace the primary probe result.

## TDD evidence
- RED head `80e8f8daaecae53a847d0274d89187057413c140`: API CI failed before production classification/retry existed;
- GREEN head `5c426c5c5c1efdd5dd07d6f04af6df2f7f9eede6`: API verification is SUCCESS; all functional workflow groups completed so far are green;
- CodeQL Java had one infrastructure-only init failure: GitHub CodeQL feature/status API returned `No server is currently available` before source analysis. JavaScript/TypeScript CodeQL analyzed successfully. This check will be retried without source changes once the workflow run completes.

## Boundary
This remains an observability hardening change for Phase C. No anti-bot bypass, cookies, credentials, protected APIs, header imitation, PDF body parsing, product/price offers or production activation are introduced.