### PR TITLE
feat(chizhik): add D2 store-scoped delivery search transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 
 ### Added
 
+#### Retailer connectivity after M5.1
+
+- Retailer Bridge long-lived-session hardening now refreshes truthfully across SPA navigation and store changes using fresh-context gating, bounded retained resource evidence and revision-safe writes; the accepted #153 merge closes the previously outstanding #54 lifecycle work without widening production extension permissions.
+- Chizhik Phase A adds a bounded opt-in plain HTTPS feasibility probe for the unauthenticated catalog surface with finite timeouts, sanitized response-shape evidence and no production-provider activation (#156).
+- Chizhik Phase B adds exact-origin observation-only browser discovery for allow-listed first-party catalog resource paths (#158); trusted `main` bridge builds that pass Chromium E2E can be published as short-lived SHA-named canary artifacts (#160).
+- Chizhik Phase C adds a bounded body-less public catalog-document reachability probe restricted to exact `media.chizhik.club` PDF paths, a controlled issue-comment live workflow, finite sanitized transport-failure classification and best-effort secondary GitHub status publication (#164/#165/#166). Document reachability is explicitly not product/price/fulfillment connectivity.
+- Chizhik Phase D1 adds a fixed-endpoint active browser-context client for `GET https://app.chizhik.club/api/v1/shops/`, an eight-second abort deadline, strict store-shape/coordinate validation, async retailer-adapter support, one active discovery attempt per content-script lifecycle, real extension Chromium E2E and an owner-only stock-Chromium live probe (#168).
+- The ordinary-user-browser Phase D field canary on 2026-08-18 returned `200 + JSON` with store `sap_id`/`lat`/`lon` evidence, but the current CI-hosted Phase D live status is `page-unavailable`. D1 therefore remains a merged implementation with an unresolved live transport gate; D2 store-scoped product/delivery mapping and production activation are not accepted.
+- Chizhik D1 preserves the safety boundary: no stealth/fingerprint spoofing, proxy rotation, credential/header/cookie extraction, private/mobile-client impersonation or arbitrary URL proxying. Technical feasibility remains separate from production/right-to-operate approval.
+
 #### Productization
 
 - M5.1 adds exactly one versioned same-origin browser-local WeeklyPlan/Pantry input draft under `zakup-gotov.weekly-plan-draft.v1` for repeat use without accounts or server persistence.
@@ -206,6 +216,8 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; entri
 ### Changed
 
 - Project phase advanced from M0 Product & Integration Discovery through M1 Shopping Core, M2 Recipes, M3 Weekly Planning / Pantry and M4 Basket Optimization; the current deterministic phase is **M5 Productization**.
+- Browser-bridge persistent-session/store-change/SPA lifecycle hardening is now **COMPLETE / ACCEPTED** through #153, so #54 is no longer outstanding connectivity debt.
+- Chizhik connectivity is implemented through merged D1 foundation, but live transport disposition is still open because ordinary-user-browser success and CI-hosted `page-unavailable` are separate evidence classes.
 - M5.1 Private local WeeklyPlan draft is **COMPLETE / ACCEPTED** after final reviewed head `6c54479044e41e5177739b57eb891830a79691f8`, squash merge `2f2b96d18521b8bb04f6ee17182d61711322de08`, issue #148 closure and 8/8 successful post-merge `main` workflows.
 - The immediate operational target is a new immutable **`v0.1.0-rc.3`** prerelease proving the existing release contract end to end; M5.2 remains intentionally unselected until release-candidate/manual-use evidence identifies the next highest-value productization constraint.
 - M1 Shopping Core is **COMPLETE / ACCEPTED** on the post-merge pre-acquisition-gate baseline `779d0b219a13e0bf82263a1e655fb732553ed5fe`.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Web CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml)
 [![Release Bundle CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/release-bundle-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/release-bundle-ci.yml)
 
-**Status:** M0 — Product & Integration Discovery · **pre-release**
+**Status:** M5 — Productization · **pre-release** · next release gate: **`v0.1.0-rc.3`**
 
-Zakup Gotov — сервис, который должен превращать рецепт, недельное меню или обычный список покупок в сравнение **полной корзины** по магазинам с учётом местоположения, актуальности цены, наличия и полноты сопоставления.
+Zakup Gotov — сервис, который превращает рецепт, недельное меню или обычный список покупок в сравнение **полной корзины** по магазинам с учётом местоположения, актуальности цены, наличия, упаковок, checkout-экономики и полноты сопоставления.
 
-Проект намеренно не маскирует неизвестность: пока реальные retailer-интеграции не доказаны в M0B, интерфейс не выдаёт сравнение магазинов за готовую функцию.
+Проект намеренно не маскирует неизвестность: продуктовые/core-семантики уже реализованы и приняты, но production retailer coverage остаётся отдельной evidence-driven работой для каждого магазина. Техническая доступность источника не считается автоматически разрешением на его production-использование.
 
 ## Зачем проект
 
@@ -32,34 +32,55 @@ Zakup Gotov — сервис, который должен превращать �
               ↓
       quantity / package fit
               ↓
+   checkout economics / eligibility
+              ↓
      complete basket ranking
 ```
 
-Целевой результат должен явно показывать:
+Результат явно показывает:
 
 - какие магазины способны закрыть весь список;
 - итоговую стоимость корзины, а не отдельных SKU;
 - отсутствующие и неоднозначно сопоставленные позиции;
 - свежесть цены и наличия;
-- разницу между удобством одной корзины и минимальной ценой нескольких магазинов.
+- известные/неизвестные delivery/service fees и minimum-order evidence;
+- разницу между complete/incomplete/uncertain/unavailable состояниями;
+- уникального победителя или честный tie только среди сопоставимых корзин.
 
 ## Текущее состояние
 
-Сейчас реализована и автоматически проверяется платформенная основа:
+Сейчас реализованы и автоматически проверяются:
 
+- **M1 Shopping Core — COMPLETE / ACCEPTED:** canonical quantities, deterministic matching, package-aware single-store basket semantics, truthful complete/uncertain/incomplete/unavailable states и production-access gating;
+- **M2 Recipes — COMPLETE / ACCEPTED:** Recipe domain, serving scaling, Recipe → ShoppingList → Comparison, responsive Recipe UI и deterministic multi-Recipe aggregation;
+- **M3 Weekly Planning / Pantry — COMPLETE / ACCEPTED:** WeeklyPlan composition, responsive planner, request-scoped Pantry subtraction с audit evidence и Pantry-aware comparison;
+- **M4 Basket Optimization — COMPLETE / ACCEPTED:** checkout economics, eligibility/comparability, deterministic cheapest-basket selection, explicit ties и responsive server-owned optimization UX;
+- **M5.1 Private local WeeklyPlan draft — COMPLETE / ACCEPTED:** versioned browser-local semantic input draft без серверных аккаунтов, generated IDs, comparison/economics/optimizer results или provider evidence;
 - Java 25 + Spring Boot 4.1 API;
 - PostgreSQL 18 + Flyway + jOOQ;
 - Spring Modulith architecture verification;
 - OpenAPI 3.1 как источник клиентского контракта;
 - генерируемый TypeScript API client;
-- Next.js 16.3 / React 19.2 responsive web shell;
+- Next.js 16.3 / React 19.2 responsive web;
 - Testcontainers с настоящим PostgreSQL;
 - Vitest + Testing Library + Playwright desktop/mobile;
 - безопасный Actuator health/readiness baseline;
 - воспроизводимый `./scripts/verify.sh`;
 - production Docker images для API/web и no-source-build `web + api + PostgreSQL` Compose topology, проверяемая отдельным `Release Bundle CI`.
 
-**Ещё не реализованы:** реальные retailer integrations, shopping-list domain, recipes, matching, basket optimization, auth и native mobile. Также пока не опубликован versioned GHCR release с multi-platform images, immutable release digests, SBOM, vulnerability report и provenance/attestation.
+### Retailer connectivity
+
+Product/core maturity и retailer acquisition readiness считаются разными измерениями:
+
+- Perekrestok/Pyaterochka имеют принятые browser-bridge acquisition evidence;
+- Magnit технически доступен через public web, но production access остаётся `BLOCKED` по operating policy проекта до появления подтверждённого права/поддерживаемого канала;
+- browser bridge для долгоживущих SPA/store-change сессий укреплён и принят (#153, закрывает #54);
+- Chizhik прошёл Phase A/B/C implementation и merged Phase D1 foundation: ordinary-user-browser field canary для `GET https://app.chizhik.club/api/v1/shops/` получил `200 + JSON`, но CI-hosted stock Chromium сейчас даёт live evidence `page-unavailable`, поэтому D1 transport disposition, D2 store-scoped offer mapping и production activation **ещё не приняты**;
+- Kuper, Ozon Fresh, Samokat, Lenta, VkusVill и остальные canonical retailers остаются обязательной connectivity work до воспроизводимого принятого acquisition path.
+
+**Ещё не выбраны/не завершены:** M5.2 (accounts/preferences, analytics abstraction, feature flags, provider health — только после release/manual-use evidence), server-side saved-plan history, полное production retailer coverage, richer substitute/package optimization, multi-store split optimization и native mobile.
+
+Новый stable `v0.1.0` также пока не разрешён: сначала должен успешно пройти полный immutable prerelease flow `v0.1.0-rc.3` с multi-platform images, Trivy, SBOM, digest smoke и provenance/attestation evidence.
 
 Фактический статус всегда фиксируется в [`docs/PROJECT_STATE.md`](docs/PROJECT_STATE.md).
 
@@ -82,7 +103,7 @@ pnpm install --frozen-lockfile
 ./scripts/verify-release-bundle.sh
 ```
 
-Полная настройка окружения и focused-команды: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md). Контейнерный/release contract и граница между уже проверенным bundle и ещё не реализованным GHCR publishing: [`docs/RELEASES.md`](docs/RELEASES.md).
+Полная настройка окружения и focused-команды: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md). Контейнерный/release contract и требования к immutable GHCR publishing: [`docs/RELEASES.md`](docs/RELEASES.md).
 
 ## Архитектура
 
@@ -109,7 +130,7 @@ pnpm install --frozen-lockfile
        retailer A     retailer B     retailer ...
 ```
 
-Основной путь retailer-интеграций — backend provider adapters. Client-side integration допускается только как осознанное исключение, если конкретный публичный API не требует секретов, разрешает CORS/browser use или действительно зависит от пользовательской browser-session.
+Основной путь retailer-интеграций — backend provider adapters. Client-side/browser integration допускается как осознанный acquisition mode, если конкретный first-party источник воспроизводимо работает только/лучше в пользовательском browser context и при этом не требует stealth, credential extraction или приватной mobile-client impersonation.
 
 Архитектурные решения: [`docs/adr/`](docs/adr/) и [`docs/superpowers/specs/`](docs/superpowers/specs/).
 
@@ -144,14 +165,14 @@ pnpm install --frozen-lockfile
 
 ## Roadmap
 
-- **M0A — Platform Foundation:** завершаем versioned GHCR/supply-chain release engineering и финальную проверку платформы.
-- **M0B — Retailer Feasibility:** доказываем минимум две технически и юридически приемлемые интеграции.
-- **M1 — Shopping Core**
-- **M2 — Recipes**
-- **M3 — Weekly Planning**
-- **M4 — Basket Optimization**
-- **M5 — Productization**
-- **M6 — Native Mobile**
+- **M0 — Product & Integration Discovery:** COMPLETE.
+- **M1 — Shopping Core:** COMPLETE / ACCEPTED.
+- **M2 — Recipes:** COMPLETE / ACCEPTED.
+- **M3 — Weekly Planning / Pantry:** COMPLETE / ACCEPTED.
+- **M4 — Basket Optimization:** COMPLETE / ACCEPTED.
+- **M5 — Productization:** CURRENT; M5.1 accepted, M5.2 intentionally unselected until RC/manual-use evidence.
+- **Immediate release gate:** immutable **`v0.1.0-rc.3`** end-to-end validation.
+- **M6 — Native Mobile:** future, after browser/API semantics stabilize enough to justify native clients.
 
 Подробные scope и exit criteria: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 

--- a/apps/retailer-bridge/src/chizhik-active-api-client.ts
+++ b/apps/retailer-bridge/src/chizhik-active-api-client.ts
@@ -1,5 +1,11 @@
 export const CHIZHIK_SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
+const CHIZHIK_DELIVERY_SEARCH_BASE =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores";
 const REQUEST_TIMEOUT_MS = 8_000;
+const DEFAULT_SEARCH_LIMIT = 12;
+const MAX_SEARCH_LIMIT = 50;
+const MAX_SEARCH_QUERY_LENGTH = 200;
+const SAP_ID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 
 export type ChizhikStoreSummary = Readonly<{
   sapId: string;
@@ -14,8 +20,19 @@ export type ChizhikStoreDiscoveryResult =
   | Readonly<{ status: "ok"; stores: readonly ChizhikStoreSummary[] }>
   | Readonly<{ status: "unavailable"; stores: readonly [] }>;
 
+export type ChizhikDeliverySearchRequest = Readonly<{
+  sapId: string;
+  query: string;
+  limit?: number;
+}>;
+
+export type ChizhikDeliverySearchResult =
+  | Readonly<{ status: "received"; payload: unknown }>
+  | Readonly<{ status: "unavailable" }>;
+
 export type ChizhikActiveApiClient = Readonly<{
   listStores(): Promise<ChizhikStoreDiscoveryResult>;
+  searchStore(request: ChizhikDeliverySearchRequest): Promise<ChizhikDeliverySearchResult>;
 }>;
 
 type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -62,6 +79,28 @@ function projectStore(raw: unknown): ChizhikStoreSummary | null {
   };
 }
 
+function buildDeliverySearchUrl(request: ChizhikDeliverySearchRequest): string | null {
+  const sapId = request.sapId.trim();
+  const query = request.query.trim();
+  const limit = request.limit ?? DEFAULT_SEARCH_LIMIT;
+
+  if (!SAP_ID_PATTERN.test(sapId)) return null;
+  if (query.length === 0 || query.length > MAX_SEARCH_QUERY_LENGTH) return null;
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_SEARCH_LIMIT) return null;
+
+  return `${CHIZHIK_DELIVERY_SEARCH_BASE}/${encodeURIComponent(sapId)}/search?mode=store&include_restrict=true&q=${encodeURIComponent(query)}&limit=${limit}`;
+}
+
+function requestInit(signal: AbortSignal): RequestInit {
+  return {
+    method: "GET",
+    mode: "cors",
+    credentials: "same-origin",
+    headers: { Accept: "application/json, text/plain, */*" },
+    signal,
+  };
+}
+
 export function createChizhikActiveApiClient(
   fetcher: Fetcher = globalThis.fetch.bind(globalThis),
 ): ChizhikActiveApiClient {
@@ -70,13 +109,7 @@ export function createChizhikActiveApiClient(
       const controller = new AbortController();
       const deadline = globalThis.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
       try {
-        const response = await fetcher(CHIZHIK_SHOPS_ENDPOINT, {
-          method: "GET",
-          mode: "cors",
-          credentials: "same-origin",
-          headers: { Accept: "application/json, text/plain, */*" },
-          signal: controller.signal,
-        });
+        const response = await fetcher(CHIZHIK_SHOPS_ENDPOINT, requestInit(controller.signal));
 
         if (!response.ok) return { status: "unavailable", stores: [] };
 
@@ -98,6 +131,32 @@ export function createChizhikActiveApiClient(
         return { status: "ok", stores };
       } catch {
         return { status: "unavailable", stores: [] };
+      } finally {
+        globalThis.clearTimeout(deadline);
+      }
+    },
+
+    async searchStore(
+      request: ChizhikDeliverySearchRequest,
+    ): Promise<ChizhikDeliverySearchResult> {
+      const url = buildDeliverySearchUrl(request);
+      if (!url) return { status: "unavailable" };
+
+      const controller = new AbortController();
+      const deadline = globalThis.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      try {
+        const response = await fetcher(url, requestInit(controller.signal));
+        if (!response.ok) return { status: "unavailable" };
+
+        const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+        if (!contentType.startsWith("application/json")) {
+          return { status: "unavailable" };
+        }
+
+        const payload: unknown = await response.json();
+        return { status: "received", payload };
+      } catch {
+        return { status: "unavailable" };
       } finally {
         globalThis.clearTimeout(deadline);
       }

--- a/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
@@ -109,4 +109,78 @@ describe("ChizhikActiveApiClient", () => {
 
     await expect(client.listStores()).resolves.toEqual({ status: "unavailable", stores: [] });
   });
+
+  it("builds one fixed store-scoped delivery search request from a validated sap id", async () => {
+    const opaquePayload = { schema: "not-yet-accepted" };
+    const fetcher = vi.fn(async () =>
+      new Response(JSON.stringify(opaquePayload), {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+    );
+    const client = createChizhikActiveApiClient(fetcher);
+
+    const result = await client.searchStore({ sapId: "HD87", query: "молоко" });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&include_restrict=true&q=%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE&limit=12",
+      {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(result).toEqual({ status: "received", payload: opaquePayload });
+  });
+
+  it("rejects unsafe store ids, blank queries, and unbounded limits before transport", async () => {
+    const fetcher = vi.fn(async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const client = createChizhikActiveApiClient(fetcher);
+
+    await expect(client.searchStore({ sapId: "../shops", query: "молоко" })).resolves.toEqual({
+      status: "unavailable",
+    });
+    await expect(client.searchStore({ sapId: "HD87", query: "   " })).resolves.toEqual({
+      status: "unavailable",
+    });
+    await expect(
+      client.searchStore({ sapId: "HD87", query: "молоко", limit: 0 }),
+    ).resolves.toEqual({ status: "unavailable" });
+    await expect(
+      client.searchStore({ sapId: "HD87", query: "молоко", limit: 51 }),
+    ).resolves.toEqual({ status: "unavailable" });
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps delivery search payload opaque and fails closed for non-json or transport failures", async () => {
+    const responses = [
+      new Response("blocked", { status: 403, headers: { "content-type": "text/plain" } }),
+      new Response("<html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    ];
+
+    for (const response of responses) {
+      const client = createChizhikActiveApiClient(vi.fn(async () => response));
+      await expect(client.searchStore({ sapId: "HD87", query: "молоко" })).resolves.toEqual({
+        status: "unavailable",
+      });
+    }
+
+    const client = createChizhikActiveApiClient(
+      vi.fn(async () => {
+        throw new Error("transport details must not escape");
+      }),
+    );
+    await expect(client.searchStore({ sapId: "HD87", query: "молоко" })).resolves.toEqual({
+      status: "unavailable",
+    });
+  });
 });

--- a/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
+++ b/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
@@ -46,9 +46,10 @@ describe("chizhikBrowserAdapter", () => {
     expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club.evil.example/"))).toBe(false);
   });
 
-  it("reports observation-only after active fixed-endpoint store discovery succeeds", async () => {
+  it("reports observation-only after active fixed-endpoint store discovery succeeds without auto-searching products", async () => {
     const listStores = vi.fn(async () => VALID_DISCOVERY);
-    const adapter = createChizhikBrowserAdapter({ listStores });
+    const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+    const adapter = createChizhikBrowserAdapter({ listStores, searchStore });
 
     await expect(
       adapter.collect({
@@ -59,11 +60,13 @@ describe("chizhikBrowserAdapter", () => {
       }),
     ).resolves.toEqual({ status: "observation-only", observations: [] });
     expect(listStores).toHaveBeenCalledTimes(1);
+    expect(searchStore).not.toHaveBeenCalled();
   });
 
   it("reuses one store discovery request for repeated collections in the same lifecycle", async () => {
     const listStores = vi.fn(async () => VALID_DISCOVERY);
-    const adapter = createChizhikBrowserAdapter({ listStores });
+    const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+    const adapter = createChizhikBrowserAdapter({ listStores, searchStore });
     const input = {
       document: documentWithGuessedProduct(),
       url: PAGE_URL,
@@ -76,6 +79,7 @@ describe("chizhikBrowserAdapter", () => {
     await adapter.collect(input);
 
     expect(listStores).toHaveBeenCalledTimes(1);
+    expect(searchStore).not.toHaveBeenCalled();
   });
 
   it("fails closed when active store discovery is unavailable or empty", async () => {
@@ -83,7 +87,11 @@ describe("chizhikBrowserAdapter", () => {
       { status: "unavailable" as const, stores: [] as const },
       { status: "ok" as const, stores: [] as const },
     ]) {
-      const adapter = createChizhikBrowserAdapter({ listStores: vi.fn(async () => result) });
+      const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+      const adapter = createChizhikBrowserAdapter({
+        listStores: vi.fn(async () => result),
+        searchStore,
+      });
       await expect(
         adapter.collect({
           document: documentWithGuessedProduct(),
@@ -92,11 +100,16 @@ describe("chizhikBrowserAdapter", () => {
           resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
         }),
       ).resolves.toEqual({ status: "missing-context", observations: [] });
+      expect(searchStore).not.toHaveBeenCalled();
     }
   });
 
   it("does not fabricate product offers from DOM or passive resource names", async () => {
-    const adapter = createChizhikBrowserAdapter({ listStores: vi.fn(async () => VALID_DISCOVERY) });
+    const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+    const adapter = createChizhikBrowserAdapter({
+      listStores: vi.fn(async () => VALID_DISCOVERY),
+      searchStore,
+    });
 
     await expect(
       adapter.collect({
@@ -106,5 +119,6 @@ describe("chizhikBrowserAdapter", () => {
         resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
       }),
     ).resolves.toEqual({ status: "observation-only", observations: [] });
+    expect(searchStore).not.toHaveBeenCalled();
   });
 });

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-16
+Updated: 2026-08-18
 
 ## Project
 
@@ -38,6 +38,8 @@ Milestone status:
 - M4 Basket Optimization — **COMPLETE / ACCEPTED**.
 - Pre-release web runtime hardening — **COMPLETE / ACCEPTED** (#150).
 - M5.1 Private local WeeklyPlan draft — **COMPLETE / ACCEPTED** (#148 / #149).
+- Retailer Bridge persistent-session / SPA / store-change lifecycle hardening — **COMPLETE / ACCEPTED** (#54 / #153).
+- Chizhik Phase D1 active normal-browser foundation — **IMPLEMENTED / MERGED; LIVE TRANSPORT GATE UNRESOLVED** (#167 / #168).
 
 Current deterministic product phase: **M5 — Productization**.  
 Immediate operational target: **`v0.1.0-rc.3` end-to-end release validation**.  
@@ -384,9 +386,89 @@ Manual source-checkout testing before M5.1 exposed two independent runtime/devel
 
 Accepted merge: `ef366c4ea65169dc3839cbf78c1df25d16f1dffa`; exact merge **8/8 normal push workflows SUCCESS**.
 
+## Retailer Bridge operational hardening — COMPLETE / ACCEPTED
+
+Issue #54 is no longer outstanding. PR #153 established the accepted long-lived browser-bridge lifecycle model and merged as `a3f7edb8028f2ba030c26d71ff10c17177e1abb9`.
+
+Accepted result:
+
+- persistent browser sessions no longer keep stale retailer/store context after SPA navigation or store changes;
+- same-document navigation is event-driven rather than polling-based;
+- fresh fulfillment-context evidence is required before recollecting a new route;
+- stale pre-navigation resources and obsolete async collection results cannot republish old-store observations;
+- monotonic lifecycle revisions prevent older service-worker writes from overwriting newer lifecycle state;
+- retained resource evidence stays bounded;
+- production extension permissions remain `storage` only and no cookies, auth headers, response bodies, `webRequest`, stealth or proxy behavior was added;
+- deterministic Chromium coverage includes same-store SPA refresh, store change, overlapping navigation/context changes, rapid navigation and obsolete in-flight collection rejection.
+
+This hardening is part of the accepted browser acquisition foundation for existing Perekrestok/Pyaterochka paths and for ongoing retailer onboarding.
+
+## Chizhik connectivity track — IMPLEMENTED THROUGH D1 / LIVE GATE UNRESOLVED
+
+Chizhik remains mandatory connectivity work, but merged implementation and live acquisition acceptance are intentionally separated.
+
+### Phase A — plain HTTPS feasibility — IMPLEMENTED / MERGED
+
+PR #156 merged as `1713b8c90b7370a54f733910c6302666b91d3413`.
+
+- bounded opt-in direct HTTPS probes target only the known unauthenticated catalog surface;
+- finite timeouts, no redirects/retries, sanitized response-shape evidence and no credential/session extraction;
+- Phase A proves only technical transport evidence and does not activate a production provider.
+
+### Phase B — browser discovery — IMPLEMENTED / MERGED
+
+PR #158 merged as `18c4f16027cbf85cff9803bfd0ed4d0cdf74533a`; PR #160 merged trusted `main` canary artifact publication as `98cc08698a19fdc7b4967d938e505e1f36955d63`.
+
+- exact official `chizhik.club` origin registration and observation-only discovery;
+- only allow-listed first-party catalog resource paths are retained as sanitized evidence;
+- discovery cannot persist guessed offers or infer fulfillment context;
+- exact bridge build that passes trusted `main` Chromium E2E can be published as a short-lived SHA-named canary artifact.
+
+### Phase C — public catalog document reachability — IMPLEMENTED / MERGED
+
+PRs #164/#165/#166 merged as `1b044ab58704c1a44a4fe4aa89dbeed4d961f1eb`, `21dbbdfb8db61ea00270c1ca2e8ae69e9f3799e1` and `a6e306da3b5a33710f94ef1956d71b1a462509e7`.
+
+- the probe is restricted to exact HTTPS `media.chizhik.club` catalog PDF paths;
+- redirects are bounded and revalidated before following;
+- production transport is body-less `HEAD`, with no cookies, auth, body parsing or header imitation;
+- controlled issue-comment execution publishes only sanitized reachability evidence;
+- transport failures use a finite safe category vocabulary and secondary GitHub status publication is bounded/best-effort;
+- document reachability is explicitly not product/price/fulfillment connectivity.
+
+### Phase D1 — active normal-browser store-directory foundation — IMPLEMENTED / MERGED; LIVE TRANSPORT GATE UNRESOLVED
+
+Issue #167 remains open. PR #168 merged as `e49c151fa44681dffe85fe90116009c86690672e`.
+
+Accepted field evidence on 2026-08-18 from an ordinary user-opened official Chizhik catalog page:
+
+- browser-context `GET https://app.chizhik.club/api/v1/shops/` returned HTTP `200`;
+- content type was JSON;
+- response was an array with observed store identity/coordinate fields including `sap_id`, `lat` and `lon`;
+- the full store response is not retained or published as project evidence.
+
+Merged D1 implementation now provides:
+
+- a fixed-endpoint active browser API client with an eight-second abort deadline;
+- strict store-shape and coordinate-range validation;
+- async retailer-adapter support while preserving existing synchronous adapters;
+- one active Chizhik store-directory discovery attempt per content-script lifecycle;
+- real extension Chromium E2E for successful CORS and fail-closed blocked transport;
+- an owner-only opt-in stock-Chromium live workflow that emits sanitized status/shape evidence only;
+- no stealth, fingerprint spoofing, proxy rotation, credential/header/cookie extraction, mobile impersonation or arbitrary URL proxying.
+
+Current live disposition is **not accepted**: the CI-hosted Phase D probe on the merged D1 `main` head reports `Provider Live Probe / Chizhik Phase D / page-unavailable` as failure evidence. This does not invalidate ordinary repository CI, which passed on the PR head; it means the server-controlled stock-Chromium acquisition path has not reproduced the successful ordinary-user-browser canary.
+
+Decision gate:
+
+- if CI-hosted stock Chromium reproducibly obtains `200 + JSON + sap_id/lat/lon`, a server-controlled browser acquisition worker remains viable;
+- if CI-hosted Chromium remains blocked while the ordinary user browser remains successful, prefer the active MV3 Retailer Bridge acquisition path;
+- only after that transport disposition should D2 validate one store-scoped product/delivery search endpoint and map only evidenced payload fields to `BrowserObservation` / `ObservedOffer`.
+
+Chizhik product/price offers, D2 and production activation remain **NOT ACCEPTED / NOT IMPLEMENTED**. Technical feasibility does not itself grant production/right-to-operate approval.
+
 ## Immediate operational target — v0.1.0-rc.3
 
-The next highest-value validation is a new immutable **`v0.1.0-rc.3` GitHub prerelease** from documentation-synchronized verified `main`.
+The next highest-value mainline validation is a new immutable **`v0.1.0-rc.3` GitHub prerelease** from documentation-synchronized verified `main`.
 
 It must prove the existing release workflow end to end: source/main ancestry verification, repository + browser + production bundle verification, multi-platform staging publication, unchanged HIGH/CRITICAL Trivy policy, SPDX SBOM evidence, staging exact-digest smoke, digest-identical final-package promotion, final exact-digest smoke, provenance attestations, prerelease SemVer tag promotion, final architecture manifest checks and attached release evidence/checksums while leaving `latest` untouched.
 
@@ -405,14 +487,18 @@ Decision: [`integrations/magnit-production-access-decision-2026-08-13.md`](integ
 
 ## Parallel mandatory work
 
-Continue without blocking deterministic M5 work unless evidence invalidates accepted core assumptions:
+Continue without blocking deterministic M5/release work unless evidence invalidates accepted core assumptions:
 
-- **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
 - **#36** Kuper supported aggregator investigation;
-- Chizhik, Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
+- Chizhik D1 transport disposition followed by D2 store-scoped product/delivery acquisition only when evidence justifies it;
+- Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
 - retailer-specific structured package semantics only where source evidence proves them;
 - retailer-specific production-access decisions before activation;
 - successful real **`v0.1.0-rc.3` GitHub Release** proving final image promotion, SBOM/attestation and digest smoke evidence.
+
+Completed parallel hardening:
+
+- **#54 / #153** browser-bridge persistent-session/store-change/SPA lifecycle hardening — **COMPLETE / ACCEPTED**.
 
 ## Permanent core invariants
 
@@ -448,6 +534,8 @@ Continue without blocking deterministic M5 work unless evidence invalidates acce
 30. The primary WeeklyPlan/Pantry optimization browser flow consumes generated M4.4.1 only; browser joins are identity/structure checks and never become a second checkout-arithmetic, comparability or winner-selection implementation.
 31. Browser-local repeat-use persistence is semantic input only: no generated identity, comparison/economics/optimizer result or provider evidence may become local draft authority.
 32. Local draft restore never implies submission; browser storage failures fail closed while explicit editing/submission remain usable.
+33. Browser acquisition lifecycle evidence must be revision-safe across SPA/store changes; stale context must not be republished after a newer navigation boundary.
+34. A successful ordinary-user-browser canary and a successful CI/server-browser transport are separate evidence classes; neither may be silently substituted for the other.
 
 ## Platform baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Updated: 2026-08-16
+Updated: 2026-08-18
 
 The roadmap is evidence-driven. Milestones change when integration evidence, product behavior or production constraints contradict an earlier assumption.
 
@@ -193,14 +193,25 @@ Server-side persistence/saved-plan history remains deferred until repeat-use evi
 
 ## Parallel connectivity / operational work
 
-Continue without blocking deterministic M5 work unless evidence invalidates accepted core assumptions:
+Continue without blocking deterministic M5/release work unless evidence invalidates accepted core assumptions.
 
-- **#54** browser-bridge persistent-session/store-change/SPA lifecycle hardening;
+Completed hardening:
+
+- **#54 / #153** browser-bridge persistent-session/store-change/SPA lifecycle hardening — **COMPLETE / ACCEPTED**. The accepted model uses event-driven navigation lifecycle handling, fresh-context gating, bounded retained resource evidence and revision-safe observation writes without widening production extension permissions.
+
+Current mandatory connectivity work:
+
 - **#36** Kuper supported aggregator investigation;
-- Chizhik, Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
+- **Chizhik #167** — Phase A/B/C and D1 implementation are merged, but the D1 live transport decision remains open: an ordinary user browser successfully reached `GET https://app.chizhik.club/api/v1/shops/` with `200 + JSON + sap_id/lat/lon`, while the current CI-hosted stock-Chromium live result is `page-unavailable`;
+- if CI-hosted stock Chromium reproducibly obtains `200 + JSON + required store shape`, a server-controlled browser worker remains viable;
+- if CI-hosted Chromium remains blocked while the ordinary user browser succeeds, prefer the active MV3 Retailer Bridge path;
+- only after that D1 transport disposition, validate one store-scoped D2 product/delivery endpoint and map only evidenced fields into `BrowserObservation` / `ObservedOffer`; do not fabricate promo/package/availability semantics;
+- Ozon Fresh, Samokat, Lenta and VkusVill onboarding/hardening;
 - structured package semantics only where source evidence proves them;
 - retailer-specific production-access/right-to-operate decisions before activation;
 - successful real **`v0.1.0-rc.3`** release event with final image promotion, SBOM/attestation and digest smoke evidence.
+
+Chizhik D1 merged implementation is not equivalent to an accepted production acquisition path. D2 and production activation remain unimplemented/unaccepted until transport and right-to-operate evidence justify them.
 
 ## M4 — Basket Optimization — COMPLETE / ACCEPTED
 

--- a/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
+++ b/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
@@ -1,0 +1,191 @@
+# Chizhik D2 store-scoped delivery-search canary — 2026-08-18
+
+## Status
+
+**Ready for ordinary-user-browser execution.** This document does not accept the delivery payload schema by itself.
+
+Phase D1 established the technical transport split:
+
+- an ordinary user-opened `https://chizhik.club/` page can fetch the fixed first-party store directory at `https://app.chizhik.club/api/v1/shops/` and receive valid JSON;
+- stock GitHub-hosted Chromium was `page-unavailable`;
+- therefore Chizhik acquisition remains a normal user-browser MV3 Retailer Bridge path rather than a managed browser worker.
+
+Issue: #169.
+
+## Candidate D2 endpoint
+
+A public third-party implementation (`Open-Inflation/chizhik_api`) is used only as endpoint-discovery input. Its current source suggests:
+
+```text
+GET https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search?mode=store&include_restrict=true&q={query}&limit={limit}
+```
+
+Its tests pass a store `sap_id` into this delivery-search path. Neither the endpoint nor its response schema becomes an accepted ZakupGotov contract until the ordinary-browser canary below succeeds.
+
+## Safety boundary
+
+The canary:
+
+- must be run only from DevTools on an already-open official `https://chizhik.club/...` page;
+- requests only the exact `/api/v1/shops/` directory and the fixed store-scoped delivery-search template;
+- selects one active store internally and **does not print its `sap_id`, address, coordinates, or other store values**;
+- searches only the fixed term `кола` with `limit=1`;
+- uses ordinary `cors`, `same-origin` credentials and an 8-second deadline;
+- prints HTTP status plus structural schema only;
+- filters reported object field names to ASCII identifier-like keys before printing them, preventing dynamic IDs/values used as object keys from leaking into evidence;
+- never prints or persists the raw JSON body, product names, SKUs, prices, promotion values, cookies, headers or credentials.
+
+Do not paste a raw response body into an issue, PR, chat or repository.
+
+## DevTools canary
+
+Open an official Chizhik catalog page, open DevTools → Console, paste the whole block and run it once:
+
+```js
+(async () => {
+  const PAGE_ORIGIN = "https://chizhik.club";
+  const SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
+  const SEARCH_BASE = "https://app.chizhik.club/delivery/api/catalog/v3/stores";
+  const QUERY = "кола";
+  const LIMIT = 1;
+  const TIMEOUT_MS = 8_000;
+  const SAP_ID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
+  const SAFE_FIELD = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+  const valueType = (value) => {
+    if (value === null) return "null";
+    if (Array.isArray(value)) return "array";
+    return typeof value;
+  };
+
+  const requestJson = async (url) => {
+    const controller = new AbortController();
+    const deadline = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+        signal: controller.signal,
+      });
+      const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+      if (!response.ok || !contentType.startsWith("application/json")) {
+        return { status: "HTTP_UNAVAILABLE", httpStatus: response.status, contentType, payload: null };
+      }
+      try {
+        return {
+          status: "RECEIVED",
+          httpStatus: response.status,
+          contentType,
+          payload: await response.json(),
+        };
+      } catch {
+        return { status: "INVALID_JSON", httpStatus: response.status, contentType, payload: null };
+      }
+    } catch {
+      return { status: "FETCH_UNAVAILABLE", httpStatus: -1, contentType: "", payload: null };
+    } finally {
+      clearTimeout(deadline);
+    }
+  };
+
+  const schema = [];
+  const seenPaths = new Set();
+  const visit = (value, path = "$", depth = 0) => {
+    if (depth > 5 || schema.length >= 80 || seenPaths.has(path)) return;
+    seenPaths.add(path);
+
+    if (Array.isArray(value)) {
+      schema.push({ path, type: "array" });
+      if (value.length > 0) visit(value[0], `${path}[]`, depth + 1);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+
+    const safeEntries = Object.entries(value).filter(([key]) => SAFE_FIELD.test(key));
+    schema.push({
+      path,
+      type: "object",
+      fields: Object.fromEntries(safeEntries.map(([key, child]) => [key, valueType(child)])),
+    });
+    for (const [key, child] of safeEntries) {
+      if (child && typeof child === "object") visit(child, `${path}.${key}`, depth + 1);
+    }
+  };
+
+  if (location.origin !== PAGE_ORIGIN) {
+    console.log("CHIZHIK_D2 status=WRONG_ORIGIN");
+    return;
+  }
+
+  const shops = await requestJson(SHOPS_ENDPOINT);
+  if (shops.status !== "RECEIVED" || !Array.isArray(shops.payload)) {
+    console.log(
+      `CHIZHIK_D2 status=SHOPS_UNAVAILABLE shops_http_status=${shops.httpStatus} search_http_status=-1 root=unknown`,
+    );
+    return;
+  }
+
+  const store = shops.payload.find(
+    (row) =>
+      row &&
+      typeof row === "object" &&
+      row.status === 1 &&
+      typeof row.sap_id === "string" &&
+      SAP_ID_PATTERN.test(row.sap_id),
+  );
+  if (!store) {
+    console.log(
+      `CHIZHIK_D2 status=NO_VALID_STORE shops_http_status=${shops.httpStatus} search_http_status=-1 root=unknown`,
+    );
+    return;
+  }
+
+  const searchUrl = `${SEARCH_BASE}/${encodeURIComponent(store.sap_id)}/search?mode=store&include_restrict=true&q=${encodeURIComponent(QUERY)}&limit=${LIMIT}`;
+  const search = await requestJson(searchUrl);
+  if (search.status !== "RECEIVED") {
+    console.log(
+      `CHIZHIK_D2 status=${search.status} shops_http_status=${shops.httpStatus} search_http_status=${search.httpStatus} root=unknown`,
+    );
+    return;
+  }
+
+  visit(search.payload);
+  console.log(
+    `CHIZHIK_D2 status=PASS shops_http_status=${shops.httpStatus} search_http_status=${search.httpStatus} content_type=application/json root=${valueType(search.payload)}`,
+  );
+  console.log(`CHIZHIK_D2_SCHEMA=${JSON.stringify(schema)}`);
+})().catch(() => {
+  console.log("CHIZHIK_D2 status=PROBE_ERROR shops_http_status=-1 search_http_status=-1 root=unknown");
+});
+```
+
+## Evidence to retain
+
+Retain only the two lines whose prefixes are:
+
+```text
+CHIZHIK_D2 ...
+CHIZHIK_D2_SCHEMA=...
+```
+
+A transport PASS alone is not enough for offer production. The schema line must show unambiguous fields/types for the minimum `BrowserObservation` mapping:
+
+- store fulfillment context remains the already validated `sap_id` from D1;
+- SKU/product identifier;
+- product name;
+- price plus enough evidence to determine whether it is already minor units or requires conversion;
+- availability only if an explicit, understood field exists; otherwise ZakupGotov must use `UNKNOWN`.
+
+Promotion, loyalty, package and discount semantics remain unavailable unless separately evidenced.
+
+## Next gate
+
+After sanitized browser evidence is accepted:
+
+1. freeze a minimal fixture containing only the evidenced fields;
+2. add a failing adapter test for exact `BrowserObservation` mapping;
+3. implement the minimum mapping;
+4. add Chromium E2E for search success, malformed JSON/schema, blocked transport and unknown-field non-persistence;
+5. keep technical feasibility separate from production/right-to-operate approval.

--- a/docs/integrations/chizhik-d2-external-schema-hypothesis-2026-08-18.md
+++ b/docs/integrations/chizhik-d2-external-schema-hypothesis-2026-08-18.md
@@ -1,0 +1,58 @@
+# Chizhik D2 external schema hypothesis — 2026-08-18
+
+## Classification
+
+**Discovery hint only — not accepted provider evidence.**
+
+This note records public third-party reverse-engineering material to make the next ordinary-browser canary easier to interpret. It must not be used by production offer mapping until the same field structure and price semantics are confirmed from the official Chizhik page origin.
+
+Tracking issue: #169.
+
+## Source inspected
+
+Public repository: `Open-Inflation/chizhik_api`.
+
+Relevant current files:
+
+- `chizhik_api/endpoints/catalog.py` — suggests the store-scoped delivery search template;
+- `tests/api_test.py` — takes `sap_id` from shop search and passes it as `store_id` to delivery search;
+- `tests/__snapshots__/ClassCatalog.delivery_search.schema.json` — generated response-schema snapshot;
+- `tests/__snapshots__/ClassCatalog.delivery_search.json` — historical response snapshot.
+
+ZakupGotov does **not** adopt that project's Camoufox/proxy/session-emulation approach. Only public endpoint/schema hints are being inspected.
+
+## Hypothesized response shape
+
+The third-party schema snapshot reports an object with a `products` array. A product item includes, among many other fields:
+
+| Candidate field | Snapshot type | Possible ZakupGotov role | Accepted? |
+| --- | --- | --- | --- |
+| `plu` | integer | SKU | **No** |
+| `name` | string | product name | **No** |
+| `prices.regular` | string | price candidate | **No** |
+| `is_available` | boolean | availability candidate | **No** |
+| `stock_limit` | string | stock metadata | **No** |
+| `uom` | string | unit hint | **No** |
+| `property_clarification` | string | package/display hint | **No** |
+
+The historical snapshot shows `prices.regular` formatted as a decimal-looking string, which is consistent with rubles rather than integer kopecks. That is still insufficient evidence to implement `priceMinor` conversion: the live official-origin canary must confirm the current field and its unit semantics first.
+
+## Fields deliberately excluded from current mapping
+
+The snapshot also contains promotion/loyalty/advertising fields such as `promo`, `prices.discount`, `cpd_promo_price`, `orange_loyalty_points`, labels and badges. None of these may be interpreted until separately evidenced. D2's minimum mapping is limited to identity, name, base price and availability.
+
+## Acceptance gate
+
+The ordinary-browser canary documented in `chizhik-d2-delivery-search-canary-2026-08-18.md` must confirm at minimum:
+
+```text
+$.products -> array
+$.products[] -> object
+$.products[].plu -> integer/number
+$.products[].name -> string
+$.products[].prices -> object
+$.products[].prices.regular -> string/number
+$.products[].is_available -> boolean
+```
+
+Only after that evidence is accepted may a new RED test specify `BrowserObservation` mapping. Until then the active Chizhik adapter remains `observation-only` and performs zero automatic delivery-search calls.

--- a/docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync-shipping.md
+++ b/docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync-shipping.md
@@ -1,0 +1,38 @@
+# Pre-RC3 documentation synchronization shipping evidence
+
+Date: 2026-08-18
+
+## Scope
+
+Docs-only synchronization before the `v0.1.0-rc.3` release gate.
+
+Changed documentation:
+
+- `README.md`
+- `CHANGELOG.md`
+- `docs/PROJECT_STATE.md`
+- `docs/ROADMAP.md`
+- design and implementation plan for this synchronization
+
+No runtime, API/OpenAPI, generated client, provider implementation, database schema, dependency or release-workflow behavior is changed.
+
+## Pre-PR verification
+
+Branch: `docs/sync-state-before-rc3`
+
+Comparison against `main=e49c151fa44681dffe85fe90116009c86690672e` before PR creation:
+
+- branch status: ahead, behind `0`;
+- changed runtime/config/dependency paths: `0`;
+- README reports `M5 — Productization` rather than obsolete M0;
+- README no longer claims Shopping Core, Recipes, matching or basket optimization are unimplemented;
+- #54/#153 is recorded as complete/accepted rather than outstanding;
+- Chizhik Phase A/B/C/D1 implementation is recorded without claiming production activation;
+- ordinary-user-browser `/api/v1/shops/` success and CI-hosted `page-unavailable` are kept as separate evidence classes;
+- D2 remains unimplemented/unaccepted;
+- `v0.1.0-rc.3` remains the immediate mainline release gate;
+- M5.2 remains intentionally unselected.
+
+## Acceptance gate
+
+This documentation synchronization is not accepted until the exact PR head passes normal repository PR CI, the PR is squash-merged with expected-head protection, and post-merge normal `main` workflows are verified.

--- a/docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync.md
+++ b/docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync.md
@@ -1,0 +1,209 @@
+# Pre-RC3 Documentation Synchronization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring canonical/public project documentation in sync with verified `main` before creating `v0.1.0-rc.3`.
+
+**Architecture:** This is a docs-only synchronization. `PROJECT_STATE.md` remains the factual state snapshot, `ROADMAP.md` owns next-step sequencing, root `CHANGELOG.md` records notable Unreleased history, and `README.md` gives a concise public-facing summary. Runtime behavior and release workflows remain untouched.
+
+**Tech Stack:** Markdown, GitHub pull requests, existing repository CI.
+
+## Global Constraints
+
+- No runtime, API, OpenAPI, generated client, provider behavior, database schema, release workflow, or dependency changes.
+- Chizhik D1 implementation may be described as merged, but not as an accepted production acquisition path while the CI-hosted live probe remains `page-unavailable`.
+- Technical accessibility must remain separate from production/right-to-operate approval.
+- Ordinary CI must remain free of hidden live retailer traffic.
+- M1–M5.1 accepted semantics must not be redefined.
+- `v0.1.0-rc.3` remains the next mainline release validation; M5.2 remains intentionally unselected.
+
+---
+
+### Task 1: Synchronize canonical state and roadmap
+
+**Files:**
+- Modify: `docs/PROJECT_STATE.md`
+- Modify: `docs/ROADMAP.md`
+
+**Interfaces:**
+- Consumes: merged `main` evidence through PR #153/#156/#158/#160/#164/#165/#166/#168 and issue #167.
+- Produces: one consistent canonical description of current M5 status, completed bridge hardening, Chizhik A–D1 evidence, unresolved live D1 gate, and RC3 sequencing.
+
+- [ ] **Step 1: Update `PROJECT_STATE.md` date and current-work summary**
+
+Set `Updated:` to `2026-08-18`. Keep `Current phase: M5 — Productization` and `v0.1.0-rc.3` as the immediate operational target. Add a post-M5.1/current-connectivity subsection that records:
+
+```text
+#54/#153 browser-bridge persistent-session / SPA / store-change hardening — COMPLETE / ACCEPTED
+Chizhik Phase A plain HTTPS probe — IMPLEMENTED / MERGED; negative/live evidence does not activate production
+Chizhik Phase B browser discovery — IMPLEMENTED / MERGED; observation-only
+Chizhik Phase C public catalog document probe + controlled workflow — IMPLEMENTED / MERGED; document reachability is not product/price connectivity
+Chizhik Phase D1 active normal-browser foundation — IMPLEMENTED / MERGED; user-browser /api/v1/shops/ field canary succeeded, CI-hosted stock Chromium currently reports page-unavailable
+Chizhik D2 store-scoped product/delivery offer mapping — NOT IMPLEMENTED / NEXT only after D1 transport disposition
+```
+
+- [ ] **Step 2: Remove stale outstanding #54 wording from `PROJECT_STATE.md`**
+
+Replace the old parallel-work bullet that lists `#54` as outstanding with a completed-hardening statement and keep the remaining Kuper/Ozon Fresh/Samokat/Lenta/VkusVill work outstanding.
+
+- [ ] **Step 3: Update `ROADMAP.md` parallel connectivity section**
+
+Move #54 from outstanding work to completed operational hardening. Add the Chizhik D1 decision gate:
+
+```text
+- if reproducible CI-hosted stock Chromium obtains 200 + JSON + required store shape, a server-controlled browser worker remains viable;
+- if CI-hosted Chromium remains blocked while an ordinary user browser succeeds, prefer the active MV3 Retailer Bridge path;
+- only after that disposition, validate one store-scoped D2 product/delivery endpoint and map only evidenced fields to BrowserObservation/ObservedOffer.
+```
+
+- [ ] **Step 4: Preserve mainline sequencing in `ROADMAP.md`**
+
+Keep `v0.1.0-rc.3` as `NEXT`, stable `v0.1.0` blocked until prerelease evidence is inspected, and M5.2 explicitly unselected until RC/manual-use evidence exists.
+
+- [ ] **Step 5: Review Task 1 diff**
+
+Expected: only the two Markdown files change; no statement claims Chizhik production activation or D1 acceptance beyond merged implementation.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add docs/PROJECT_STATE.md docs/ROADMAP.md
+git commit -m "docs: sync state and roadmap after Chizhik D1"
+```
+
+---
+
+### Task 2: Synchronize changelog and public README
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: canonical state established in Task 1.
+- Produces: public-facing project description and Unreleased history consistent with the canonical docs.
+
+- [ ] **Step 1: Add Unreleased retailer-connectivity entries to `CHANGELOG.md`**
+
+Under `## [Unreleased]`, record:
+
+```text
+Retailer Bridge long-lived session hardening for SPA/store changes, fresh-context gating, bounded resource evidence and revision-safe writes (#153).
+Chizhik Phase A bounded plain HTTPS feasibility probe (#156).
+Chizhik Phase B observation-only browser discovery (#158) and trusted main canary artifact publication (#160).
+Chizhik Phase C bounded public catalog-document probe, controlled live workflow, and sanitized transport classification (#164/#165/#166).
+Chizhik Phase D1 active browser-context store-directory foundation (#168), including strict fixed endpoint/shape validation and ordinary extension Chromium E2E.
+```
+
+State explicitly that the ordinary-user-browser `/api/v1/shops/` canary succeeded but current CI-hosted Phase D live status is `page-unavailable`, so D2/production offer acquisition remains unaccepted.
+
+- [ ] **Step 2: Replace obsolete README status**
+
+Change:
+
+```text
+Status: M0 — Product & Integration Discovery
+```
+
+into a current pre-release statement equivalent to:
+
+```text
+Status: M5 — Productization · pre-release · next release gate: v0.1.0-rc.3
+```
+
+- [ ] **Step 3: Replace obsolete README implementation summary**
+
+Remove claims that Shopping Core, Recipes, matching and basket optimization are not implemented. Summarize accepted capabilities:
+
+```text
+M1 Shopping Core
+M2 Recipes
+M3 Weekly Planning + Pantry
+M4 truthful checkout economics + deterministic basket optimization
+M5.1 private browser-local WeeklyPlan/Pantry draft
+```
+
+Keep accounts/auth, server-side saved-plan history, analytics/feature flags/provider health, complete retailer production coverage and native mobile as future work.
+
+- [ ] **Step 4: Update README retailer-connectivity paragraph**
+
+Explain that product/core semantics are accepted, while retailer production coverage remains retailer-specific and evidence-gated. Mention that Perekrestok/Pyaterochka have accepted browser-bridge acquisition evidence, Magnit is technically reachable but production-blocked by project operating policy, and Chizhik is under active D1/D2 validation.
+
+- [ ] **Step 5: Update README roadmap bullets**
+
+Mark M0–M4 complete, M5 current, and M6 future. Keep `v0.1.0-rc.3` as the immediate release gate.
+
+- [ ] **Step 6: Review Task 2 diff**
+
+Expected: README no longer contradicts `PROJECT_STATE.md`; changelog distinguishes merged implementation from live/production acceptance.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: refresh public status before rc3"
+```
+
+---
+
+### Task 3: Verify documentation consistency and ship PR
+
+**Files:**
+- Review: `docs/PROJECT_STATE.md`
+- Review: `docs/ROADMAP.md`
+- Review: `CHANGELOG.md`
+- Review: `README.md`
+- Review: `docs/superpowers/specs/2026-08-18-pre-rc3-documentation-sync-design.md`
+- Review: `docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync.md`
+
+**Interfaces:**
+- Consumes: Tasks 1–2.
+- Produces: reviewable docs-only PR ready for standard repository CI.
+
+- [ ] **Step 1: Search final branch content for stale contradictions**
+
+Verify all of the following:
+
+```text
+README does not say Status: M0
+README does not say shopping-list domain / recipes / matching / basket optimization are unimplemented
+PROJECT_STATE/ROADMAP do not list #54 as outstanding
+all four docs keep v0.1.0-rc.3 as the next mainline release gate
+all four docs avoid claiming Chizhik production activation
+M5.2 remains unselected
+```
+
+- [ ] **Step 2: Compare branch against `main`**
+
+Expected changed paths are limited to:
+
+```text
+README.md
+CHANGELOG.md
+docs/PROJECT_STATE.md
+docs/ROADMAP.md
+docs/superpowers/specs/2026-08-18-pre-rc3-documentation-sync-design.md
+docs/superpowers/plans/2026-08-18-pre-rc3-documentation-sync.md
+```
+
+- [ ] **Step 3: Open a docs-only pull request**
+
+Use title:
+
+```text
+docs: synchronize project state before v0.1.0-rc.3
+```
+
+PR body must state that runtime/config/dependencies are unchanged, summarize #54 completion and Chizhik A–D1 evidence, and call out the unresolved `page-unavailable` D1 live result.
+
+- [ ] **Step 4: Wait for exact-head standard PR CI and inspect all workflow groups**
+
+Expected: required repository workflow groups complete successfully. A controlled provider-live status is evidence, not an ordinary PR build gate, unless the PR explicitly changes that workflow.
+
+- [ ] **Step 5: Merge only on green exact head**
+
+Use squash merge with expected-head protection.
+
+- [ ] **Step 6: Verify post-merge `main` CI**
+
+Confirm normal `main` push workflows complete successfully before considering documentation synchronization accepted.

--- a/docs/superpowers/specs/2026-08-18-pre-rc3-documentation-sync-design.md
+++ b/docs/superpowers/specs/2026-08-18-pre-rc3-documentation-sync-design.md
@@ -1,0 +1,74 @@
+# Pre-RC3 documentation synchronization design
+
+Date: 2026-08-18
+
+## Context
+
+Canonical product documentation was last synchronized after M5.1 acceptance on 2026-08-16. Since then `main` has advanced through retailer-bridge lifecycle hardening and Chizhik acquisition investigation through the merged Phase D1 foundation. The release roadmap requires `v0.1.0-rc.3` to be cut from documentation-synchronized verified `main`, so documentation drift is now a release blocker.
+
+## Goal
+
+Synchronize the public project narrative with the verified repository state without changing runtime behavior and without overstating live retailer readiness.
+
+## Approaches considered
+
+1. **Minimal state-only patch** — update only `PROJECT_STATE.md` and `ROADMAP.md`. Lowest diff, but leaves the public README and changelog materially misleading.
+2. **Canonical four-file synchronization** — update `PROJECT_STATE.md`, `ROADMAP.md`, root `CHANGELOG.md`, and `README.md`. This keeps the release gate, public project status, and historical record aligned. **Chosen.**
+3. **Broad documentation rewrite** — audit and rewrite all integration docs at once. More comprehensive, but unnecessarily expands scope before RC3.
+
+## Scope
+
+### `docs/PROJECT_STATE.md`
+
+- advance the update date to 2026-08-18;
+- retain M5 / `v0.1.0-rc.3` as the deterministic product/release target;
+- mark browser-bridge persistent-session / SPA / store-change hardening (#54/#153) complete;
+- record Chizhik Phase A, B, C, and merged D1 implementation evidence;
+- record the accepted ordinary-user-browser `/api/v1/shops/` field canary;
+- explicitly keep Chizhik production offer acquisition and D2 unaccepted;
+- record the current CI-hosted Phase D `page-unavailable` live outcome as negative evidence, not as ordinary CI failure;
+- keep production/right-to-operate approval separate from technical feasibility.
+
+### `docs/ROADMAP.md`
+
+- remove #54 from outstanding parallel work and record it as completed hardening;
+- describe Chizhik as an active connectivity track with D1 implementation merged but live transport gate unresolved;
+- keep D2 as the next Chizhik evidence slice only after D1 transport disposition;
+- preserve `v0.1.0-rc.3` as the next mainline release validation and keep M5.2 intentionally unselected.
+
+### `CHANGELOG.md`
+
+- add Unreleased entries for retailer-bridge lifecycle hardening;
+- add Chizhik Phase A/B/C/D1 work and its safety boundaries;
+- distinguish merged implementation from unresolved live acquisition evidence.
+
+### `README.md`
+
+- replace obsolete M0 status with current M5 Productization / pre-release status;
+- replace the stale “not implemented” section with the accepted M1–M5.1 capability summary;
+- describe retailer connectivity truthfully: core product semantics are implemented, but production acquisition coverage remains incomplete and retailer-specific;
+- keep `v0.1.0-rc.3` as the immediate release target.
+
+## Invariants
+
+- No runtime, API, OpenAPI, generated client, provider behavior, database schema, release workflow, or dependency changes.
+- No claim that Chizhik D1 is accepted as a production acquisition path while the CI-hosted live probe remains `page-unavailable`.
+- No claim that technical accessibility grants legal or operational permission.
+- No hidden live retailer traffic is introduced into ordinary CI.
+- Existing accepted M1–M5.1 semantics are not redefined.
+
+## Verification
+
+- review the final diff for contradictions between all four documents;
+- ensure references to #54 as outstanding work are removed;
+- ensure README no longer claims M1–M4 are unimplemented;
+- run repository PR CI through the normal GitHub workflow after opening the docs-only PR;
+- merge only after the exact PR head is green and the branch is current with `main`.
+
+## Non-goals
+
+- creating `v0.1.0-rc.3` in this patch;
+- selecting M5.2;
+- implementing Chizhik D2;
+- merging dependency-update PRs;
+- changing retailer production-access policy.


### PR DESCRIPTION
Tracks #169. This PR intentionally does **not** close D2 because live schema acceptance and offer mapping remain pending.

## Scope
- add a fixed Chizhik store-scoped delivery-search transport using a validated-form `sap_id`;
- exact `https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search` path only;
- URL-encoded nonblank query, default limit 12, bounded limit 1..50;
- ordinary page-origin `cors` + `same-origin` credentials and 8s abort deadline;
- keep successful JSON payload typed as `unknown` / opaque;
- adapter remains `observation-only` and is explicitly tested to perform **zero** delivery-search calls until schema acceptance;
- add a privacy-safe ordinary-user-browser canary that prints only HTTP/type and filtered field-name/type schema;
- no extension permission widening, stealth, proxies, credential/header/cookie extraction, mobile impersonation, arbitrary URL forwarding, or raw-body evidence.

## TDD evidence
1. RED `7e6107d7…`: 45 existing tests PASS; 3 new D2 tests FAIL only with `client.searchStore is not a function`.
2. GREEN `999e3035…`: 48/48 unit tests PASS, typecheck PASS, build PASS, Chromium E2E PASS.
3. Regression gate: adapter never invokes `searchStore` before schema acceptance.
4. Latest head `31463d4c…`: all 9 PR workflows PASS, including Retailer Bridge CI, CodeQL, Dependency Review, Container Security, API/Web/Contract/Release checks.
5. Review threads: 0; review pass found no blocker.

## Evidence gate still open
A third-party snapshot suggests `products[]` with fields such as `plu`, `name`, `prices.regular`, and `is_available`, but this remains discovery input only. In particular, price units are **not** accepted yet. The documented ordinary-browser canary must confirm the endpoint and schema before any `BrowserObservation` mapping is implemented.

Technical feasibility remains separate from production/right-to-operate approval.