### PR TITLE
feat(chizhik): add active normal-browser acquisition foundation

### DIFF
--- a/.github/workflows/provider-live-probe-chizhik-browser.yml
+++ b/.github/workflows/provider-live-probe-chizhik-browser.yml
@@ -1,0 +1,126 @@
+name: Provider Live Probe / Chizhik Phase D
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: provider-live-probe-chizhik-browser-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  chizhik_browser:
+    name: Chizhik Active Browser Phase D
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 167 &&
+      github.event.comment.user.login == github.repository_owner &&
+      github.event.comment.body == '/provider-probe chizhik-browser'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install pinned pnpm
+        shell: bash
+        run: npm install --global pnpm@11.4.0
+
+      - name: Install workspace dependencies
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Install stock Playwright Chromium
+        shell: bash
+        run: pnpm --dir apps/retailer-bridge exec playwright install --with-deps chromium
+
+      - name: Run Chizhik active browser Phase D
+        shell: bash
+        run: |
+          set -euo pipefail
+          node apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs \
+            2>&1 | tee "$RUNNER_TEMP/chizhik-phase-d-live-probe.log"
+
+      - name: Publish sanitized evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo '## Chizhik active browser Phase D' >> "$GITHUB_STEP_SUMMARY"
+
+          evidence=''
+          if [[ -f "$RUNNER_TEMP/chizhik-phase-d-live-probe.log" ]]; then
+            evidence="$(grep -F 'CHIZHIK_PHASE_D' "$RUNNER_TEMP/chizhik-phase-d-live-probe.log" | tail -n 1 || true)"
+          fi
+
+          state='failure'
+          outcome='no-evidence'
+          description='CHIZHIK_PHASE_D no_sanitized_evidence=true'
+
+          if [[ -n "$evidence" ]]; then
+            description="$evidence"
+            printf '`%s`\n' "$evidence" >> "$GITHUB_STEP_SUMMARY"
+
+            status="$(sed -n 's/^CHIZHIK_PHASE_D status=\([^ ]*\).*/\1/p' <<<"$evidence")"
+            shops_http_status="$(sed -n 's/.* shops_http_status=\([-0-9]*\).*/\1/p' <<<"$evidence")"
+            store_shape="$(sed -n 's/.* store_shape=\([^ ]*\).*/\1/p' <<<"$evidence")"
+
+            if [[ "$status" == 'PASS' \
+               && "$shops_http_status" == '200' \
+               && "$store_shape" == 'true' ]]; then
+              state='success'
+              outcome='pass'
+            elif [[ "$status" == 'PAGE_UNAVAILABLE' ]]; then
+              outcome='page-unavailable'
+            elif [[ "$status" == 'HTTP_UNAVAILABLE' ]]; then
+              outcome="http-${shops_http_status:-unknown}"
+            elif [[ "$status" == 'FETCH_UNAVAILABLE' ]]; then
+              outcome='fetch-unavailable'
+            elif [[ "$status" == 'INVALID_JSON' ]]; then
+              outcome='invalid-json'
+            elif [[ "$status" == 'SHAPE_INVALID' ]]; then
+              outcome='shape-invalid'
+            else
+              outcome='failed'
+            fi
+          else
+            echo 'No sanitized Phase D evidence line was emitted.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          context="Provider Live Probe / Chizhik Phase D / ${outcome}"
+          description="${description:0:140}"
+
+          published='false'
+          for attempt in 1 2 3; do
+            if gh api \
+                --method POST \
+                "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+                -f state="$state" \
+                -f context="$context" \
+                -f description="$description" >/dev/null; then
+              published='true'
+              break
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 2))
+            fi
+          done
+
+          if [[ "$published" != 'true' ]]; then
+            echo 'Commit-status publication failed after 3 attempts.' >> "$GITHUB_STEP_SUMMARY"
+            echo '::warning::Unable to publish Phase D commit status after retries'
+          fi

--- a/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test } from "@playwright/test";
+
+const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
+const extensionPath = resolve(bridgeRoot, "dist");
+const pageHtml = "<!doctype html><html><body><main>Chizhik catalog fixture</main></body></html>";
+const shopsEndpoint = "https://app.chizhik.club/api/v1/shops/";
+
+async function launchBridge() {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-chizhik-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+  return { context, userDataDir };
+}
+
+test("actively discovers Chizhik stores once through normal page-origin CORS without creating offers", async () => {
+  const { context, userDataDir } = await launchBridge();
+  let shopsRequests = 0;
+
+  try {
+    await context.route("https://chizhik.club/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: pageHtml,
+      });
+    });
+    await context.route(shopsEndpoint, async (route) => {
+      shopsRequests += 1;
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify([
+          {
+            id: 26504,
+            sap_id: "HD87",
+            lon: 37.83372708,
+            lat: 55.76833314,
+            status: 1,
+            name: "Москва, Саянская ул., Дом 11Б",
+            locality: "Москва",
+            secret_like_field: "MUST_NOT_PERSIST",
+          },
+        ]),
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("observation-only");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
+    expect(shopsRequests).toBe(1);
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const stored = await worker.evaluate(async () => chrome.storage.local.get("zg.latestObservations"));
+    expect(stored["zg.latestObservations"] ?? []).toEqual([]);
+    expect(JSON.stringify(stored)).not.toContain("MUST_NOT_PERSIST");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when active Chizhik store discovery is blocked", async () => {
+  const { context, userDataDir } = await launchBridge();
+
+  try {
+    await context.route("https://chizhik.club/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: pageHtml,
+      });
+    });
+    await context.route(shopsEndpoint, async (route) => {
+      await route.fulfill({
+        status: 403,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "text/plain; charset=utf-8",
+        },
+        body: "blocked",
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("missing-context");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
+++ b/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
@@ -11,6 +11,18 @@ function evidence(fields) {
   console.log(`CHIZHIK_PHASE_D ${values.join(" ")}`);
 }
 
+function unavailableEvidence(status, pageStatus = -1, shopsStatus = -1) {
+  evidence({
+    status,
+    page_http_status: pageStatus,
+    shops_http_status: shopsStatus,
+    json: false,
+    array: false,
+    nonempty: false,
+    store_shape: false,
+  });
+}
+
 function validStoreShape(value) {
   return (
     value &&
@@ -29,119 +41,110 @@ function validStoreShape(value) {
   );
 }
 
-const browser = await chromium.launch({ headless: true });
-try {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-
-  let pageResponse;
+async function runProbe() {
+  const browser = await chromium.launch({ headless: true });
   try {
-    pageResponse = await page.goto(PAGE_URL, {
-      waitUntil: "domcontentloaded",
-      timeout: PAGE_TIMEOUT_MS,
-    });
-  } catch {
-    evidence({
-      status: "PAGE_UNAVAILABLE",
-      page_http_status: -1,
-      shops_http_status: -1,
-      json: false,
-      array: false,
-      nonempty: false,
-      store_shape: false,
-    });
-    process.exitCode = 0;
-    await context.close();
-    process.exit();
-  }
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
 
-  const pageStatus = pageResponse?.status() ?? -1;
-  if (pageStatus < 200 || pageStatus >= 400) {
-    evidence({
-      status: "PAGE_UNAVAILABLE",
-      page_http_status: pageStatus,
-      shops_http_status: -1,
-      json: false,
-      array: false,
-      nonempty: false,
-      store_shape: false,
-    });
-    await context.close();
-    process.exit();
-  }
-
-  const result = await page.evaluate(
-    async ({ endpoint, timeoutMs }) => {
-      const controller = new AbortController();
-      const deadline = setTimeout(() => controller.abort(), timeoutMs);
+      let pageResponse;
       try {
-        const response = await fetch(endpoint, {
-          method: "GET",
-          mode: "cors",
-          credentials: "same-origin",
-          headers: { Accept: "application/json, text/plain, */*" },
-          signal: controller.signal,
+        pageResponse = await page.goto(PAGE_URL, {
+          waitUntil: "domcontentloaded",
+          timeout: PAGE_TIMEOUT_MS,
         });
-        const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-        if (!response.ok || !contentType.startsWith("application/json")) {
-          return {
-            status: "HTTP_UNAVAILABLE",
-            httpStatus: response.status,
-            json: false,
-            payload: null,
-          };
-        }
-
-        try {
-          return {
-            status: "RECEIVED",
-            httpStatus: response.status,
-            json: true,
-            payload: await response.json(),
-          };
-        } catch {
-          return {
-            status: "INVALID_JSON",
-            httpStatus: response.status,
-            json: false,
-            payload: null,
-          };
-        }
       } catch {
-        return {
-          status: "FETCH_UNAVAILABLE",
-          httpStatus: -1,
-          json: false,
-          payload: null,
-        };
-      } finally {
-        clearTimeout(deadline);
+        unavailableEvidence("PAGE_UNAVAILABLE");
+        return;
       }
-    },
-    { endpoint: SHOPS_ENDPOINT, timeoutMs: FETCH_TIMEOUT_MS },
-  );
 
-  const isArray = Array.isArray(result.payload);
-  const nonempty = isArray && result.payload.length > 0;
-  const storeShape = nonempty && result.payload.every(validStoreShape);
-  const status =
-    result.status === "RECEIVED" && result.httpStatus === 200 && result.json && storeShape
-      ? "PASS"
-      : result.status === "RECEIVED"
-        ? "SHAPE_INVALID"
-        : result.status;
+      const pageStatus = pageResponse?.status() ?? -1;
+      if (pageStatus < 200 || pageStatus >= 400) {
+        unavailableEvidence("PAGE_UNAVAILABLE", pageStatus);
+        return;
+      }
 
-  evidence({
-    status,
-    page_http_status: pageStatus,
-    shops_http_status: result.httpStatus,
-    json: result.json,
-    array: isArray,
-    nonempty,
-    store_shape: Boolean(storeShape),
-  });
+      const result = await page.evaluate(
+        async ({ endpoint, timeoutMs }) => {
+          const controller = new AbortController();
+          const deadline = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            const response = await fetch(endpoint, {
+              method: "GET",
+              mode: "cors",
+              credentials: "same-origin",
+              headers: { Accept: "application/json, text/plain, */*" },
+              signal: controller.signal,
+            });
+            const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+            if (!response.ok || !contentType.startsWith("application/json")) {
+              return {
+                status: "HTTP_UNAVAILABLE",
+                httpStatus: response.status,
+                json: false,
+                payload: null,
+              };
+            }
 
-  await context.close();
-} finally {
-  await browser.close();
+            try {
+              return {
+                status: "RECEIVED",
+                httpStatus: response.status,
+                json: true,
+                payload: await response.json(),
+              };
+            } catch {
+              return {
+                status: "INVALID_JSON",
+                httpStatus: response.status,
+                json: false,
+                payload: null,
+              };
+            }
+          } catch {
+            return {
+              status: "FETCH_UNAVAILABLE",
+              httpStatus: -1,
+              json: false,
+              payload: null,
+            };
+          } finally {
+            clearTimeout(deadline);
+          }
+        },
+        { endpoint: SHOPS_ENDPOINT, timeoutMs: FETCH_TIMEOUT_MS },
+      );
+
+      const isArray = Array.isArray(result.payload);
+      const nonempty = isArray && result.payload.length > 0;
+      const storeShape = nonempty && result.payload.every(validStoreShape);
+      const status =
+        result.status === "RECEIVED" && result.httpStatus === 200 && result.json && storeShape
+          ? "PASS"
+          : result.status === "RECEIVED"
+            ? "SHAPE_INVALID"
+            : result.status;
+
+      evidence({
+        status,
+        page_http_status: pageStatus,
+        shops_http_status: result.httpStatus,
+        json: result.json,
+        array: isArray,
+        nonempty,
+        store_shape: Boolean(storeShape),
+      });
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+try {
+  await runProbe();
+} catch {
+  unavailableEvidence("PROBE_ERROR");
 }

--- a/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
+++ b/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
@@ -58,8 +58,12 @@ async function runProbe() {
             value.sap_id.trim().length > 0 &&
             typeof value.lat === "number" &&
             Number.isFinite(value.lat) &&
+            value.lat >= -90 &&
+            value.lat <= 90 &&
             typeof value.lon === "number" &&
             Number.isFinite(value.lon) &&
+            value.lon >= -180 &&
+            value.lon <= 180 &&
             Number.isInteger(value.status) &&
             typeof value.name === "string" &&
             value.name.trim().length > 0 &&

--- a/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
+++ b/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
@@ -23,24 +23,6 @@ function unavailableEvidence(status, pageStatus = -1, shopsStatus = -1) {
   });
 }
 
-function validStoreShape(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    typeof value.sap_id === "string" &&
-    value.sap_id.trim().length > 0 &&
-    typeof value.lat === "number" &&
-    Number.isFinite(value.lat) &&
-    typeof value.lon === "number" &&
-    Number.isFinite(value.lon) &&
-    Number.isInteger(value.status) &&
-    typeof value.name === "string" &&
-    value.name.trim().length > 0 &&
-    typeof value.locality === "string" &&
-    value.locality.trim().length > 0
-  );
-}
-
 async function runProbe() {
   const browser = await chromium.launch({ headless: true });
   try {
@@ -69,6 +51,21 @@ async function runProbe() {
         async ({ endpoint, timeoutMs }) => {
           const controller = new AbortController();
           const deadline = setTimeout(() => controller.abort(), timeoutMs);
+          const validStoreShape = (value) =>
+            value &&
+            typeof value === "object" &&
+            typeof value.sap_id === "string" &&
+            value.sap_id.trim().length > 0 &&
+            typeof value.lat === "number" &&
+            Number.isFinite(value.lat) &&
+            typeof value.lon === "number" &&
+            Number.isFinite(value.lon) &&
+            Number.isInteger(value.status) &&
+            typeof value.name === "string" &&
+            value.name.trim().length > 0 &&
+            typeof value.locality === "string" &&
+            value.locality.trim().length > 0;
+
           try {
             const response = await fetch(endpoint, {
               method: "GET",
@@ -83,23 +80,33 @@ async function runProbe() {
                 status: "HTTP_UNAVAILABLE",
                 httpStatus: response.status,
                 json: false,
-                payload: null,
+                array: false,
+                nonempty: false,
+                storeShape: false,
               };
             }
 
             try {
+              const payload = await response.json();
+              const isArray = Array.isArray(payload);
+              const nonempty = isArray && payload.length > 0;
+              const storeShape = nonempty && payload.every(validStoreShape);
               return {
-                status: "RECEIVED",
+                status: storeShape ? "PASS" : "SHAPE_INVALID",
                 httpStatus: response.status,
                 json: true,
-                payload: await response.json(),
+                array: isArray,
+                nonempty,
+                storeShape: Boolean(storeShape),
               };
             } catch {
               return {
                 status: "INVALID_JSON",
                 httpStatus: response.status,
                 json: false,
-                payload: null,
+                array: false,
+                nonempty: false,
+                storeShape: false,
               };
             }
           } catch {
@@ -107,7 +114,9 @@ async function runProbe() {
               status: "FETCH_UNAVAILABLE",
               httpStatus: -1,
               json: false,
-              payload: null,
+              array: false,
+              nonempty: false,
+              storeShape: false,
             };
           } finally {
             clearTimeout(deadline);
@@ -116,24 +125,14 @@ async function runProbe() {
         { endpoint: SHOPS_ENDPOINT, timeoutMs: FETCH_TIMEOUT_MS },
       );
 
-      const isArray = Array.isArray(result.payload);
-      const nonempty = isArray && result.payload.length > 0;
-      const storeShape = nonempty && result.payload.every(validStoreShape);
-      const status =
-        result.status === "RECEIVED" && result.httpStatus === 200 && result.json && storeShape
-          ? "PASS"
-          : result.status === "RECEIVED"
-            ? "SHAPE_INVALID"
-            : result.status;
-
       evidence({
-        status,
+        status: result.status,
         page_http_status: pageStatus,
         shops_http_status: result.httpStatus,
         json: result.json,
-        array: isArray,
-        nonempty,
-        store_shape: Boolean(storeShape),
+        array: result.array,
+        nonempty: result.nonempty,
+        store_shape: result.storeShape,
       });
     } finally {
       await context.close();

--- a/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
+++ b/apps/retailer-bridge/scripts/chizhik-live-browser-probe.mjs
@@ -1,0 +1,147 @@
+import { chromium } from "@playwright/test";
+
+const PAGE_ORIGIN = "https://chizhik.club/";
+const PAGE_URL = `${PAGE_ORIGIN}catalog/`;
+const SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
+const PAGE_TIMEOUT_MS = 20_000;
+const FETCH_TIMEOUT_MS = 8_000;
+
+function evidence(fields) {
+  const values = Object.entries(fields).map(([key, value]) => `${key}=${String(value)}`);
+  console.log(`CHIZHIK_PHASE_D ${values.join(" ")}`);
+}
+
+function validStoreShape(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    typeof value.sap_id === "string" &&
+    value.sap_id.trim().length > 0 &&
+    typeof value.lat === "number" &&
+    Number.isFinite(value.lat) &&
+    typeof value.lon === "number" &&
+    Number.isFinite(value.lon) &&
+    Number.isInteger(value.status) &&
+    typeof value.name === "string" &&
+    value.name.trim().length > 0 &&
+    typeof value.locality === "string" &&
+    value.locality.trim().length > 0
+  );
+}
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  let pageResponse;
+  try {
+    pageResponse = await page.goto(PAGE_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: PAGE_TIMEOUT_MS,
+    });
+  } catch {
+    evidence({
+      status: "PAGE_UNAVAILABLE",
+      page_http_status: -1,
+      shops_http_status: -1,
+      json: false,
+      array: false,
+      nonempty: false,
+      store_shape: false,
+    });
+    process.exitCode = 0;
+    await context.close();
+    process.exit();
+  }
+
+  const pageStatus = pageResponse?.status() ?? -1;
+  if (pageStatus < 200 || pageStatus >= 400) {
+    evidence({
+      status: "PAGE_UNAVAILABLE",
+      page_http_status: pageStatus,
+      shops_http_status: -1,
+      json: false,
+      array: false,
+      nonempty: false,
+      store_shape: false,
+    });
+    await context.close();
+    process.exit();
+  }
+
+  const result = await page.evaluate(
+    async ({ endpoint, timeoutMs }) => {
+      const controller = new AbortController();
+      const deadline = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(endpoint, {
+          method: "GET",
+          mode: "cors",
+          credentials: "same-origin",
+          headers: { Accept: "application/json, text/plain, */*" },
+          signal: controller.signal,
+        });
+        const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+        if (!response.ok || !contentType.startsWith("application/json")) {
+          return {
+            status: "HTTP_UNAVAILABLE",
+            httpStatus: response.status,
+            json: false,
+            payload: null,
+          };
+        }
+
+        try {
+          return {
+            status: "RECEIVED",
+            httpStatus: response.status,
+            json: true,
+            payload: await response.json(),
+          };
+        } catch {
+          return {
+            status: "INVALID_JSON",
+            httpStatus: response.status,
+            json: false,
+            payload: null,
+          };
+        }
+      } catch {
+        return {
+          status: "FETCH_UNAVAILABLE",
+          httpStatus: -1,
+          json: false,
+          payload: null,
+        };
+      } finally {
+        clearTimeout(deadline);
+      }
+    },
+    { endpoint: SHOPS_ENDPOINT, timeoutMs: FETCH_TIMEOUT_MS },
+  );
+
+  const isArray = Array.isArray(result.payload);
+  const nonempty = isArray && result.payload.length > 0;
+  const storeShape = nonempty && result.payload.every(validStoreShape);
+  const status =
+    result.status === "RECEIVED" && result.httpStatus === 200 && result.json && storeShape
+      ? "PASS"
+      : result.status === "RECEIVED"
+        ? "SHAPE_INVALID"
+        : result.status;
+
+  evidence({
+    status,
+    page_http_status: pageStatus,
+    shops_http_status: result.httpStatus,
+    json: result.json,
+    array: isArray,
+    nonempty,
+    store_shape: Boolean(storeShape),
+  });
+
+  await context.close();
+} finally {
+  await browser.close();
+}

--- a/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
@@ -1,3 +1,8 @@
+import {
+  createChizhikActiveApiClient,
+  type ChizhikActiveApiClient,
+  type ChizhikStoreDiscoveryResult,
+} from "../chizhik-active-api-client";
 import type {
   AdapterResult,
   RetailerBrowserAdapter,
@@ -5,43 +10,37 @@ import type {
 
 const RETAILER_ID = "chizhik";
 const OFFICIAL_PAGE_HOST = "chizhik.club";
-const PUBLIC_CATALOG_ORIGIN = "https://app.chizhik.club";
-const PUBLIC_CATALOG_PATH = /^\/api\/v1\/catalog\/unauthorized\/(?:categories|products)\/?$/;
 
 function isOfficialPageUrl(url: URL): boolean {
   return url.protocol === "https:" && url.hostname === OFFICIAL_PAGE_HOST;
 }
 
-function hasObservedPublicCatalogResource(resourceUrls: readonly string[]): boolean {
-  return resourceUrls.some((rawUrl) => {
-    try {
-      const resourceUrl = new URL(rawUrl);
-      return (
-        resourceUrl.origin === PUBLIC_CATALOG_ORIGIN &&
-        PUBLIC_CATALOG_PATH.test(resourceUrl.pathname)
-      );
-    } catch {
-      return false;
-    }
-  });
+export function createChizhikBrowserAdapter(
+  client: ChizhikActiveApiClient = createChizhikActiveApiClient(),
+): RetailerBrowserAdapter {
+  let storeDiscovery: Promise<ChizhikStoreDiscoveryResult> | null = null;
+
+  return {
+    adapterId: "chizhik-browser-active-v2",
+    retailerId: RETAILER_ID,
+
+    supports(url: URL): boolean {
+      return isOfficialPageUrl(url);
+    },
+
+    async collect(): Promise<AdapterResult> {
+      storeDiscovery ??= client.listStores();
+      const result = await storeDiscovery;
+      if (result.status !== "ok" || result.stores.length === 0) {
+        return { status: "missing-context", observations: [] };
+      }
+
+      // Phase D1 proves active browser-context access and a valid store directory only.
+      // Product offers remain fail-closed until a store-scoped delivery response is
+      // independently evidenced and mapped in Phase D2.
+      return { status: "observation-only", observations: [] };
+    },
+  };
 }
 
-export const chizhikBrowserAdapter: RetailerBrowserAdapter = {
-  adapterId: "chizhik-browser-discovery-v1",
-  retailerId: RETAILER_ID,
-
-  supports(url: URL): boolean {
-    return isOfficialPageUrl(url);
-  },
-
-  collect({ resourceUrls = [] }): AdapterResult {
-    if (!hasObservedPublicCatalogResource(resourceUrls)) {
-      return { status: "missing-context", observations: [] };
-    }
-
-    // Phase B is intentionally observation-only: a sanitized catalog pathname proves
-    // browser-side reachability but carries neither a trusted fulfillment context nor
-    // enough product evidence to create an offer observation.
-    return { status: "observation-only", observations: [] };
-  },
-};
+export const chizhikBrowserAdapter = createChizhikBrowserAdapter();

--- a/apps/retailer-bridge/src/adapters/retailer-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/retailer-browser-adapter.ts
@@ -18,5 +18,5 @@ export interface RetailerBrowserAdapter {
     url: URL;
     observedAt: string;
     resourceUrls?: readonly string[];
-  }): AdapterResult;
+  }): AdapterResult | Promise<AdapterResult>;
 }

--- a/apps/retailer-bridge/src/chizhik-active-api-client.ts
+++ b/apps/retailer-bridge/src/chizhik-active-api-client.ts
@@ -1,0 +1,92 @@
+export const CHIZHIK_SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
+
+export type ChizhikStoreSummary = Readonly<{
+  sapId: string;
+  longitude: number;
+  latitude: number;
+  active: boolean;
+  name: string;
+  locality: string;
+}>;
+
+export type ChizhikStoreDiscoveryResult =
+  | Readonly<{ status: "ok"; stores: readonly ChizhikStoreSummary[] }>
+  | Readonly<{ status: "unavailable"; stores: readonly [] }>;
+
+export type ChizhikActiveApiClient = Readonly<{
+  listStores(): Promise<ChizhikStoreDiscoveryResult>;
+}>;
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function isNonBlank(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isFiniteCoordinate(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function projectStore(raw: unknown): ChizhikStoreSummary | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+
+  const record = raw as Record<string, unknown>;
+  if (
+    !isNonBlank(record.sap_id) ||
+    !isFiniteCoordinate(record.lon) ||
+    !isFiniteCoordinate(record.lat) ||
+    typeof record.status !== "number" ||
+    !Number.isInteger(record.status) ||
+    !isNonBlank(record.name) ||
+    !isNonBlank(record.locality)
+  ) {
+    return null;
+  }
+
+  return {
+    sapId: record.sap_id,
+    longitude: record.lon,
+    latitude: record.lat,
+    active: record.status === 1,
+    name: record.name,
+    locality: record.locality,
+  };
+}
+
+export function createChizhikActiveApiClient(
+  fetcher: Fetcher = globalThis.fetch.bind(globalThis),
+): ChizhikActiveApiClient {
+  return {
+    async listStores(): Promise<ChizhikStoreDiscoveryResult> {
+      try {
+        const response = await fetcher(CHIZHIK_SHOPS_ENDPOINT, {
+          method: "GET",
+          mode: "cors",
+          credentials: "same-origin",
+          headers: { Accept: "application/json, text/plain, */*" },
+        });
+
+        if (!response.ok) return { status: "unavailable", stores: [] };
+
+        const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+        if (!contentType.startsWith("application/json")) {
+          return { status: "unavailable", stores: [] };
+        }
+
+        const payload: unknown = await response.json();
+        if (!Array.isArray(payload)) return { status: "unavailable", stores: [] };
+
+        const stores: ChizhikStoreSummary[] = [];
+        for (const raw of payload) {
+          const store = projectStore(raw);
+          if (!store) return { status: "unavailable", stores: [] };
+          stores.push(store);
+        }
+
+        return { status: "ok", stores };
+      } catch {
+        return { status: "unavailable", stores: [] };
+      }
+    },
+  };
+}

--- a/apps/retailer-bridge/src/chizhik-active-api-client.ts
+++ b/apps/retailer-bridge/src/chizhik-active-api-client.ts
@@ -1,4 +1,5 @@
 export const CHIZHIK_SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
+const REQUEST_TIMEOUT_MS = 8_000;
 
 export type ChizhikStoreSummary = Readonly<{
   sapId: string;
@@ -58,12 +59,15 @@ export function createChizhikActiveApiClient(
 ): ChizhikActiveApiClient {
   return {
     async listStores(): Promise<ChizhikStoreDiscoveryResult> {
+      const controller = new AbortController();
+      const deadline = globalThis.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
       try {
         const response = await fetcher(CHIZHIK_SHOPS_ENDPOINT, {
           method: "GET",
           mode: "cors",
           credentials: "same-origin",
           headers: { Accept: "application/json, text/plain, */*" },
+          signal: controller.signal,
         });
 
         if (!response.ok) return { status: "unavailable", stores: [] };
@@ -86,6 +90,8 @@ export function createChizhikActiveApiClient(
         return { status: "ok", stores };
       } catch {
         return { status: "unavailable", stores: [] };
+      } finally {
+        globalThis.clearTimeout(deadline);
       }
     },
   };

--- a/apps/retailer-bridge/src/chizhik-active-api-client.ts
+++ b/apps/retailer-bridge/src/chizhik-active-api-client.ts
@@ -24,8 +24,16 @@ function isNonBlank(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function isFiniteCoordinate(value: unknown): value is number {
+function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function isLongitude(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= -180 && value <= 180;
+}
+
+function isLatitude(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= -90 && value <= 90;
 }
 
 function projectStore(raw: unknown): ChizhikStoreSummary | null {
@@ -34,8 +42,8 @@ function projectStore(raw: unknown): ChizhikStoreSummary | null {
   const record = raw as Record<string, unknown>;
   if (
     !isNonBlank(record.sap_id) ||
-    !isFiniteCoordinate(record.lon) ||
-    !isFiniteCoordinate(record.lat) ||
+    !isLongitude(record.lon) ||
+    !isLatitude(record.lat) ||
     typeof record.status !== "number" ||
     !Number.isInteger(record.status) ||
     !isNonBlank(record.name) ||

--- a/apps/retailer-bridge/src/collector/browser-observation-collector.ts
+++ b/apps/retailer-bridge/src/collector/browser-observation-collector.ts
@@ -95,7 +95,7 @@ export class BrowserObservationCollector {
       return { status: "unsupported-page", observationCount: 0 };
     }
 
-    const result = adapter.collect({ document, url, observedAt, resourceUrls });
+    const result = await adapter.collect({ document, url, observedAt, resourceUrls });
     if (result.status !== "ok") {
       return { status: result.status, observationCount: 0 };
     }

--- a/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../src/chizhik-active-api-client";
 
 describe("ChizhikActiveApiClient", () => {
-  it("uses only the fixed first-party shops endpoint with ordinary CORS semantics", async () => {
+  it("uses only the fixed first-party shops endpoint with ordinary CORS semantics and an abort deadline", async () => {
     const fetcher = vi.fn(async () =>
       new Response(
         JSON.stringify([
@@ -35,7 +35,11 @@ describe("ChizhikActiveApiClient", () => {
       mode: "cors",
       credentials: "same-origin",
       headers: { Accept: "application/json, text/plain, */*" },
+      signal: expect.any(AbortSignal),
     });
+    const requestSignal = fetcher.mock.calls[0]?.[1]?.signal;
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal?.aborted).toBe(false);
     expect(result).toEqual({
       status: "ok",
       stores: [

--- a/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
@@ -55,7 +55,7 @@ describe("ChizhikActiveApiClient", () => {
     });
   });
 
-  it("fails closed for non-JSON, non-2xx, and malformed store payloads", async () => {
+  it("fails closed for non-JSON, non-2xx, malformed rows, and impossible coordinates", async () => {
     const cases: Array<Response> = [
       new Response("blocked", { status: 403, headers: { "content-type": "text/plain" } }),
       new Response("<html></html>", {
@@ -66,6 +66,32 @@ describe("ChizhikActiveApiClient", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       }),
+      new Response(
+        JSON.stringify([
+          {
+            sap_id: "HD87",
+            lon: 37.8,
+            lat: 155.7,
+            status: 1,
+            name: "Invalid latitude",
+            locality: "Москва",
+          },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+      new Response(
+        JSON.stringify([
+          {
+            sap_id: "HD87",
+            lon: 237.8,
+            lat: 55.7,
+            status: 1,
+            name: "Invalid longitude",
+            locality: "Москва",
+          },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
     ];
 
     for (const response of cases) {

--- a/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CHIZHIK_SHOPS_ENDPOINT,
+  createChizhikActiveApiClient,
+} from "../src/chizhik-active-api-client";
+
+describe("ChizhikActiveApiClient", () => {
+  it("uses only the fixed first-party shops endpoint with ordinary CORS semantics", async () => {
+    const fetcher = vi.fn(async () =>
+      new Response(
+        JSON.stringify([
+          {
+            id: 26504,
+            sap_id: "HD87",
+            lon: 37.83372708,
+            lat: 55.76833314,
+            status: 1,
+            name: "Москва, Саянская ул., Дом 11Б",
+            locality: "Москва",
+            working_hours: "с 09:00 до 21:00",
+            average_rating: 3.4,
+            ignored_secret_like_field: "must-not-project",
+          },
+        ]),
+        { status: 200, headers: { "content-type": "application/json; charset=utf-8" } },
+      ),
+    );
+
+    const client = createChizhikActiveApiClient(fetcher);
+    const result = await client.listStores();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(CHIZHIK_SHOPS_ENDPOINT, {
+      method: "GET",
+      mode: "cors",
+      credentials: "same-origin",
+      headers: { Accept: "application/json, text/plain, */*" },
+    });
+    expect(result).toEqual({
+      status: "ok",
+      stores: [
+        {
+          sapId: "HD87",
+          longitude: 37.83372708,
+          latitude: 55.76833314,
+          active: true,
+          name: "Москва, Саянская ул., Дом 11Б",
+          locality: "Москва",
+        },
+      ],
+    });
+  });
+
+  it("fails closed for non-JSON, non-2xx, and malformed store payloads", async () => {
+    const cases: Array<Response> = [
+      new Response("blocked", { status: 403, headers: { "content-type": "text/plain" } }),
+      new Response("<html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+      new Response(JSON.stringify([{ sap_id: "HD87", lat: 55.7 }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ];
+
+    for (const response of cases) {
+      const client = createChizhikActiveApiClient(vi.fn(async () => response));
+      await expect(client.listStores()).resolves.toEqual({ status: "unavailable", stores: [] });
+    }
+  });
+
+  it("fails closed on transport exceptions without exposing exception details", async () => {
+    const client = createChizhikActiveApiClient(
+      vi.fn(async () => {
+        throw new Error("sensitive transport details");
+      }),
+    );
+
+    await expect(client.listStores()).resolves.toEqual({ status: "unavailable", stores: [] });
+  });
+});

--- a/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
+++ b/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { chizhikBrowserAdapter } from "../src/adapters/chizhik-browser-adapter";
+import { describe, expect, it, vi } from "vitest";
+import {
+  chizhikBrowserAdapter,
+  createChizhikBrowserAdapter,
+} from "../src/adapters/chizhik-browser-adapter";
 
-const OBSERVED_AT = "2026-08-17T00:15:00Z";
-const PAGE_URL = new URL("https://chizhik.club/deeplink?action_type=to_screen#fragment");
+const OBSERVED_AT = "2026-08-18T00:15:00Z";
+const PAGE_URL = new URL("https://chizhik.club/catalog/chay-kofe--264C39224/#fragment");
 
 function documentWithGuessedProduct(): Document {
   return new DOMParser().parseFromString(
@@ -18,10 +21,24 @@ function documentWithGuessedProduct(): Document {
   );
 }
 
+const VALID_DISCOVERY = {
+  status: "ok" as const,
+  stores: [
+    {
+      sapId: "HD87",
+      longitude: 37.83372708,
+      latitude: 55.76833314,
+      active: true,
+      name: "Москва, Саянская ул., Дом 11Б",
+      locality: "Москва",
+    },
+  ],
+};
+
 describe("chizhikBrowserAdapter", () => {
   it("supports only the explicit official Chizhik HTTPS page origin", () => {
     expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club/"))).toBe(true);
-    expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club/deeplink"))).toBe(true);
+    expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club/catalog/test"))).toBe(true);
 
     expect(chizhikBrowserAdapter.supports(new URL("http://chizhik.club/"))).toBe(false);
     expect(chizhikBrowserAdapter.supports(new URL("https://www.chizhik.club/"))).toBe(false);
@@ -29,28 +46,65 @@ describe("chizhikBrowserAdapter", () => {
     expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club.evil.example/"))).toBe(false);
   });
 
-  it("reports observation-only when a sanitized public catalog resource was browser-observed", () => {
-    expect(
-      chizhikBrowserAdapter.collect({
+  it("reports observation-only after active fixed-endpoint store discovery succeeds", async () => {
+    const listStores = vi.fn(async () => VALID_DISCOVERY);
+    const adapter = createChizhikBrowserAdapter({ listStores });
+
+    await expect(
+      adapter.collect({
         document: documentWithGuessedProduct(),
         url: PAGE_URL,
         observedAt: OBSERVED_AT,
-        resourceUrls: [
-          "https://app.chizhik.club/api/v1/catalog/unauthorized/categories/",
-          "https://app.chizhik.club/api/v1/catalog/unauthorized/products/",
-        ],
+        resourceUrls: [],
       }),
-    ).toEqual({ status: "observation-only", observations: [] });
+    ).resolves.toEqual({ status: "observation-only", observations: [] });
+    expect(listStores).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fabricate offers from guessed DOM fields or unrelated resource URLs", () => {
-    expect(
-      chizhikBrowserAdapter.collect({
+  it("reuses one store discovery request for repeated collections in the same lifecycle", async () => {
+    const listStores = vi.fn(async () => VALID_DISCOVERY);
+    const adapter = createChizhikBrowserAdapter({ listStores });
+    const input = {
+      document: documentWithGuessedProduct(),
+      url: PAGE_URL,
+      observedAt: OBSERVED_AT,
+      resourceUrls: [] as string[],
+    };
+
+    await adapter.collect(input);
+    await adapter.collect(input);
+    await adapter.collect(input);
+
+    expect(listStores).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when active store discovery is unavailable or empty", async () => {
+    for (const result of [
+      { status: "unavailable" as const, stores: [] as const },
+      { status: "ok" as const, stores: [] as const },
+    ]) {
+      const adapter = createChizhikBrowserAdapter({ listStores: vi.fn(async () => result) });
+      await expect(
+        adapter.collect({
+          document: documentWithGuessedProduct(),
+          url: PAGE_URL,
+          observedAt: OBSERVED_AT,
+          resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
+        }),
+      ).resolves.toEqual({ status: "missing-context", observations: [] });
+    }
+  });
+
+  it("does not fabricate product offers from DOM or passive resource names", async () => {
+    const adapter = createChizhikBrowserAdapter({ listStores: vi.fn(async () => VALID_DISCOVERY) });
+
+    await expect(
+      adapter.collect({
         document: documentWithGuessedProduct(),
         url: PAGE_URL,
         observedAt: OBSERVED_AT,
-        resourceUrls: ["https://analytics.example.test/api/v1/catalog/unauthorized/products/"],
+        resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
       }),
-    ).toEqual({ status: "missing-context", observations: [] });
+    ).resolves.toEqual({ status: "observation-only", observations: [] });
   });
 });

--- a/apps/retailer-bridge/test/chizhik-live-browser-workflow-contract.test.ts
+++ b/apps/retailer-bridge/test/chizhik-live-browser-workflow-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const workflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/provider-live-probe-chizhik-browser.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+const scriptPath = fileURLToPath(
+  new URL("../scripts/chizhik-live-browser-probe.mjs", import.meta.url),
+);
+const script = readFileSync(scriptPath, "utf8");
+
+describe("Chizhik Phase D stock Chromium live probe", () => {
+  it("is owner-only, issue-scoped, opt-in, and minimally privileged", () => {
+    expect(workflow).toContain("issue_comment:");
+    expect(workflow).toContain("github.event.issue.number == 167");
+    expect(workflow).toContain("github.event.comment.user.login == github.repository_owner");
+    expect(workflow).toContain("/provider-probe chizhik-browser");
+    expect(workflow).toContain("permissions:\n  contents: read\n  statuses: write");
+    expect(workflow).not.toMatch(/(?:packages|issues|pull-requests|id-token):\s*write/);
+  });
+
+  it("uses stock Chromium and emits only sanitized Phase D evidence", () => {
+    expect(workflow).toContain("playwright install --with-deps chromium");
+    expect(workflow).toContain("chizhik-live-browser-probe.mjs");
+    expect(script).toContain("https://chizhik.club/");
+    expect(script).toContain("https://app.chizhik.club/api/v1/shops/");
+    expect(script).toContain("CHIZHIK_PHASE_D");
+    expect(script).not.toMatch(/camoufox|proxy|user-agent|cookie|authorization/i);
+    expect(script).not.toContain("JSON.stringify(data)");
+  });
+});


### PR DESCRIPTION
Tracks #167. Do not auto-close it on merge: Phase D1 code acceptance and live stock-Chromium evidence are separate gates.

## Scope
- codify the successful user-browser `GET https://app.chizhik.club/api/v1/shops/` canary (`200 application/json` with store `sap_id`/coordinates);
- add a fixed-endpoint active Chizhik browser API client with an 8s abort deadline and strict store-shape/coordinate validation;
- allow retailer adapters to be async while preserving existing synchronous adapters;
- make Chizhik perform one active store-directory discovery per content-script lifecycle and remain observation-only until D2;
- add real extension Chromium E2E for successful CORS and fail-closed blocked transport;
- add an owner-only, issue-scoped stock-Chromium Phase D live probe that emits only sanitized status/shape evidence;
- keep extension permissions unchanged (`storage` only): no stealth, proxy rotation, credential/header/cookie extraction, mobile impersonation, or arbitrary URL proxying.

## TDD evidence
- RED 1: missing active API client module; all existing bridge tests passed.
- GREEN 1: fixed `/api/v1/shops/` client.
- RED 2: missing active Chizhik adapter factory/wiring; client and legacy tests passed.
- GREEN 2: async adapter boundary + one discovery per lifecycle.
- RED 3: active request lacked an abort deadline.
- GREEN 3: bounded `AbortSignal` request.
- RED 4: live workflow/script contract absent.
- GREEN 4: opt-in stock Chromium workflow with sanitized evidence only.
- RED 5: impossible latitude/longitude accepted.
- GREEN 5: `lat [-90,90]`, `lon [-180,180]` enforced in runtime and live shape validation.

D2 store-specific delivery search and `ObservedOffer` mapping remain follow-up after D1 transport evidence is accepted.