### PR TITLE
docs: correct next prerelease gate to v0.1.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,12 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; this 
 - Phase B adds exact-origin observation-only browser discovery and trusted `main` bridge canary artifact publication.
 - Phase C adds bounded body-less public catalog-document reachability probing with controlled live execution and finite sanitized transport-failure classification; document reachability is not product/price connectivity.
 - Phase D1 (#167/#168) adds active ordinary-browser access to the fixed `/api/v1/shops/` store directory with strict store-shape/coordinate validation and real extension Chromium E2E.
-- D1 transport decision is **COMPLETE / ACCEPTED**: an ordinary user-opened official Chizhik page receives `200 + JSON` store-directory evidence while stock GitHub-hosted Chromium is `page-unavailable`; the selected acquisition architecture is therefore the normal user-browser MV3 Retailer Bridge, not a managed CI/server browser worker.
-- D2 transport foundation (#169/#171) adds an exact bounded store-scoped delivery-search transport under `https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search`; successful JSON deliberately remains opaque and automatic search/offer production stays disabled pending live schema acceptance.
-- A privacy-safe ordinary-user-browser D2 schema canary is documented in `docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md`; it retains structural evidence only and never raw response/product/store values.
-- D2 store-context binding (#173/#174) accepts only exact first-party delivery resource evidence already observed by the official browser session, intersects path-embedded `sap_id` with the validated `/api/v1/shops/` directory, and requires exactly one distinct validated context.
-- Missing context, foreign origin, unknown store and conflicting validated Chizhik stores fail closed; `searchStore` remains uncalled and observations remain empty before #169 schema acceptance.
-- Chizhik offer mapping is now blocked specifically on ordinary-user-browser evidence for product container/identifier/name, price field **and monetary unit/scale**, plus explicit availability semantics if present. Unknown availability remains `UNKNOWN`; promotion/loyalty/package/discount semantics are not inferred.
+- D1 transport decision is **COMPLETE / ACCEPTED**: ordinary user-browser store-directory evidence succeeds while stock GitHub-hosted Chromium is `page-unavailable`; the selected architecture is therefore normal user-browser MV3 Retailer Bridge, not managed CI/server browser worker.
+- D2 transport foundation (#169/#171) adds exact bounded store-scoped delivery search; successful JSON deliberately remains opaque and automatic search/offer production stays disabled pending live schema acceptance.
+- A privacy-safe ordinary-user-browser D2 schema canary retains structural evidence only and never raw response/product/store values.
+- D2 store-context binding (#173/#174) accepts only exact first-party delivery resource evidence already observed by the official browser session, intersects path-embedded `sap_id` with the validated store directory and requires exactly one distinct validated context.
+- Missing context, foreign origin, unknown store and conflicting validated stores fail closed; `searchStore` remains uncalled before #169 schema acceptance.
+- Chizhik offer mapping is blocked specifically on ordinary-user-browser evidence for product container/identifier/name, price field **and monetary unit/scale**, plus explicit availability semantics if present. Unknown availability remains `UNKNOWN`; promotion/loyalty/package/discount semantics are not inferred.
 - Chizhik safety boundary remains unchanged: no stealth/fingerprint spoofing, proxy rotation, credential/header/cookie extraction, private/mobile-client impersonation or arbitrary URL forwarding.
 
 #### Product and Shopping Core
@@ -73,12 +73,14 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; this 
 - M5.1 Private local WeeklyPlan draft is **COMPLETE / ACCEPTED**; M5.2 remains intentionally unselected until real release-candidate/manual-use evidence identifies the next constraint.
 - Chizhik D1 no longer has an unresolved server-vs-browser transport decision: the accepted path is user-browser MV3 Retailer Bridge.
 - Chizhik D2 now has a merged fixed search transport and an accepted browser-evidenced store-context rule, but it is **not** yet an offer provider; #169 remains open for live schema/price-unit evidence and mapping acceptance.
-- The former `v0.1.0-rc.3` target `d988b8c596a737326aeac67f74b6f65a6aaed3bf` is invalidated because accepted work merged after it. Issue #152 requires a new documentation-synchronized, fully verified exact `main` SHA before publication.
+- Release history correction: `v0.1.0-rc.3` already exists and its immutable tag resolves to `d988b8c596a737326aeac67f74b6f65a6aaed3bf`; it must not be repointed to newer source.
+- The next operational release gate is **`v0.1.0-rc.4`**, tracked by #152. Its final exact target is selected only after this correction is merged and verified.
 - Stable `v0.1.0` remains blocked until a prerelease completes the immutable release workflow and manual product canary satisfactorily.
 - Technical retailer accessibility and production/right-to-operate readiness remain independent facts.
 
 ### Fixed
 
+- Corrected canonical release planning that had incorrectly attempted to reuse the already-published `v0.1.0-rc.3` tag for newer source.
 - Clean-checkout local web development builds the generated `@zakup-gotov/api-client` before `next dev`, preventing module-resolution failure found during pre-release manual testing (#150).
 - Manual-list SSR/hydration uses deterministic presentation identity and creates request UUIDs only on explicit submit (#150).
 - Local draft persistence prevents failed reads from causing blind blank autosave, gates clear until restore readiness and surfaces cleanup/storage failure instead of claiming success.
@@ -93,6 +95,12 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; this 
 - Ordinary CI remains deterministic and does not perform live retailer acquisition; controlled live workflows are explicit and sanitized.
 - Chizhik connectivity adds no anti-bot bypass, stealth, proxy rotation, credential extraction or private-client impersonation.
 - Release vulnerability policy remains fail-closed at `HIGH,CRITICAL`; no ignore/suppression behavior is added to make a release pass.
+- Published prerelease tags are treated as immutable release evidence and are never repointed to later source.
+
+## [0.1.0-rc.3] — existing historical prerelease
+
+- GitHub prerelease/tag already exists at immutable source `d988b8c596a737326aeac67f74b6f65a6aaed3bf`.
+- Later accepted connectivity and documentation work advanced `main`; those changes belong to the next prerelease rather than a rewritten rc.3.
 
 ## [0.1.0-rc.2] — 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Web CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/web-ci.yml)
 [![Release Bundle CI](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/release-bundle-ci.yml/badge.svg)](https://github.com/True-Ruslan/zakup-gotov/actions/workflows/release-bundle-ci.yml)
 
-**Status:** M5 — Productization · **pre-release** · next release gate: **`v0.1.0-rc.3`**
+**Status:** M5 — Productization · **pre-release** · next release gate: **`v0.1.0-rc.4`**
 
 Zakup Gotov превращает рецепт, недельное меню или обычный список покупок в сравнение **полной корзины** по магазинам с учётом местоположения, актуальности цены, наличия, упаковок, checkout-экономики и полноты сопоставления.
 
@@ -83,13 +83,15 @@ Privacy-safe Chizhik D2 canary: [`docs/integrations/chizhik-d2-delivery-search-c
 
 ## Release gate
 
-Следующий основной operational milestone — immutable **`v0.1.0-rc.3`**.
+`v0.1.0-rc.3` уже опубликован и его immutable tag указывает на `d988b8c596a737326aeac67f74b6f65a6aaed3bf`. Этот tag не переиспользуется и не перемещается.
+
+Следующий основной operational milestone — immutable **`v0.1.0-rc.4`**.
 
 Issue #152 требует:
 
 1. documentation-synchronized final `main`;
-2. exact final `main` SHA с зелёными required push workflows;
-3. отсутствие существующих `v0.1.0-rc.3` tag/release перед публикацией;
+2. exact final `main` SHA с необходимым verification evidence;
+3. отсутствие существующих `v0.1.0-rc.4` tag/release перед публикацией;
 4. published GitHub prerelease, направленный только на этот exact SHA;
 5. multi-platform `linux/amd64` + `linux/arm64` staging images;
 6. неизменённый fail-closed Trivy `HIGH,CRITICAL` gate;
@@ -98,7 +100,7 @@ Issue #152 требует:
 9. copy-without-rebuild promotion с сохранением digest identity;
 10. provenance attestations и release evidence/checksums;
 11. отсутствие `latest` promotion для prerelease;
-12. manual product canary именно из immutable rc.3 artifacts.
+12. manual product canary именно из immutable rc.4 artifacts.
 
 Stable `v0.1.0` остаётся заблокирован до успешного prerelease и manual acceptance.
 
@@ -184,7 +186,7 @@ pnpm install --frozen-lockfile
 - M3 — COMPLETE / ACCEPTED;
 - M4 — COMPLETE / ACCEPTED;
 - M5 — CURRENT; M5.1 accepted, M5.2 intentionally unselected;
-- immediate gate — `v0.1.0-rc.3`;
+- immediate gate — `v0.1.0-rc.4`;
 - M6 Native Mobile — future.
 
 Подробности: [`docs/ROADMAP.md`](docs/ROADMAP.md).

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -9,7 +9,7 @@ Updated: 2026-08-18
 Repository: `True-Ruslan/zakup-gotov`  
 Visibility: Public  
 Current product phase: **M5 — Productization**  
-Immediate operational target: **`v0.1.0-rc.3` end-to-end release validation**
+Immediate operational target: **`v0.1.0-rc.4` end-to-end release validation**
 
 The product/core and retailer-connectivity tracks are intentionally separate. A retailer can be technically reachable without being approved for production acquisition, and a merged transport implementation is not automatically an accepted product/price provider.
 
@@ -34,60 +34,31 @@ The product/core and retailer-connectivity tracks are intentionally separate. A 
 
 Acceptance: [`m1-shopping-core-acceptance-2026-08-13.md`](m1-shopping-core-acceptance-2026-08-13.md).
 
-Accepted behavior includes:
-
-- canonical retailer visibility/readiness;
-- canonical shopping quantities and stable Shopping identities;
-- provider/location provenance and explicit freshness/availability evidence;
-- deterministic exact/normalized matching with explicit ambiguity;
-- whole-package single-store basket arithmetic;
-- truthful `READY / UNCERTAIN / INCOMPLETE / UNAVAILABLE` comparison states;
-- production-access gating before acquisition;
-- stateless comparison preview and responsive manual-list flow.
+Accepted behavior includes canonical retailer visibility/readiness, canonical quantities and stable Shopping identities, provider/location provenance, freshness/availability evidence, deterministic exact/normalized matching with explicit ambiguity, whole-package single-store basket arithmetic, truthful `READY / UNCERTAIN / INCOMPLETE / UNAVAILABLE` states, production-access gating before acquisition and stateless responsive comparison flows.
 
 ### M2 — Recipes
 
-Recipes are a deterministic first-class source of shopping requirements.
-
-Accepted behavior includes Recipe domain/conversion, serving scaling, Recipe → ShoppingList → Comparison, responsive Recipe UI and deterministic occurrence-aware multi-Recipe aggregation.
+Recipes are a deterministic first-class source of shopping requirements. Accepted behavior includes Recipe domain/conversion, serving scaling, Recipe → ShoppingList → Comparison, responsive Recipe UI and deterministic occurrence-aware multi-Recipe aggregation.
 
 Permanent rule: automatic Recipe merging is exact normalized requirement + canonical unit only. Fuzzy/synonym/AI equivalence is never implicit.
 
 ### M3 — Weekly Planning / Pantry
 
-Weekly Planning is the primary browser journey.
-
-Accepted behavior includes:
-
-- ordered WeeklyPlan meal occurrences with day metadata and explicit target servings;
-- deterministic multi-Recipe shopping composition;
-- stateless WeeklyPlan shopping/comparison boundaries;
-- request-scoped Pantry subtraction with ordered audit evidence;
-- `NO_REMAINING_DEMAND` as a truthful terminal state;
-- responsive desktop/mobile/accessibility coverage;
-- no browser-side Recipe scaling, Pantry subtraction, matching or basket arithmetic.
+Weekly Planning is the primary browser journey. Accepted behavior includes ordered meal occurrences, day metadata, target servings, deterministic weekly shopping composition, stateless WeeklyPlan shopping/comparison boundaries, request-scoped Pantry subtraction with ordered audit evidence, truthful `NO_REMAINING_DEMAND`, responsive browser acceptance and no browser-side Recipe scaling/Pantry subtraction/matching/basket arithmetic.
 
 Explicit omit-all / never-buy semantics remain intentionally deferred; they are not Pantry stock.
 
 ### M4 — Basket Optimization
 
-Accepted behavior includes:
+Accepted behavior includes explicit known/unknown delivery and service fees, explicit minimum-order evidence, separate merchandise subtotal / checkout-total knowledge / eligibility / comparability, deterministic single-retailer checkout assessment, exact cheapest comparable basket selection with explicit ties, server-owned Optimization Preview and responsive Optimization UX.
 
-- explicit known/unknown delivery and service fees;
-- explicit minimum-order evidence;
-- separate merchandise subtotal, checkout-total knowledge, eligibility and comparability;
-- deterministic single-retailer checkout assessment;
-- exact cheapest comparable basket selection with explicit ties;
-- server-owned Optimization Preview API and responsive Optimization UX;
-- no hidden monetary freshness penalty, substitute search or multi-store split optimization.
-
-The production checkout-economics source remains intentionally fail-closed/unknown until retailer-specific evidence is accepted.
+Production checkout economics remains fail-closed/unknown until retailer-specific evidence is accepted. Rich substitute/package optimization and multi-store split optimization remain deferred.
 
 ### M5.1 — Private local WeeklyPlan draft
 
 Acceptance: [`m5-1-private-local-weekly-plan-draft-acceptance-2026-08-16.md`](m5-1-private-local-weekly-plan-draft-acceptance-2026-08-16.md).
 
-Accepted browser-local persistence stores only editable semantic WeeklyPlan/Pantry input under one versioned same-origin key. Generated identities, retailer results, economics, optimizer output and provider evidence never become local draft authority. Restore never implies submission, and storage failures fail closed without breaking explicit editing/submission.
+Only editable semantic WeeklyPlan/Pantry input is persisted under one versioned same-origin key. Generated identities, retailer results, economics, optimizer output and provider evidence never become local draft authority. Restore never implies submission; storage failures fail closed without breaking explicit editing/submission.
 
 ## Retailer connectivity
 
@@ -99,14 +70,7 @@ Technical connectivity, production-access readiness and deterministic product/co
 
 ### Perekrestok / Pyaterochka
 
-Accepted browser-bridge acquisition evidence exists. The bridge lifecycle is hardened for long-lived SPA/store-change sessions through #153:
-
-- event-driven navigation lifecycle rather than polling;
-- fresh fulfillment-context gating after navigation/store change;
-- stale-resource and obsolete in-flight result rejection;
-- revision-safe writes;
-- bounded retained resource evidence;
-- production extension permissions remain minimal (`storage` only).
+Accepted browser-bridge acquisition evidence exists. #54/#153 hardened long-lived SPA/store-change sessions through event-driven navigation handling, fresh-context gating, stale/in-flight rejection, revision-safe writes and bounded retained resource evidence without widening production extension permissions.
 
 ### Magnit
 
@@ -125,95 +89,62 @@ Technical accessibility is not treated as permission for recurring production ac
 
 Issue #167 is closed completed; PR #168 merged as `e49c151fa44681dffe85fe90116009c86690672e`.
 
-Evidence:
+An ordinary user-opened official Chizhik page successfully fetched `GET https://app.chizhik.club/api/v1/shops/` with HTTP `200`, JSON and valid store rows containing `sap_id` and coordinates. Stock GitHub-hosted Chromium produced sanitized `page-unavailable` evidence. Therefore the accepted acquisition architecture is the normal **user-browser MV3 Retailer Bridge**; managed CI/server browser worker is not selected for Chizhik.
 
-- an ordinary user-opened official `https://chizhik.club/` page successfully fetched `GET https://app.chizhik.club/api/v1/shops/` with HTTP `200`, JSON and valid store rows including `sap_id` and coordinates;
-- stock GitHub-hosted Chromium produced sanitized `page-unavailable` evidence;
-- therefore the accepted Chizhik acquisition architecture is the normal **user-browser MV3 Retailer Bridge**;
-- a managed CI/server-browser worker is not selected for Chizhik;
-- stealth, fingerprint spoofing, proxy rotation, cookie/header/credential extraction, mobile impersonation and arbitrary URL forwarding remain out of scope.
-
-The CI-browser negative result is retained as evidence; it is no longer an unresolved architecture gate.
+Stealth, fingerprint spoofing, proxy rotation, cookie/header/credential extraction, private/mobile-client impersonation and arbitrary URL forwarding remain out of scope.
 
 #### D2 search transport — IMPLEMENTED / MERGED, NOT YET AN OFFER PROVIDER
 
 Issue #169 remains open. PR #171 merged as `bb11bd45d0c5da20eed2a24dfdf585714912c1b1`.
 
-Merged transport foundation:
+Merged foundation uses an exact store-scoped Chizhik delivery-search endpoint family, validated-form `sap_id`, URL-encoded query, bounded limit, finite abort deadline and ordinary browser CORS behavior. Successful JSON remains opaque until live schema acceptance; automatic delivery search and offer mapping remain disabled.
 
-- exact store-scoped endpoint family under `https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search`;
-- validated-form `sap_id`;
-- URL-encoded nonblank query;
-- bounded result limit and finite abort deadline;
-- ordinary page-origin CORS + same-origin credentials;
-- successful JSON remains opaque `unknown` until live schema acceptance;
-- the active adapter is regression-protected to perform **zero automatic delivery-search calls** before schema acceptance;
-- no offer/price/availability mapping is active.
-
-Privacy-safe canary instructions: [`integrations/chizhik-d2-delivery-search-canary-2026-08-18.md`](integrations/chizhik-d2-delivery-search-canary-2026-08-18.md).
+Privacy-safe canary: [`integrations/chizhik-d2-delivery-search-canary-2026-08-18.md`](integrations/chizhik-d2-delivery-search-canary-2026-08-18.md).
 
 #### D2 store-context binding — COMPLETE / ACCEPTED
 
 Issue #173 is closed completed. PR #174 squash-merged as `6c0af6ffa347c434e02600e83533244f8e2d15db`.
 
-Accepted rule:
-
-- candidate fulfillment context comes only from already-observed exact first-party delivery catalog resource paths;
-- only `https://app.chizhik.club/delivery/api/catalog/v2|v3/stores/{sap_id}/...` can contribute context;
-- query/fragment data is stripped before retention;
-- path-embedded `sap_id` must match the safe ID shape and exist in the validated `/api/v1/shops/` directory;
-- exactly one distinct validated context is required;
-- no candidate, foreign origin, unknown store or conflicting validated stores fail closed to `missing-context`;
-- `searchStore` remains uncalled and observations remain empty until #169 schema evidence is accepted;
-- Chromium extension E2E covers valid, foreign-origin, unknown-store, conflict and blocked-discovery paths;
-- no extension permission changes and no new live retailer traffic were introduced.
+Candidate fulfillment context comes only from already-observed exact first-party delivery catalog resource paths. Path-embedded `sap_id` must match the safe ID shape and exist in the validated `/api/v1/shops/` directory. Exactly one distinct validated context is required; missing, foreign, unknown or conflicting context fails closed. `searchStore` remains uncalled until #169 schema evidence is accepted.
 
 PR #174 final head `0a0da74d744b85a9a936fc6049946174d96a4d09` passed **9/9 PR workflow groups SUCCESS** before merge.
 
 #### Chizhik next evidence gate
 
-#169 is now blocked on **ordinary-user-browser schema and price-unit evidence**, not on transport implementation.
-
-The canary may retain only sanitized structural evidence. Before `BrowserObservation` / `ObservedOffer` mapping, evidence must establish:
-
-- actual product-array/container path;
-- stable product identifier field;
-- product-name field;
-- price field **and its unit/scale**;
-- explicit availability semantics if present; otherwise availability remains `UNKNOWN`.
-
-Do not infer promotion, loyalty, package or discount semantics. Do not persist raw response bodies or store/product values as live evidence.
+#169 is blocked on ordinary-user-browser sanitized schema and price-unit evidence. Before `BrowserObservation` / `ObservedOffer` mapping, evidence must establish product-array/container path, stable product identifier field, product-name field, price field **and its monetary unit/scale**, plus explicit availability semantics if present. Unknown availability stays `UNKNOWN`; promo/loyalty/package/discount semantics are never inferred.
 
 ## Other mandatory connectivity work
 
-Continue without removing retailers from scope:
+Continue universal coverage for #36 Kuper supported aggregator/API access and permitted reuse, Ozon Fresh, Samokat, Lenta, VkusVill and additional major banners. Retailer-specific production/right-to-operate decisions remain mandatory before activation.
 
-- #36 Kuper supported aggregator/API access and permitted reuse;
-- Ozon Fresh;
-- Samokat;
-- Lenta;
-- VkusVill;
-- additional major banners as they enter the canonical registry;
-- retailer-specific package semantics only where source evidence proves them;
-- retailer-specific production-access/right-to-operate decisions before activation.
+## Release history and next gate
 
-## Release gate — `v0.1.0-rc.3`
+### `v0.1.0-rc.3` — EXISTING HISTORICAL PRERELEASE
+
+The immutable `v0.1.0-rc.3` ref already exists and resolves to:
+
+`d988b8c596a737326aeac67f74b6f65a6aaed3bf`
+
+Current `main` is 13 commits ahead of that ref as of this correction. The rc.3 tag/release must not be deleted, moved or reused for later source.
+
+### `v0.1.0-rc.4` — NEXT OPERATIONAL TARGET
 
 Issue: #152.
 
-The old M5.1-only release target `d988b8c596a737326aeac67f74b6f65a6aaed3bf` is invalidated because accepted work merged after it.
+The `v0.1.0-rc.4` ref is currently absent. The required sequence is:
 
-The rc.3 sequence is now:
+1. synchronize canonical docs so rc.3 is historical and rc.4 is the next gate;
+2. merge that docs-only correction through fresh exact-head CI/review;
+3. record the exact resulting `main` SHA in #152;
+4. verify the final release target per repository policy;
+5. re-check that `v0.1.0-rc.4` tag/release is absent immediately before publication;
+6. publish one immutable GitHub prerelease targeting only that exact SHA;
+7. require the existing release workflow to pass repository verification, production browser E2E, `linux/amd64` + `linux/arm64` staging, unchanged Trivy `HIGH,CRITICAL`, SPDX SBOM, exact-digest staging/final smoke, copy-without-rebuild promotion, provenance attestations, manifest checks and release evidence attachment;
+8. leave `latest` untouched;
+9. run the manual product canary from immutable rc.4 artifacts;
+10. choose M5.2 only from resulting evidence.
 
-1. merge this post-D2 documentation synchronization;
-2. record the exact resulting `main` SHA in #152;
-3. verify that exact SHA with all normal required push workflow groups and zero failures;
-4. re-check that tag/release `v0.1.0-rc.3` is absent;
-5. only then publish an immutable GitHub prerelease targeting that exact SHA;
-6. require the existing release workflow to pass verify, multi-platform staging, Trivy `HIGH,CRITICAL`, SPDX SBOM, exact-digest staging/final smoke, digest-identical promotion, provenance attestations, final manifest checks and release evidence attachment;
-7. leave `latest` untouched;
-8. run the manual product canary from immutable rc.3 artifacts;
-9. choose M5.2 only from resulting evidence.
+`.github/workflows/release.yml` validates generic SemVer prereleases, so `v0.1.0-rc.4` requires no release-code change.
 
 Stable `v0.1.0` remains blocked until prerelease and manual-canary evidence are satisfactory.
 
@@ -252,14 +183,16 @@ Stable `v0.1.0` remains blocked until prerelease and manual-canary evidence are 
 18. Browser-local persistence contains semantic editable input only and restore never implies submission.
 19. Browser acquisition lifecycle evidence is revision-safe across SPA/store changes.
 20. Ordinary-user-browser evidence and CI/server-browser evidence are separate evidence classes.
-21. A browser fulfillment context must be evidenced by the current official session and validated against accepted retailer context evidence; it is never guessed from list order or convenience.
+21. Browser fulfillment context must be evidenced by the current official session and validated against accepted retailer context evidence; it is never guessed.
 22. No price mapping is accepted until the source field and monetary unit/scale are evidenced.
+23. Published prerelease tags are immutable historical evidence and are never repointed to newer source.
 
 ## Platform baseline
 
 - Java 25 / Spring Boot 4.1 / Spring MVC virtual threads / Spring Modulith;
 - PostgreSQL 18 / Flyway / jOOQ;
-- OpenAPI 3.1 with generated TypeScript client;
-- Next.js 16.3 / React 19.2 / TypeScript 5.9 / Node 24;
-- Vitest + Testing Library + Playwright;
-- deterministic CI/security/release gates before acceptance.
+- OpenAPI 3.1 + generated TypeScript client;
+- Next.js 16.3 / React 19.2;
+- Testcontainers / Vitest / Testing Library / Playwright;
+- Docker multi-stage production images + no-source-build Compose release topology;
+- CodeQL / Dependency Review / Container Security / Release Contract / Release Bundle CI.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,13 +28,7 @@ Goal achieved: deterministic provider-neutral shopping requirements, canonical q
 
 Goal achieved: recipes are a deterministic first-class source of shopping requirements.
 
-Accepted slices:
-
-- M2.1 Recipe domain + Recipe → ShoppingList;
-- M2.2 stateless Recipe shopping preview API;
-- M2.3 Recipe → Comparison composition;
-- M2.4 responsive Recipe UI;
-- M2.5 deterministic multi-Recipe aggregation.
+Accepted slices: Recipe domain + ShoppingList conversion, stateless Recipe shopping preview, Recipe → Comparison composition, responsive Recipe UI and deterministic multi-Recipe aggregation.
 
 Permanent rule: automatic Recipe merging remains exact normalized requirement + canonical unit. Fuzzy/synonym/AI equivalence is never implicit.
 
@@ -42,16 +36,7 @@ Permanent rule: automatic Recipe merging remains exact normalized requirement + 
 
 Goal achieved: combine ordered meal occurrences into deterministic weekly demand, compare it across retailers and subtract explicit request-scoped Pantry evidence without hidden ingredient loss.
 
-Accepted slices:
-
-- M3.1 WeeklyPlan domain + deterministic shopping composition;
-- M3.2 stateless WeeklyPlan shopping preview;
-- M3.3 WeeklyPlan → Comparison composition;
-- M3.4 responsive Weekly Planning UI;
-- M3.5.1 pure Pantry subtraction semantics;
-- M3.5.2 Pantry-aware weekly shopping preview;
-- M3.5.3 Pantry-aware comparison composition;
-- M3.5.4 responsive Pantry controls.
+Accepted slices include WeeklyPlan domain/composition, stateless shopping/comparison boundaries, responsive planning UI, pure Pantry subtraction, Pantry-aware shopping/comparison composition and responsive Pantry controls.
 
 Explicit omit-all / never-buy semantics remain deferred and must not be encoded as Pantry stock.
 
@@ -59,14 +44,9 @@ Explicit omit-all / never-buy semantics remain deferred and must not be encoded 
 
 Goal achieved for the current deterministic slice: optimize truthful one-retailer checkout cost rather than naive SKU sums.
 
-Accepted scope:
+Accepted scope: explicit known/unknown delivery/service fees and minimum-order evidence, checkout eligibility/comparability, deterministic cheapest comparable basket with explicit ties, server-owned Optimization Preview and responsive Optimization UX.
 
-- M4.1 explicit known/unknown delivery/service fees and minimum-order evidence;
-- M4.2 one-retailer checkout eligibility/comparability;
-- M4.3 deterministic cheapest comparable basket with explicit ties;
-- M4.4 server-owned Optimization Preview and responsive Optimization UX.
-
-Deferred: richer substitute/package optimization, multi-store split optimization and any confidence/freshness pricing policy.
+Deferred: richer substitute/package optimization, multi-store split optimization and confidence/freshness pricing policy.
 
 ## M5 — Productization — CURRENT
 
@@ -82,25 +62,33 @@ Accepted result: one versioned same-origin semantic WeeklyPlan/Pantry draft. Gen
 
 Do not preselect accounts, analytics, feature flags, provider health or saved history before the real release-candidate/manual-use canary demonstrates the highest-value constraint.
 
-## Immediate mainline target — `v0.1.0-rc.3`
+## Release history correction
+
+`v0.1.0-rc.3` is **already an existing immutable prerelease**. Its tag resolves to:
+
+`d988b8c596a737326aeac67f74b6f65a6aaed3bf`
+
+Current main is 13 commits ahead of that tag at the time of this correction. rc.3 must not be moved, deleted or reused for newer source.
+
+## Immediate mainline target — `v0.1.0-rc.4`
 
 Issue: #152.
 
-The previous M5.1-only target SHA is invalidated because accepted connectivity work merged afterwards. The next release must be cut from the **documentation-synchronized, fully verified final `main` SHA** recorded in #152.
+The next release must be cut from the documentation-synchronized, fully verified final `main` SHA recorded in #152. `v0.1.0-rc.4` is currently absent.
 
 Required sequence:
 
-1. merge the post-D2 canonical documentation synchronization;
+1. merge the rc.4 canonical-documentation correction;
 2. record the exact resulting `main` SHA in #152;
-3. verify that exact SHA with all normal required push workflow groups and zero failures;
-4. confirm `v0.1.0-rc.3` Release and tag/ref are still absent;
+3. verify the final target per repository release policy;
+4. confirm `v0.1.0-rc.4` Release and tag/ref are absent immediately before publication;
 5. publish one GitHub prerelease targeting only that exact SHA;
 6. require `Release / Verify` and `Release / Publish` to complete the existing immutable release contract;
 7. inspect evidence/checksums/digests and verify `latest` remains unchanged;
-8. manually exercise the product from immutable rc.3 artifacts;
+8. manually exercise the product from immutable rc.4 artifacts;
 9. fix release-canary defects before choosing M5.2.
 
-The existing release contract must prove:
+The release contract must prove:
 
 - source/main ancestry and release metadata;
 - repository verification and production browser E2E;
@@ -108,18 +96,20 @@ The existing release contract must prove:
 - unchanged fail-closed Trivy `HIGH,CRITICAL` gate;
 - SPDX SBOM per candidate image manifest;
 - staging exact-digest Compose smoke;
-- copy-without-rebuild promotion to final packages with digest identity preserved;
+- copy-without-rebuild promotion with digest identity preserved;
 - final exact-digest smoke;
 - GitHub provenance attestations;
 - prerelease SemVer OCI promotion without mutating `latest`;
 - final manifest architecture checks;
 - attached release evidence and checksums.
 
+`.github/workflows/release.yml` accepts generic SemVer prereleases, so rc.4 does not require release-code changes.
+
 Stable `v0.1.0` remains blocked until prerelease evidence and manual acceptance are satisfactory.
 
 ## Parallel retailer connectivity
 
-Connectivity work may proceed in parallel, but it must not silently move the final rc.3 SHA after the release issue is returned to READY.
+Connectivity work may proceed in parallel before the final rc.4 SHA is frozen. Once #152 returns to READY with an exact SHA, no merge may silently move that target.
 
 ### Browser Bridge lifecycle — COMPLETE / ACCEPTED
 
@@ -135,48 +125,25 @@ Connectivity work may proceed in parallel, but it must not silently move the fin
 - managed CI/server browser worker: not selected;
 - no stealth, proxy rotation, fingerprint spoofing, credential/cookie/header extraction, mobile impersonation or arbitrary forwarding.
 
-The CI-browser negative result is evidence, not an unresolved decision gate.
-
 ### Chizhik D2 transport — IMPLEMENTED / MERGED; SCHEMA GATE OPEN
 
-#169 remains open. PR #171 added the exact, bounded store-scoped delivery-search transport while deliberately keeping successful JSON opaque and preventing automatic search/offer production before schema acceptance.
+#169 remains open. PR #171 added the exact bounded store-scoped delivery-search transport while deliberately keeping successful JSON opaque and preventing automatic search/offer production before schema acceptance.
 
 Canary: [`integrations/chizhik-d2-delivery-search-canary-2026-08-18.md`](integrations/chizhik-d2-delivery-search-canary-2026-08-18.md).
 
 ### Chizhik D2 evidenced store context — COMPLETE / ACCEPTED
 
-#173/#174 establishes that store context cannot be guessed:
-
-- context comes only from exact first-party Chizhik delivery catalog resource paths already seen by the official browser session;
-- path-embedded `sap_id` must intersect with the validated `/api/v1/shops/` directory;
-- exactly one distinct validated store is required;
-- missing, foreign-origin, unknown-store and conflicting contexts fail closed;
-- `searchStore` remains disabled and observations remain empty;
-- Chromium E2E covers the accepted failure modes;
-- PR #174 merge: `6c0af6ffa347c434e02600e83533244f8e2d15db`.
+#173/#174 requires store context to come only from exact first-party Chizhik delivery resource evidence already seen by the official browser session, intersected with the validated `/api/v1/shops/` directory. Exactly one distinct validated store is required; missing/foreign/unknown/conflicting contexts fail closed. `searchStore` remains disabled before schema acceptance.
 
 ### Chizhik next slice — BLOCKED ON ORDINARY-USER-BROWSER EVIDENCE
 
-Do **not** implement `BrowserObservation` / `ObservedOffer` mapping until #169 receives sanitized evidence from the documented ordinary-user-browser canary proving:
-
-- product-array/container path;
-- product identifier field;
-- product-name field;
-- price field and monetary unit/scale;
-- explicit availability semantics, if any.
+Do **not** implement `BrowserObservation` / `ObservedOffer` mapping until #169 receives sanitized evidence proving product-array/container path, product identifier, product name, price field **and monetary unit/scale**, plus explicit availability semantics if any.
 
 If availability semantics are not proven, map `UNKNOWN`. Promotion, loyalty, package and discount semantics remain unavailable until separately evidenced.
 
 ### Other mandatory retailer work
 
-Continue universal connectivity for:
-
-- #36 Kuper supported aggregator/API path and permitted reuse;
-- Ozon Fresh;
-- Samokat;
-- Lenta;
-- VkusVill;
-- additional canonical retailers/banners.
+Continue universal connectivity for #36 Kuper supported aggregator/API path and permitted reuse, Ozon Fresh, Samokat, Lenta, VkusVill and additional canonical retailers/banners.
 
 For every retailer, keep technical feasibility and production-access/right-to-operate approval separate.
 


### PR DESCRIPTION
Corrects release planning after discovering that `v0.1.0-rc.3` already exists and is immutable at `d988b8c596a737326aeac67f74b6f65a6aaed3bf`.

## Changes
- records rc.3 as historical release evidence instead of a future target;
- advances the next operational release gate to `v0.1.0-rc.4`;
- keeps issue #152 as the release acceptance tracker;
- records that rc.4 ref is currently absent;
- preserves all existing release/security gates and Chizhik evidence boundaries;
- adds the invariant that published prerelease tags are never repointed.

## Scope
Documentation only: `README.md`, `docs/PROJECT_STATE.md`, `docs/ROADMAP.md`, `CHANGELOG.md`.

No runtime, workflow, dependency, API, OpenAPI, generated-client, provider, database or permission change.

Baseline: `main=87df964013fb249a23e96eab474601aa803f61ab`; branch is behind=0. Acceptance requires fresh exact-head CI and squash merge before #152 can return to READY for rc.4.