### PR TITLE
feat(chizhik): bind D2 to evidenced browser store context

### DIFF
--- a/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
@@ -13,6 +13,8 @@ const hd88Search =
   "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD88/search?mode=store&q=cola";
 const unknownSearch =
   "https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search?mode=store&q=cola";
+const foreignOriginSearch =
+  "https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=cola";
 
 const stores = [
   {
@@ -100,6 +102,19 @@ async function routeDeliveryEvidence(context: BrowserContext): Promise<void> {
   });
 }
 
+async function routeForeignDeliveryEvidence(context: BrowserContext): Promise<void> {
+  await context.route("https://app.chizhik.club.evil.example/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "access-control-allow-origin": "https://chizhik.club",
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ products: [] }),
+    });
+  });
+}
+
 async function emitDeliveryResource(page: Page, url: string): Promise<void> {
   await page.evaluate(async (resourceUrl) => {
     await fetch(resourceUrl, {
@@ -155,6 +170,28 @@ test("fails closed for an evidenced delivery store absent from the validated dir
     const page = await context.newPage();
     await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
     await emitDeliveryResource(page, unknownSearch);
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("missing-context");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("fails closed for a foreign-origin delivery resource even when it carries a validated store id", async () => {
+  const { context, userDataDir } = await launchBridge();
+
+  try {
+    await routeOfficialPage(context);
+    await routeShops(context);
+    await routeForeignDeliveryEvidence(context);
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+    await emitDeliveryResource(page, foreignOriginSearch);
 
     await expect
       .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))

--- a/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-active-extension.spec.ts
@@ -1,12 +1,40 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { chromium, expect, test } from "@playwright/test";
+import { chromium, expect, test, type BrowserContext, type Page } from "@playwright/test";
 
 const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
 const extensionPath = resolve(bridgeRoot, "dist");
 const pageHtml = "<!doctype html><html><body><main>Chizhik catalog fixture</main></body></html>";
 const shopsEndpoint = "https://app.chizhik.club/api/v1/shops/";
+const hd87Search =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=cola";
+const hd88Search =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD88/search?mode=store&q=cola";
+const unknownSearch =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search?mode=store&q=cola";
+
+const stores = [
+  {
+    id: 26504,
+    sap_id: "HD87",
+    lon: 37.83372708,
+    lat: 55.76833314,
+    status: 1,
+    name: "Москва, Саянская ул., Дом 11Б",
+    locality: "Москва",
+    secret_like_field: "MUST_NOT_PERSIST",
+  },
+  {
+    id: 26523,
+    sap_id: "HD88",
+    lon: 37.80898339,
+    lat: 55.39666279,
+    status: 1,
+    name: "Домодедово, Вокзальная ул., Строение 2г",
+    locality: "Домодедово",
+  },
+];
 
 async function launchBridge() {
   const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-chizhik-"));
@@ -21,49 +49,90 @@ async function launchBridge() {
   return { context, userDataDir };
 }
 
-test("actively discovers Chizhik stores once through normal page-origin CORS without creating offers", async () => {
-  const { context, userDataDir } = await launchBridge();
-  let shopsRequests = 0;
-
-  try {
-    await context.route("https://chizhik.club/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "text/html; charset=utf-8",
-        body: pageHtml,
-      });
+async function routeOfficialPage(context: BrowserContext): Promise<void> {
+  await context.route("https://chizhik.club/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: pageHtml,
     });
-    await context.route(shopsEndpoint, async (route) => {
-      shopsRequests += 1;
+  });
+}
+
+async function routeShops(context: BrowserContext, status = 200): Promise<() => number> {
+  let requests = 0;
+  await context.route(shopsEndpoint, async (route) => {
+    requests += 1;
+    if (status !== 200) {
       await route.fulfill({
-        status: 200,
+        status,
         headers: {
           "access-control-allow-origin": "https://chizhik.club",
-          "content-type": "application/json; charset=utf-8",
+          "content-type": "text/plain; charset=utf-8",
         },
-        body: JSON.stringify([
-          {
-            id: 26504,
-            sap_id: "HD87",
-            lon: 37.83372708,
-            lat: 55.76833314,
-            status: 1,
-            name: "Москва, Саянская ул., Дом 11Б",
-            locality: "Москва",
-            secret_like_field: "MUST_NOT_PERSIST",
-          },
-        ]),
+        body: "blocked",
       });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "access-control-allow-origin": "https://chizhik.club",
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(stores),
     });
+  });
+  return () => requests;
+}
+
+async function routeDeliveryEvidence(context: BrowserContext): Promise<void> {
+  await context.route("https://app.chizhik.club/delivery/api/catalog/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "access-control-allow-origin": "https://chizhik.club",
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ products: [] }),
+    });
+  });
+}
+
+async function emitDeliveryResource(page: Page, url: string): Promise<void> {
+  await page.evaluate(async (resourceUrl) => {
+    await fetch(resourceUrl, {
+      method: "GET",
+      mode: "cors",
+      credentials: "same-origin",
+      headers: { Accept: "application/json, text/plain, */*" },
+    });
+  }, url);
+}
+
+test("binds Chizhik to one browser-evidenced validated store without creating offers", async () => {
+  const { context, userDataDir } = await launchBridge();
+
+  try {
+    await routeOfficialPage(context);
+    const shopsRequests = await routeShops(context);
+    await routeDeliveryEvidence(context);
 
     const page = await context.newPage();
     await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
 
     await expect
       .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("missing-context");
+
+    await emitDeliveryResource(page, hd87Search);
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
       .toBe("observation-only");
     await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
-    expect(shopsRequests).toBe(1);
+    expect(shopsRequests()).toBe(1);
 
     const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
     const stored = await worker.evaluate(async () => chrome.storage.local.get("zg.latestObservations"));
@@ -75,30 +144,66 @@ test("actively discovers Chizhik stores once through normal page-origin CORS wit
   }
 });
 
+test("fails closed for an evidenced delivery store absent from the validated directory", async () => {
+  const { context, userDataDir } = await launchBridge();
+
+  try {
+    await routeOfficialPage(context);
+    await routeShops(context);
+    await routeDeliveryEvidence(context);
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+    await emitDeliveryResource(page, unknownSearch);
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("missing-context");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("fails closed when retained delivery evidence conflicts across validated stores", async () => {
+  const { context, userDataDir } = await launchBridge();
+
+  try {
+    await routeOfficialPage(context);
+    await routeShops(context);
+    await routeDeliveryEvidence(context);
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+    await emitDeliveryResource(page, hd87Search);
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("observation-only");
+
+    await emitDeliveryResource(page, hd88Search);
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("missing-context");
+    await expect.poll(() => page.locator("html").getAttribute("data-zg-bridge-count")).toBe("0");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when active Chizhik store discovery is blocked", async () => {
   const { context, userDataDir } = await launchBridge();
 
   try {
-    await context.route("https://chizhik.club/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "text/html; charset=utf-8",
-        body: pageHtml,
-      });
-    });
-    await context.route(shopsEndpoint, async (route) => {
-      await route.fulfill({
-        status: 403,
-        headers: {
-          "access-control-allow-origin": "https://chizhik.club",
-          "content-type": "text/plain; charset=utf-8",
-        },
-        body: "blocked",
-      });
-    });
+    await routeOfficialPage(context);
+    await routeShops(context, 403);
+    await routeDeliveryEvidence(context);
 
     const page = await context.newPage();
     await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+    await emitDeliveryResource(page, hd87Search);
 
     await expect
       .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))

--- a/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
@@ -3,6 +3,7 @@ import {
   type ChizhikActiveApiClient,
   type ChizhikStoreDiscoveryResult,
 } from "../chizhik-active-api-client";
+import { fulfillmentContextResource } from "../resource-observation-policy";
 import type {
   AdapterResult,
   RetailerBrowserAdapter,
@@ -10,9 +11,28 @@ import type {
 
 const RETAILER_ID = "chizhik";
 const OFFICIAL_PAGE_HOST = "chizhik.club";
+const CONTEXT_PREFIX = `${RETAILER_ID}:`;
 
 function isOfficialPageUrl(url: URL): boolean {
   return url.protocol === "https:" && url.hostname === OFFICIAL_PAGE_HOST;
+}
+
+function evidencedStoreIds(
+  resourceUrls: readonly string[],
+  pageUrl: URL,
+  validStoreIds: ReadonlySet<string>,
+): Set<string> {
+  const contexts = new Set<string>();
+
+  for (const rawUrl of resourceUrls) {
+    const resource = fulfillmentContextResource(rawUrl, pageUrl);
+    if (!resource?.contextKey.startsWith(CONTEXT_PREFIX)) continue;
+
+    const sapId = resource.contextKey.slice(CONTEXT_PREFIX.length);
+    if (validStoreIds.has(sapId)) contexts.add(sapId);
+  }
+
+  return contexts;
 }
 
 export function createChizhikBrowserAdapter(
@@ -28,16 +48,22 @@ export function createChizhikBrowserAdapter(
       return isOfficialPageUrl(url);
     },
 
-    async collect(): Promise<AdapterResult> {
+    async collect({ url, resourceUrls = [] }): Promise<AdapterResult> {
       storeDiscovery ??= client.listStores();
       const result = await storeDiscovery;
       if (result.status !== "ok" || result.stores.length === 0) {
         return { status: "missing-context", observations: [] };
       }
 
-      // Phase D1 proves active browser-context access and a valid store directory only.
-      // Product offers remain fail-closed until a store-scoped delivery response is
-      // independently evidenced and mapped in Phase D2.
+      const validStoreIds = new Set(result.stores.map((store) => store.sapId));
+      const contexts = evidencedStoreIds(resourceUrls, url, validStoreIds);
+      if (contexts.size !== 1) {
+        return { status: "missing-context", observations: [] };
+      }
+
+      // Phase D2 now has one browser-evidenced store context validated against the
+      // active first-party directory. Product search remains intentionally disabled
+      // until live response schema and price-unit evidence are accepted in #169.
       return { status: "observation-only", observations: [] };
     },
   };

--- a/apps/retailer-bridge/src/resource-observation-policy.ts
+++ b/apps/retailer-bridge/src/resource-observation-policy.ts
@@ -6,6 +6,8 @@ const PYATEROCHKA_STORE_RESOURCE_PATH = /^\/api\/catalog\/v2\/stores\/([A-Za-z0-
 const CHIZHIK_PAGE_HOST = "chizhik.club";
 const CHIZHIK_CATALOG_ORIGIN = "https://app.chizhik.club";
 const CHIZHIK_PUBLIC_CATALOG_RESOURCE_PATH = /^\/api\/v1\/catalog\/unauthorized\/(?:categories|products)\/?$/;
+const CHIZHIK_DELIVERY_STORE_RESOURCE_PATH =
+  /^\/delivery\/api\/catalog\/v(?:2|3)\/stores\/([A-Za-z0-9_-]{1,32})(?:\/|$)/;
 
 export type FulfillmentContextResource = Readonly<{
   contextKey: string;
@@ -40,12 +42,13 @@ export function canonicalObservedResourceUrl(rawUrl: string, pageUrl: URL): stri
       return `${resourceUrl.origin}${resourceUrl.pathname}`;
     }
 
-    if (
-      isOfficialChizhikPage(pageUrl) &&
-      resourceUrl.origin === CHIZHIK_CATALOG_ORIGIN &&
-      CHIZHIK_PUBLIC_CATALOG_RESOURCE_PATH.test(resourceUrl.pathname)
-    ) {
-      return `${resourceUrl.origin}${resourceUrl.pathname}`;
+    if (isOfficialChizhikPage(pageUrl) && resourceUrl.origin === CHIZHIK_CATALOG_ORIGIN) {
+      if (
+        CHIZHIK_PUBLIC_CATALOG_RESOURCE_PATH.test(resourceUrl.pathname) ||
+        CHIZHIK_DELIVERY_STORE_RESOURCE_PATH.test(resourceUrl.pathname)
+      ) {
+        return `${resourceUrl.origin}${resourceUrl.pathname}`;
+      }
     }
 
     return null;
@@ -81,8 +84,11 @@ export function fulfillmentContextResource(
         : null;
     }
 
-    // Chizhik Phase B deliberately does not infer fulfillment context from
-    // catalog query parameters because they are stripped before retention.
+    if (isOfficialChizhikPage(pageUrl) && resourceUrl.origin === CHIZHIK_CATALOG_ORIGIN) {
+      const contextId = resourceUrl.pathname.match(CHIZHIK_DELIVERY_STORE_RESOURCE_PATH)?.[1];
+      return contextId ? { contextKey: `chizhik:${contextId}`, canonicalUrl } : null;
+    }
+
     return null;
   } catch {
     return null;

--- a/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
+++ b/apps/retailer-bridge/test/chizhik-browser-adapter.test.ts
@@ -8,6 +8,8 @@ import {
 
 const OBSERVED_AT = "2026-08-18T00:15:00Z";
 const PAGE_URL = new URL("https://chizhik.club/catalog/chay-kofe--264C39224/#fragment");
+const HD87_RESOURCE =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=cola";
 
 function documentWithGuessedProduct(): Document {
   return new DOMParser().parseFromString(
@@ -32,6 +34,14 @@ const VALID_DISCOVERY = {
       name: "Москва, Саянская ул., Дом 11Б",
       locality: "Москва",
     },
+    {
+      sapId: "HD88",
+      longitude: 37.80898339,
+      latitude: 55.39666279,
+      active: true,
+      name: "Домодедово, Вокзальная ул., Строение 2г",
+      locality: "Домодедово",
+    },
   ],
 };
 
@@ -46,7 +56,7 @@ describe("chizhikBrowserAdapter", () => {
     expect(chizhikBrowserAdapter.supports(new URL("https://chizhik.club.evil.example/"))).toBe(false);
   });
 
-  it("reports observation-only after active fixed-endpoint store discovery succeeds without auto-searching products", async () => {
+  it("reports observation-only only after a delivery resource identifies one validated store", async () => {
     const listStores = vi.fn(async () => VALID_DISCOVERY);
     const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
     const adapter = createChizhikBrowserAdapter({ listStores, searchStore });
@@ -56,10 +66,73 @@ describe("chizhikBrowserAdapter", () => {
         document: documentWithGuessedProduct(),
         url: PAGE_URL,
         observedAt: OBSERVED_AT,
-        resourceUrls: [],
+        resourceUrls: [HD87_RESOURCE],
       }),
     ).resolves.toEqual({ status: "observation-only", observations: [] });
     expect(listStores).toHaveBeenCalledTimes(1);
+    expect(searchStore).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when no evidenced store context is present", async () => {
+    const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+    const adapter = createChizhikBrowserAdapter({
+      listStores: vi.fn(async () => VALID_DISCOVERY),
+      searchStore,
+    });
+
+    await expect(
+      adapter.collect({
+        document: documentWithGuessedProduct(),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
+      }),
+    ).resolves.toEqual({ status: "missing-context", observations: [] });
+    expect(searchStore).not.toHaveBeenCalled();
+  });
+
+  it("ignores foreign-origin and unknown-store delivery resource candidates", async () => {
+    for (const resourceUrls of [
+      ["https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search"],
+      ["https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search"],
+      ["https://app.chizhik.club/delivery/api/profile/v1/me"],
+    ]) {
+      const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+      const adapter = createChizhikBrowserAdapter({
+        listStores: vi.fn(async () => VALID_DISCOVERY),
+        searchStore,
+      });
+
+      await expect(
+        adapter.collect({
+          document: documentWithGuessedProduct(),
+          url: PAGE_URL,
+          observedAt: OBSERVED_AT,
+          resourceUrls,
+        }),
+      ).resolves.toEqual({ status: "missing-context", observations: [] });
+      expect(searchStore).not.toHaveBeenCalled();
+    }
+  });
+
+  it("fails closed when retained delivery resources conflict across validated stores", async () => {
+    const searchStore = vi.fn(async () => ({ status: "unavailable" as const }));
+    const adapter = createChizhikBrowserAdapter({
+      listStores: vi.fn(async () => VALID_DISCOVERY),
+      searchStore,
+    });
+
+    await expect(
+      adapter.collect({
+        document: documentWithGuessedProduct(),
+        url: PAGE_URL,
+        observedAt: OBSERVED_AT,
+        resourceUrls: [
+          HD87_RESOURCE,
+          "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD88/categories/drinks/products",
+        ],
+      }),
+    ).resolves.toEqual({ status: "missing-context", observations: [] });
     expect(searchStore).not.toHaveBeenCalled();
   });
 
@@ -71,7 +144,7 @@ describe("chizhikBrowserAdapter", () => {
       document: documentWithGuessedProduct(),
       url: PAGE_URL,
       observedAt: OBSERVED_AT,
-      resourceUrls: [] as string[],
+      resourceUrls: [HD87_RESOURCE],
     };
 
     await adapter.collect(input);
@@ -97,7 +170,7 @@ describe("chizhikBrowserAdapter", () => {
           document: documentWithGuessedProduct(),
           url: PAGE_URL,
           observedAt: OBSERVED_AT,
-          resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
+          resourceUrls: [HD87_RESOURCE],
         }),
       ).resolves.toEqual({ status: "missing-context", observations: [] });
       expect(searchStore).not.toHaveBeenCalled();
@@ -116,7 +189,7 @@ describe("chizhikBrowserAdapter", () => {
         document: documentWithGuessedProduct(),
         url: PAGE_URL,
         observedAt: OBSERVED_AT,
-        resourceUrls: ["https://app.chizhik.club/api/v1/catalog/unauthorized/products/"],
+        resourceUrls: [HD87_RESOURCE],
       }),
     ).resolves.toEqual({ status: "observation-only", observations: [] });
     expect(searchStore).not.toHaveBeenCalled();

--- a/apps/retailer-bridge/test/resource-observation-policy.test.ts
+++ b/apps/retailer-bridge/test/resource-observation-policy.test.ts
@@ -41,7 +41,7 @@ describe("canonicalObservedResourceUrl", () => {
     ).toBeNull();
   });
 
-  it("allows only path-only Chizhik unauthorized catalog evidence on an official Chizhik page", () => {
+  it("allows only path-only Chizhik public catalog and store-scoped delivery catalog evidence", () => {
     const page = new URL("https://chizhik.club/deeplink?action_type=to_screen");
 
     expect(
@@ -56,10 +56,42 @@ describe("canonicalObservedResourceUrl", () => {
         page,
       ),
     ).toBe("https://app.chizhik.club/api/v1/catalog/unauthorized/products/");
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=SECRET#fragment",
+        page,
+      ),
+    ).toBe("https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search");
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD87/categories/drinks/products?token=SECRET",
+        page,
+      ),
+    ).toBe(
+      "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD87/categories/drinks/products",
+    );
 
     expect(
       canonicalObservedResourceUrl(
         "https://app.chizhik.club/api/v1/profile/me",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/delivery/api/profile/v1/me",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/../../profile/me",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalObservedResourceUrl(
+        "https://app.chizhik.club/delivery/api/catalog/v3/stores/%2Fprofile/search",
         page,
       ),
     ).toBeNull();
@@ -71,7 +103,7 @@ describe("canonicalObservedResourceUrl", () => {
     ).toBeNull();
     expect(
       canonicalObservedResourceUrl(
-        "https://app.chizhik.club.evil.example/api/v1/catalog/unauthorized/products/",
+        "https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search",
         page,
       ),
     ).toBeNull();
@@ -113,12 +145,48 @@ describe("fulfillmentContextResource", () => {
     ).toBeNull();
   });
 
-  it("does not promote Chizhik catalog resource paths into a guessed fulfillment context", () => {
+  it("projects an exact Chizhik delivery catalog store path as fulfillment context", () => {
+    const page = new URL("https://chizhik.club/catalog/test");
+
+    expect(
+      fulfillmentContextResource(
+        "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=SECRET",
+        page,
+      ),
+    ).toEqual({
+      contextKey: "chizhik:HD87",
+      canonicalUrl: "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search",
+    });
+    expect(
+      fulfillmentContextResource(
+        "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD87/categories/drinks/products?token=SECRET",
+        page,
+      ),
+    ).toEqual({
+      contextKey: "chizhik:HD87",
+      canonicalUrl:
+        "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD87/categories/drinks/products",
+    });
+  });
+
+  it("does not promote public Chizhik catalog resources or unsafe delivery paths", () => {
     const page = new URL("https://chizhik.club/");
 
     expect(
       fulfillmentContextResource(
         "https://app.chizhik.club/api/v1/catalog/unauthorized/products/?store=SECRET",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      fulfillmentContextResource(
+        "https://app.chizhik.club/delivery/api/catalog/v3/stores/%2Fprofile/search",
+        page,
+      ),
+    ).toBeNull();
+    expect(
+      fulfillmentContextResource(
+        "https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search",
         page,
       ),
     ).toBeNull();


### PR DESCRIPTION
Tracks #173.

## Scope
- allow only exact first-party Chizhik delivery catalog resource paths to survive browser resource observation;
- project their path-embedded `sap_id` as a fulfillment-context signal;
- require the adapter to intersect that context with the validated `/api/v1/shops/` directory and accept exactly one distinct store;
- keep delivery search disabled and observations empty until #169 live schema/price evidence is accepted;
- no permission changes and no new live traffic.

## TDD evidence
1. RED `6e97fd9…` specified the missing Chizhik delivery resource policy.
2. RED `cc3164f…` required one evidenced store context validated against `/api/v1/shops/`.
3. GREEN `ea7f98f…` retained only exact-origin v2/v3 delivery catalog store paths with query/fragment stripped.
4. GREEN `bfe6baa…` intersected evidenced `sap_id` values with the validated store directory and failed closed unless exactly one distinct context remained.
5. Chromium E2E `6eac3f1…` covered valid context, unknown store, conflicting contexts and blocked store discovery while preserving zero observations/search calls.
6. Independent review found the explicit #173 foreign-origin Chromium acceptance case was only unit-covered; `0a0da74…` adds deterministic foreign-origin extension E2E with the request intercepted locally.

## Safety boundary
- exact `https://app.chizhik.club` evidence origin only;
- path-embedded safe `sap_id` shape only;
- unvalidated/foreign/malformed candidates are ignored;
- multiple contexts fail closed to `missing-context`;
- `searchStore` remains disabled and `observations` remain empty;
- no extension permission changes, stealth, proxying, credential/header/cookie extraction, or new live retailer traffic.

Acceptance requires fresh exact-head 9/9 PR CI, clean review, squash merge with expected-head protection, and closure of #173 only after merge.