### PR TITLE
feat(chizhik): add user-invoked sanitized D2 schema canary

### DIFF
--- a/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test } from "@playwright/test";
+
+const bridgeRoot = resolve(process.cwd(), "../retailer-bridge");
+const extensionPath = resolve(bridgeRoot, "dist");
+const shopsEndpoint = "https://app.chizhik.club/api/v1/shops/";
+const contextResource =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/categories/drinks/products";
+
+const stores = [
+  {
+    id: 26504,
+    sap_id: "HD87",
+    lon: 37.83372708,
+    lat: 55.76833314,
+    status: 1,
+    name: "Москва, Саянская ул., Дом 11Б",
+    locality: "Москва",
+  },
+];
+
+const secretPayload = {
+  products: [
+    {
+      sku: "SECRET-SKU-123",
+      name: "Secret product name",
+      price: 12999,
+      available: true,
+      promotion: { label: "secret promo" },
+    },
+  ],
+  requestId: "SECRET-REQUEST-ID",
+};
+
+test("runs the Chizhik D2 schema canary only on user invocation and renders sanitized evidence", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-canary-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  let searchRequests = 0;
+  try {
+    await context.route("https://chizhik.club/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><html><body><main>Chizhik catalog fixture</main></body></html>",
+      }),
+    );
+    await context.route(shopsEndpoint, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(stores),
+      }),
+    );
+    await context.route("https://app.chizhik.club/delivery/api/catalog/**", async (route) => {
+      const url = new URL(route.request().url());
+      const isCanarySearch = url.pathname.endsWith("/search") && url.searchParams.get("q") === "кола";
+      if (isCanarySearch) searchRequests += 1;
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(isCanarySearch ? secretPayload : { products: [] }),
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/chay-kofe--264C39224/");
+    await page.evaluate(async (resourceUrl) => {
+      await fetch(resourceUrl, {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+      });
+    }, contextResource);
+
+    await expect
+      .poll(() => page.locator("html").getAttribute("data-zg-bridge-status"))
+      .toBe("observation-only");
+    expect(searchRequests).toBe(0);
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(worker.url()).host;
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await page.bringToFront();
+
+    await popup.getByRole("button", { name: "Run sanitized Chizhik canary" }).click();
+    const evidence = popup.locator("#evidence");
+    await expect(evidence).toContainText("CHIZHIK_D2 status=PASS search_http_status=200");
+    await expect(evidence).toContainText('"products":"array"');
+    await expect(evidence).toContainText('"sku":"string"');
+    await expect(evidence).toContainText('"name":"string"');
+    await expect(evidence).toContainText('"price":"number"');
+    await expect(evidence).toContainText('"available":"boolean"');
+    expect(searchRequests).toBe(1);
+
+    const rendered = await evidence.textContent();
+    expect(rendered).not.toContain("HD87");
+    expect(rendered).not.toContain("SECRET-SKU-123");
+    expect(rendered).not.toContain("Secret product name");
+    expect(rendered).not.toContain("12999");
+    expect(rendered).not.toContain("secret promo");
+    expect(rendered).not.toContain("SECRET-REQUEST-ID");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
@@ -24,14 +24,20 @@ const stores = [
 const secretPayload = {
   products: [
     {
-      sku: "SECRET-SKU-123",
+      plu: 123456,
       name: "Secret product name",
-      price: 12999,
-      available: true,
+      prices: { regular: "129.99", discount: "99.99" },
+      is_available: true,
+      stock_limit: "7",
+      uom: "шт",
+      property_clarification: "0.5 л",
+      secretSkuValue: { nested: true },
+      sku123: "dynamic-key-must-not-leak",
       promotion: { label: "secret promo" },
     },
   ],
   requestId: "SECRET-REQUEST-ID",
+  SECRET_DYNAMIC_KEY: "must-not-leak",
 };
 
 test("runs the Chizhik D2 schema canary only on user invocation and renders sanitized evidence", async () => {
@@ -104,19 +110,29 @@ test("runs the Chizhik D2 schema canary only on user invocation and renders sani
     const evidence = popup.locator("#evidence");
     await expect(evidence).toContainText("CHIZHIK_D2 status=PASS search_http_status=200");
     await expect(evidence).toContainText('"products":"array"');
-    await expect(evidence).toContainText('"sku":"string"');
+    await expect(evidence).toContainText('"plu":"number"');
     await expect(evidence).toContainText('"name":"string"');
-    await expect(evidence).toContainText('"price":"number"');
-    await expect(evidence).toContainText('"available":"boolean"');
+    await expect(evidence).toContainText('"prices":"object"');
+    await expect(evidence).toContainText('"regular":"string"');
+    await expect(evidence).toContainText('"is_available":"boolean"');
+    await expect(evidence).toContainText('"stock_limit":"string"');
+    await expect(evidence).toContainText('"uom":"string"');
+    await expect(evidence).toContainText('"property_clarification":"string"');
     expect(searchRequests).toBe(1);
 
     const rendered = await evidence.textContent();
     expect(rendered).not.toContain("HD87");
-    expect(rendered).not.toContain("SECRET-SKU-123");
+    expect(rendered).not.toContain("123456");
     expect(rendered).not.toContain("Secret product name");
-    expect(rendered).not.toContain("12999");
+    expect(rendered).not.toContain("129.99");
+    expect(rendered).not.toContain("99.99");
     expect(rendered).not.toContain("secret promo");
     expect(rendered).not.toContain("SECRET-REQUEST-ID");
+    expect(rendered).not.toContain("secretSkuValue");
+    expect(rendered).not.toContain("sku123");
+    expect(rendered).not.toContain("promotion");
+    expect(rendered).not.toContain("discount");
+    expect(rendered).not.toContain("SECRET_DYNAMIC_KEY");
   } finally {
     await context.close();
     await rm(userDataDir, { recursive: true, force: true });

--- a/apps/retailer-bridge/scripts/build.mjs
+++ b/apps/retailer-bridge/scripts/build.mjs
@@ -113,3 +113,5 @@ await copyFile(
   resolve(root, e2e ? "static/service-worker.e2e.js" : "static/service-worker.js"),
   resolve(outDir, "service-worker.js"),
 );
+await copyFile(resolve(root, "static/popup.html"), resolve(outDir, "popup.html"));
+await copyFile(resolve(root, "static/popup.js"), resolve(outDir, "popup.js"));

--- a/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
+++ b/apps/retailer-bridge/src/adapters/chizhik-browser-adapter.ts
@@ -3,7 +3,7 @@ import {
   type ChizhikActiveApiClient,
   type ChizhikStoreDiscoveryResult,
 } from "../chizhik-active-api-client";
-import { fulfillmentContextResource } from "../resource-observation-policy";
+import { resolveChizhikEvidencedStoreId } from "../chizhik-store-context";
 import type {
   AdapterResult,
   RetailerBrowserAdapter,
@@ -11,28 +11,9 @@ import type {
 
 const RETAILER_ID = "chizhik";
 const OFFICIAL_PAGE_HOST = "chizhik.club";
-const CONTEXT_PREFIX = `${RETAILER_ID}:`;
 
 function isOfficialPageUrl(url: URL): boolean {
   return url.protocol === "https:" && url.hostname === OFFICIAL_PAGE_HOST;
-}
-
-function evidencedStoreIds(
-  resourceUrls: readonly string[],
-  pageUrl: URL,
-  validStoreIds: ReadonlySet<string>,
-): Set<string> {
-  const contexts = new Set<string>();
-
-  for (const rawUrl of resourceUrls) {
-    const resource = fulfillmentContextResource(rawUrl, pageUrl);
-    if (!resource?.contextKey.startsWith(CONTEXT_PREFIX)) continue;
-
-    const sapId = resource.contextKey.slice(CONTEXT_PREFIX.length);
-    if (validStoreIds.has(sapId)) contexts.add(sapId);
-  }
-
-  return contexts;
 }
 
 export function createChizhikBrowserAdapter(
@@ -56,8 +37,8 @@ export function createChizhikBrowserAdapter(
       }
 
       const validStoreIds = new Set(result.stores.map((store) => store.sapId));
-      const contexts = evidencedStoreIds(resourceUrls, url, validStoreIds);
-      if (contexts.size !== 1) {
+      const sapId = resolveChizhikEvidencedStoreId(resourceUrls, url, validStoreIds);
+      if (!sapId) {
         return { status: "missing-context", observations: [] };
       }
 

--- a/apps/retailer-bridge/src/chizhik-active-api-client.ts
+++ b/apps/retailer-bridge/src/chizhik-active-api-client.ts
@@ -27,7 +27,12 @@ export type ChizhikDeliverySearchRequest = Readonly<{
 }>;
 
 export type ChizhikDeliverySearchResult =
-  | Readonly<{ status: "received"; payload: unknown }>
+  | Readonly<{
+      status: "received";
+      httpStatus: number;
+      contentType: string;
+      payload: unknown;
+    }>
   | Readonly<{ status: "unavailable" }>;
 
 export type ChizhikActiveApiClient = Readonly<{
@@ -154,7 +159,12 @@ export function createChizhikActiveApiClient(
         }
 
         const payload: unknown = await response.json();
-        return { status: "received", payload };
+        return {
+          status: "received",
+          httpStatus: response.status,
+          contentType,
+          payload,
+        };
       } catch {
         return { status: "unavailable" };
       } finally {

--- a/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
@@ -1,0 +1,58 @@
+import type { ChizhikSchemaCanaryResult } from "./chizhik-schema-canary";
+
+export const CHIZHIK_SCHEMA_CANARY_REQUEST = "zg-chizhik-schema-canary";
+export const CHIZHIK_SCHEMA_CANARY_RESULT = "zg-chizhik-schema-canary-result";
+
+export type ChizhikSchemaCanaryMessageResult = Readonly<{
+  type: typeof CHIZHIK_SCHEMA_CANARY_RESULT;
+  evidence: string;
+}>;
+
+type RunCanary = () => Promise<ChizhikSchemaCanaryResult>;
+
+function baseContentType(contentType: string): string {
+  const [base] = contentType.split(";", 1);
+  return base?.trim() || "unknown";
+}
+
+export function formatChizhikSchemaCanaryEvidence(
+  result: ChizhikSchemaCanaryResult,
+): string {
+  switch (result.status) {
+    case "pass":
+      return (
+        `CHIZHIK_D2 status=PASS search_http_status=${result.httpStatus} ` +
+        `content_type=${baseContentType(result.contentType)} root=${result.rootType}\n` +
+        `CHIZHIK_D2_SCHEMA=${JSON.stringify(result.schema)}`
+      );
+    case "wrong-origin":
+      return "CHIZHIK_D2 status=WRONG_ORIGIN";
+    case "stores-unavailable":
+      return "CHIZHIK_D2 status=STORES_UNAVAILABLE";
+    case "missing-context":
+      return "CHIZHIK_D2 status=MISSING_CONTEXT";
+    case "search-unavailable":
+      return "CHIZHIK_D2 status=SEARCH_UNAVAILABLE";
+  }
+}
+
+function isCanaryRequest(message: unknown): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    !Array.isArray(message) &&
+    (message as { type?: unknown }).type === CHIZHIK_SCHEMA_CANARY_REQUEST
+  );
+}
+
+export function createChizhikSchemaCanaryMessageHandler(runCanary: RunCanary) {
+  return async (message: unknown): Promise<ChizhikSchemaCanaryMessageResult | null> => {
+    if (!isCanaryRequest(message)) return null;
+
+    const result = await runCanary();
+    return {
+      type: CHIZHIK_SCHEMA_CANARY_RESULT,
+      evidence: formatChizhikSchemaCanaryEvidence(result),
+    };
+  };
+}

--- a/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
@@ -36,7 +36,7 @@ export function formatChizhikSchemaCanaryEvidence(
   }
 }
 
-function isCanaryRequest(message: unknown): boolean {
+export function isChizhikSchemaCanaryRequest(message: unknown): boolean {
   return (
     typeof message === "object" &&
     message !== null &&
@@ -47,7 +47,7 @@ function isCanaryRequest(message: unknown): boolean {
 
 export function createChizhikSchemaCanaryMessageHandler(runCanary: RunCanary) {
   return async (message: unknown): Promise<ChizhikSchemaCanaryMessageResult | null> => {
-    if (!isCanaryRequest(message)) return null;
+    if (!isChizhikSchemaCanaryRequest(message)) return null;
 
     const result = await runCanary();
     return {

--- a/apps/retailer-bridge/src/chizhik-schema-canary.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary.ts
@@ -7,11 +7,31 @@ import { resolveChizhikEvidencedStoreId } from "./chizhik-store-context";
 const OFFICIAL_PAGE_ORIGIN = "https://chizhik.club";
 const CANARY_QUERY = "кола";
 const CANARY_LIMIT = 1;
-const SAFE_FIELD = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
 const MAX_SCHEMA_DEPTH = 5;
-const MAX_SCHEMA_NODES = 80;
+const MAX_SCHEMA_NODES = 32;
+const CANDIDATE_FIELDS = new Set([
+  "products",
+  "plu",
+  "name",
+  "prices",
+  "regular",
+  "is_available",
+  "stock_limit",
+  "uom",
+  "property_clarification",
+]);
 
-type JsonValueType = "null" | "array" | "object" | "string" | "number" | "boolean" | "undefined" | "bigint" | "symbol" | "function";
+type JsonValueType =
+  | "null"
+  | "array"
+  | "object"
+  | "string"
+  | "number"
+  | "boolean"
+  | "undefined"
+  | "bigint"
+  | "symbol"
+  | "function";
 
 type SchemaNode =
   | Readonly<{ path: string; type: "array" }>
@@ -77,13 +97,15 @@ function summarizeSchema(payload: unknown): readonly SchemaNode[] {
     }
     if (typeof value !== "object" || value === null) return;
 
-    const safeEntries = Object.entries(value).filter(([key]) => SAFE_FIELD.test(key));
+    const candidateEntries = Object.entries(value).filter(([key]) => CANDIDATE_FIELDS.has(key));
     schema.push({
       path,
       type: "object",
-      fields: Object.fromEntries(safeEntries.map(([key, child]) => [key, valueType(child)])),
+      fields: Object.fromEntries(
+        candidateEntries.map(([key, child]) => [key, valueType(child)]),
+      ),
     });
-    for (const [key, child] of safeEntries) {
+    for (const [key, child] of candidateEntries) {
       if (typeof child === "object" && child !== null) {
         visit(child, `${path}.${key}`, depth + 1);
       }

--- a/apps/retailer-bridge/src/chizhik-schema-canary.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary.ts
@@ -1,0 +1,151 @@
+import type {
+  ChizhikDeliverySearchRequest,
+  ChizhikStoreDiscoveryResult,
+} from "./chizhik-active-api-client";
+import { fulfillmentContextResource } from "./resource-observation-policy";
+
+const OFFICIAL_PAGE_ORIGIN = "https://chizhik.club";
+const CONTEXT_PREFIX = "chizhik:";
+const CANARY_QUERY = "кола";
+const CANARY_LIMIT = 1;
+const SAFE_FIELD = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+const MAX_SCHEMA_DEPTH = 5;
+const MAX_SCHEMA_NODES = 80;
+
+type JsonValueType = "null" | "array" | "object" | "string" | "number" | "boolean" | "undefined" | "bigint" | "symbol" | "function";
+
+type SchemaNode =
+  | Readonly<{ path: string; type: "array" }>
+  | Readonly<{
+      path: string;
+      type: "object";
+      fields: Readonly<Record<string, JsonValueType>>;
+    }>;
+
+type CanarySearchResult =
+  | Readonly<{
+      status: "received";
+      httpStatus: number;
+      contentType: string;
+      payload: unknown;
+    }>
+  | Readonly<{ status: "unavailable" }>;
+
+type CanaryClient = Readonly<{
+  listStores(): Promise<ChizhikStoreDiscoveryResult>;
+  searchStore(request: ChizhikDeliverySearchRequest): Promise<CanarySearchResult>;
+}>;
+
+export type ChizhikSchemaCanaryResult =
+  | Readonly<{ status: "wrong-origin" }>
+  | Readonly<{ status: "stores-unavailable" }>
+  | Readonly<{ status: "missing-context" }>
+  | Readonly<{ status: "search-unavailable" }>
+  | Readonly<{
+      status: "pass";
+      httpStatus: number;
+      contentType: string;
+      rootType: JsonValueType;
+      schema: readonly SchemaNode[];
+    }>;
+
+export type ChizhikSchemaCanaryInput = Readonly<{
+  client: CanaryClient;
+  pageUrl: URL;
+  resourceUrls: readonly string[];
+}>;
+
+function valueType(value: unknown): JsonValueType {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function evidencedStoreIds(
+  resourceUrls: readonly string[],
+  pageUrl: URL,
+  validStoreIds: ReadonlySet<string>,
+): Set<string> {
+  const contexts = new Set<string>();
+  for (const rawUrl of resourceUrls) {
+    const resource = fulfillmentContextResource(rawUrl, pageUrl);
+    if (!resource?.contextKey.startsWith(CONTEXT_PREFIX)) continue;
+
+    const sapId = resource.contextKey.slice(CONTEXT_PREFIX.length);
+    if (validStoreIds.has(sapId)) contexts.add(sapId);
+  }
+  return contexts;
+}
+
+function summarizeSchema(payload: unknown): readonly SchemaNode[] {
+  const schema: SchemaNode[] = [];
+  const seenPaths = new Set<string>();
+
+  const visit = (value: unknown, path = "$", depth = 0): void => {
+    if (depth > MAX_SCHEMA_DEPTH || schema.length >= MAX_SCHEMA_NODES || seenPaths.has(path)) {
+      return;
+    }
+    seenPaths.add(path);
+
+    if (Array.isArray(value)) {
+      schema.push({ path, type: "array" });
+      if (value.length > 0) visit(value[0], `${path}[]`, depth + 1);
+      return;
+    }
+    if (typeof value !== "object" || value === null) return;
+
+    const safeEntries = Object.entries(value).filter(([key]) => SAFE_FIELD.test(key));
+    schema.push({
+      path,
+      type: "object",
+      fields: Object.fromEntries(safeEntries.map(([key, child]) => [key, valueType(child)])),
+    });
+    for (const [key, child] of safeEntries) {
+      if (typeof child === "object" && child !== null) {
+        visit(child, `${path}.${key}`, depth + 1);
+      }
+    }
+  };
+
+  visit(payload);
+  return schema;
+}
+
+export async function runChizhikSchemaCanary(
+  input: ChizhikSchemaCanaryInput,
+): Promise<ChizhikSchemaCanaryResult> {
+  if (input.pageUrl.origin !== OFFICIAL_PAGE_ORIGIN) {
+    return { status: "wrong-origin" };
+  }
+
+  const stores = await input.client.listStores();
+  if (stores.status !== "ok" || stores.stores.length === 0) {
+    return { status: "stores-unavailable" };
+  }
+
+  const validStoreIds = new Set(stores.stores.map((store) => store.sapId));
+  const contexts = evidencedStoreIds(input.resourceUrls, input.pageUrl, validStoreIds);
+  if (contexts.size !== 1) {
+    return { status: "missing-context" };
+  }
+
+  const [sapId] = contexts;
+  if (!sapId) return { status: "missing-context" };
+
+  const search = await input.client.searchStore({
+    sapId,
+    query: CANARY_QUERY,
+    limit: CANARY_LIMIT,
+  });
+  if (search.status !== "received") {
+    return { status: "search-unavailable" };
+  }
+
+  return {
+    status: "pass",
+    httpStatus: search.httpStatus,
+    contentType: search.contentType,
+    rootType: valueType(search.payload),
+    schema: summarizeSchema(search.payload),
+  };
+}

--- a/apps/retailer-bridge/src/chizhik-schema-canary.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary.ts
@@ -2,10 +2,9 @@ import type {
   ChizhikDeliverySearchRequest,
   ChizhikStoreDiscoveryResult,
 } from "./chizhik-active-api-client";
-import { fulfillmentContextResource } from "./resource-observation-policy";
+import { resolveChizhikEvidencedStoreId } from "./chizhik-store-context";
 
 const OFFICIAL_PAGE_ORIGIN = "https://chizhik.club";
-const CONTEXT_PREFIX = "chizhik:";
 const CANARY_QUERY = "кола";
 const CANARY_LIMIT = 1;
 const SAFE_FIELD = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
@@ -61,22 +60,6 @@ function valueType(value: unknown): JsonValueType {
   return typeof value;
 }
 
-function evidencedStoreIds(
-  resourceUrls: readonly string[],
-  pageUrl: URL,
-  validStoreIds: ReadonlySet<string>,
-): Set<string> {
-  const contexts = new Set<string>();
-  for (const rawUrl of resourceUrls) {
-    const resource = fulfillmentContextResource(rawUrl, pageUrl);
-    if (!resource?.contextKey.startsWith(CONTEXT_PREFIX)) continue;
-
-    const sapId = resource.contextKey.slice(CONTEXT_PREFIX.length);
-    if (validStoreIds.has(sapId)) contexts.add(sapId);
-  }
-  return contexts;
-}
-
 function summarizeSchema(payload: unknown): readonly SchemaNode[] {
   const schema: SchemaNode[] = [];
   const seenPaths = new Set<string>();
@@ -124,12 +107,11 @@ export async function runChizhikSchemaCanary(
   }
 
   const validStoreIds = new Set(stores.stores.map((store) => store.sapId));
-  const contexts = evidencedStoreIds(input.resourceUrls, input.pageUrl, validStoreIds);
-  if (contexts.size !== 1) {
-    return { status: "missing-context" };
-  }
-
-  const [sapId] = contexts;
+  const sapId = resolveChizhikEvidencedStoreId(
+    input.resourceUrls,
+    input.pageUrl,
+    validStoreIds,
+  );
   if (!sapId) return { status: "missing-context" };
 
   const search = await input.client.searchStore({

--- a/apps/retailer-bridge/src/chizhik-store-context.ts
+++ b/apps/retailer-bridge/src/chizhik-store-context.ts
@@ -1,0 +1,22 @@
+import { fulfillmentContextResource } from "./resource-observation-policy";
+
+const CONTEXT_PREFIX = "chizhik:";
+
+export function resolveChizhikEvidencedStoreId(
+  resourceUrls: readonly string[],
+  pageUrl: URL,
+  validStoreIds: ReadonlySet<string>,
+): string | null {
+  const contexts = new Set<string>();
+
+  for (const rawUrl of resourceUrls) {
+    const resource = fulfillmentContextResource(rawUrl, pageUrl);
+    if (!resource?.contextKey.startsWith(CONTEXT_PREFIX)) continue;
+
+    const sapId = resource.contextKey.slice(CONTEXT_PREFIX.length);
+    if (validStoreIds.has(sapId)) contexts.add(sapId);
+  }
+
+  if (contexts.size !== 1) return null;
+  return contexts.values().next().value ?? null;
+}

--- a/apps/retailer-bridge/src/chrome.d.ts
+++ b/apps/retailer-bridge/src/chrome.d.ts
@@ -1,5 +1,14 @@
 declare const chrome: {
   runtime: {
     sendMessage(message: unknown): Promise<unknown>;
+    onMessage: {
+      addListener(
+        listener: (
+          message: unknown,
+          sender: unknown,
+          sendResponse: (response: unknown) => void,
+        ) => boolean | void,
+      ): void;
+    };
   };
 };

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -1,4 +1,11 @@
 import { retailerBrowserAdapters } from "./adapters/retailer-browser-adapters";
+import { createChizhikActiveApiClient } from "./chizhik-active-api-client";
+import { runChizhikSchemaCanary } from "./chizhik-schema-canary";
+import {
+  CHIZHIK_SCHEMA_CANARY_RESULT,
+  createChizhikSchemaCanaryMessageHandler,
+  isChizhikSchemaCanaryRequest,
+} from "./chizhik-schema-canary-message";
 import { BrowserObservationCollector } from "./collector/browser-observation-collector";
 import {
   createChromeObservationClearer,
@@ -14,6 +21,30 @@ const sendMessage = (message: unknown) => chrome.runtime.sendMessage(message);
 const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const observedResourceUrls = new Set<string>();
+const chizhikSchemaCanaryClient = createChizhikActiveApiClient();
+const handleChizhikSchemaCanaryMessage = createChizhikSchemaCanaryMessageHandler(() =>
+  runChizhikSchemaCanary({
+    client: chizhikSchemaCanaryClient,
+    pageUrl: new URL(location.href),
+    resourceUrls: [...observedResourceUrls],
+  }),
+);
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!isChizhikSchemaCanaryRequest(message)) return false;
+
+  void handleChizhikSchemaCanaryMessage(message)
+    .then((response) => {
+      if (response) sendResponse(response);
+    })
+    .catch(() => {
+      sendResponse({
+        type: CHIZHIK_SCHEMA_CANARY_RESULT,
+        evidence: "CHIZHIK_D2 status=PROBE_ERROR",
+      });
+    });
+  return true;
+});
 
 function nextObservationRevision(previous: number): number {
   const clockRevision = Math.floor((performance.timeOrigin + performance.now()) * 1_000);

--- a/apps/retailer-bridge/static/manifest.e2e.json
+++ b/apps/retailer-bridge/static/manifest.e2e.json
@@ -4,6 +4,10 @@
   "version": "0.1.0",
   "description": "Local fixture build for deterministic extension tests.",
   "permissions": ["storage"],
+  "action": {
+    "default_title": "Chizhik D2 schema canary",
+    "default_popup": "popup.html"
+  },
   "background": {
     "service_worker": "service-worker.js"
   },

--- a/apps/retailer-bridge/static/manifest.json
+++ b/apps/retailer-bridge/static/manifest.json
@@ -4,6 +4,10 @@
   "version": "0.1.0",
   "description": "Reads sanitized grocery offer observations from supported first-party retailer pages.",
   "permissions": ["storage"],
+  "action": {
+    "default_title": "Chizhik D2 schema canary",
+    "default_popup": "popup.html"
+  },
   "background": {
     "service_worker": "service-worker.js"
   },

--- a/apps/retailer-bridge/static/popup.html
+++ b/apps/retailer-bridge/static/popup.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chizhik D2 schema canary</title>
+    <style>
+      body { font: 13px system-ui, sans-serif; margin: 12px; min-width: 340px; max-width: 520px; }
+      button { font: inherit; padding: 7px 10px; }
+      pre { margin: 10px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; user-select: text; }
+    </style>
+  </head>
+  <body>
+    <button id="run" type="button">Run sanitized Chizhik canary</button>
+    <pre id="evidence" aria-live="polite">CHIZHIK_D2 status=IDLE</pre>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/apps/retailer-bridge/static/popup.js
+++ b/apps/retailer-bridge/static/popup.js
@@ -1,0 +1,41 @@
+const REQUEST_TYPE = "zg-chizhik-schema-canary";
+const RESULT_TYPE = "zg-chizhik-schema-canary-result";
+const FALLBACK = "CHIZHIK_D2 status=UNAVAILABLE";
+
+const runButton = document.getElementById("run");
+const evidence = document.getElementById("evidence");
+
+async function runCanary() {
+  if (!(runButton instanceof HTMLButtonElement) || !(evidence instanceof HTMLElement)) return;
+
+  runButton.disabled = true;
+  evidence.textContent = "CHIZHIK_D2 status=RUNNING";
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!Number.isInteger(tab?.id)) {
+      evidence.textContent = FALLBACK;
+      return;
+    }
+
+    const response = await chrome.tabs.sendMessage(tab.id, { type: REQUEST_TYPE });
+    if (
+      !response ||
+      response.type !== RESULT_TYPE ||
+      typeof response.evidence !== "string" ||
+      !response.evidence.startsWith("CHIZHIK_D2 status=")
+    ) {
+      evidence.textContent = FALLBACK;
+      return;
+    }
+
+    evidence.textContent = response.evidence;
+  } catch {
+    evidence.textContent = FALLBACK;
+  } finally {
+    runButton.disabled = false;
+  }
+}
+
+runButton?.addEventListener("click", () => {
+  void runCanary();
+});

--- a/apps/retailer-bridge/test/chizhik-active-api-client-metadata.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client-metadata.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChizhikActiveApiClient } from "../src/chizhik-active-api-client";
+
+describe("ChizhikActiveApiClient delivery-search metadata", () => {
+  it("returns only HTTP status and content type alongside the opaque successful payload", async () => {
+    const payload = { secretProduct: "must-remain-opaque" };
+    const client = createChizhikActiveApiClient(
+      vi.fn(async () =>
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { "content-type": "application/json; charset=utf-8" },
+        }),
+      ),
+    );
+
+    await expect(
+      client.searchStore({ sapId: "HD87", query: "кола", limit: 1 }),
+    ).resolves.toEqual({
+      status: "received",
+      httpStatus: 200,
+      contentType: "application/json; charset=utf-8",
+      payload,
+    });
+  });
+});

--- a/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
+++ b/apps/retailer-bridge/test/chizhik-active-api-client.test.ts
@@ -133,7 +133,12 @@ describe("ChizhikActiveApiClient", () => {
         signal: expect.any(AbortSignal),
       },
     );
-    expect(result).toEqual({ status: "received", payload: opaquePayload });
+    expect(result).toEqual({
+      status: "received",
+      httpStatus: 200,
+      contentType: "application/json; charset=utf-8",
+      payload: opaquePayload,
+    });
   });
 
   it("rejects unsafe store ids, blank queries, and unbounded limits before transport", async () => {

--- a/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CHIZHIK_SCHEMA_CANARY_REQUEST,
+  createChizhikSchemaCanaryMessageHandler,
+  formatChizhikSchemaCanaryEvidence,
+} from "../src/chizhik-schema-canary-message";
+
+const PASS_RESULT = {
+  status: "pass" as const,
+  httpStatus: 200,
+  contentType: "application/json; charset=utf-8",
+  rootType: "object" as const,
+  schema: [
+    { path: "$", type: "object" as const, fields: { products: "array" as const } },
+    { path: "$.products", type: "array" as const },
+    {
+      path: "$.products[]",
+      type: "object" as const,
+      fields: { sku: "string" as const, name: "string" as const, price: "number" as const },
+    },
+  ],
+};
+
+describe("Chizhik schema canary message contract", () => {
+  it("formats PASS as exactly two sanitized evidence lines", () => {
+    expect(formatChizhikSchemaCanaryEvidence(PASS_RESULT)).toBe(
+      'CHIZHIK_D2 status=PASS search_http_status=200 content_type=application/json root=object\n' +
+        'CHIZHIK_D2_SCHEMA=[{"path":"$","type":"object","fields":{"products":"array"}},{"path":"$.products","type":"array"},{"path":"$.products[]","type":"object","fields":{"sku":"string","name":"string","price":"number"}}]',
+    );
+  });
+
+  it("formats failures without exception, store, product, or payload details", () => {
+    expect(formatChizhikSchemaCanaryEvidence({ status: "wrong-origin" })).toBe(
+      "CHIZHIK_D2 status=WRONG_ORIGIN",
+    );
+    expect(formatChizhikSchemaCanaryEvidence({ status: "missing-context" })).toBe(
+      "CHIZHIK_D2 status=MISSING_CONTEXT",
+    );
+    expect(formatChizhikSchemaCanaryEvidence({ status: "stores-unavailable" })).toBe(
+      "CHIZHIK_D2 status=STORES_UNAVAILABLE",
+    );
+    expect(formatChizhikSchemaCanaryEvidence({ status: "search-unavailable" })).toBe(
+      "CHIZHIK_D2 status=SEARCH_UNAVAILABLE",
+    );
+  });
+
+  it("runs only for the explicit user-invoked canary message", async () => {
+    const runCanary = vi.fn(async () => PASS_RESULT);
+    const handler = createChizhikSchemaCanaryMessageHandler(runCanary);
+
+    await expect(handler({ type: "unrelated" })).resolves.toBeNull();
+    expect(runCanary).not.toHaveBeenCalled();
+
+    await expect(handler({ type: CHIZHIK_SCHEMA_CANARY_REQUEST })).resolves.toEqual({
+      type: "zg-chizhik-schema-canary-result",
+      evidence: formatChizhikSchemaCanaryEvidence(PASS_RESULT),
+    });
+    expect(runCanary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/retailer-bridge/test/chizhik-schema-canary-popup-contract.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary-popup-contract.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const productionManifest = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../static/manifest.json", import.meta.url)), "utf8"),
+);
+const e2eManifest = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../static/manifest.e2e.json", import.meta.url)), "utf8"),
+);
+const buildScript = readFileSync(
+  fileURLToPath(new URL("../scripts/build.mjs", import.meta.url)),
+  "utf8",
+);
+
+function assertPopupManifest(manifest: Record<string, unknown>): void {
+  expect(manifest.permissions).toEqual(["storage"]);
+  expect(manifest.host_permissions ?? []).toEqual([]);
+  expect(manifest.action).toEqual({
+    default_title: "Chizhik D2 schema canary",
+    default_popup: "popup.html",
+  });
+}
+
+describe("Chizhik schema canary popup contract", () => {
+  it("declares the same no-permission-widening toolbar popup in production and E2E manifests", () => {
+    assertPopupManifest(productionManifest);
+    assertPopupManifest(e2eManifest);
+  });
+
+  it("packages popup HTML and JavaScript into both extension builds", () => {
+    expect(buildScript).toContain('resolve(root, "static/popup.html")');
+    expect(buildScript).toContain('resolve(outDir, "popup.html")');
+    expect(buildScript).toContain('resolve(root, "static/popup.js")');
+    expect(buildScript).toContain('resolve(outDir, "popup.js")');
+  });
+});

--- a/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
@@ -37,19 +37,24 @@ function clientWithPayload(payload: unknown) {
 }
 
 describe("runChizhikSchemaCanary", () => {
-  it("uses one browser-evidenced validated store and emits structural schema only", async () => {
+  it("uses one browser-evidenced validated store and emits only approved candidate schema keys", async () => {
     const client = clientWithPayload({
       products: [
         {
-          sku: "SECRET-SKU-123",
+          plu: 123456,
           name: "Secret product name",
-          price: 12999,
-          available: true,
+          prices: { regular: "129.99", discount: "99.99" },
+          is_available: true,
+          stock_limit: "7",
+          uom: "шт",
+          property_clarification: "0.5 л",
+          secretSkuValue: { nested: true },
+          sku123: "dynamic-key-must-not-leak",
           promotion: { label: "secret promo" },
-          "123456": "dynamic-key-must-not-leak",
         },
       ],
       requestId: "SECRET-REQUEST-ID",
+      SECRET_DYNAMIC_KEY: "must-not-leak",
     });
 
     const result = await runChizhikSchemaCanary({
@@ -66,34 +71,39 @@ describe("runChizhikSchemaCanary", () => {
       contentType: "application/json; charset=utf-8",
       rootType: "object",
       schema: [
-        { path: "$", type: "object", fields: { products: "array", requestId: "string" } },
+        { path: "$", type: "object", fields: { products: "array" } },
         { path: "$.products", type: "array" },
         {
           path: "$.products[]",
           type: "object",
           fields: {
-            sku: "string",
+            plu: "number",
             name: "string",
-            price: "number",
-            available: "boolean",
-            promotion: "object",
+            prices: "object",
+            is_available: "boolean",
+            stock_limit: "string",
+            uom: "string",
+            property_clarification: "string",
           },
         },
         {
-          path: "$.products[].promotion",
+          path: "$.products[].prices",
           type: "object",
-          fields: { label: "string" },
+          fields: { regular: "string" },
         },
       ],
     });
 
     const serialized = JSON.stringify(result);
-    expect(serialized).not.toContain("SECRET-SKU-123");
     expect(serialized).not.toContain("Secret product name");
-    expect(serialized).not.toContain("12999");
-    expect(serialized).not.toContain("secret promo");
+    expect(serialized).not.toContain("129.99");
+    expect(serialized).not.toContain("99.99");
     expect(serialized).not.toContain("SECRET-REQUEST-ID");
-    expect(serialized).not.toContain("123456");
+    expect(serialized).not.toContain("secretSkuValue");
+    expect(serialized).not.toContain("sku123");
+    expect(serialized).not.toContain("promotion");
+    expect(serialized).not.toContain("discount");
+    expect(serialized).not.toContain("SECRET_DYNAMIC_KEY");
   });
 
   it("fails closed without exactly one evidenced store and never searches", async () => {

--- a/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { runChizhikSchemaCanary } from "../src/chizhik-schema-canary";
+
+const PAGE_URL = new URL("https://chizhik.club/catalog/chay-kofe--264C39224/");
+const HD87_RESOURCE =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/categories/drinks/products";
+
+const STORES = [
+  {
+    sapId: "HD87",
+    longitude: 37.83372708,
+    latitude: 55.76833314,
+    active: true,
+    name: "Москва",
+    locality: "Москва",
+  },
+  {
+    sapId: "HD88",
+    longitude: 37.80898339,
+    latitude: 55.39666279,
+    active: true,
+    name: "Домодедово",
+    locality: "Домодедово",
+  },
+] as const;
+
+function clientWithPayload(payload: unknown) {
+  return {
+    listStores: vi.fn(async () => ({ status: "ok" as const, stores: STORES })),
+    searchStore: vi.fn(async () => ({
+      status: "received" as const,
+      httpStatus: 200,
+      contentType: "application/json; charset=utf-8",
+      payload,
+    })),
+  };
+}
+
+describe("runChizhikSchemaCanary", () => {
+  it("uses one browser-evidenced validated store and emits structural schema only", async () => {
+    const client = clientWithPayload({
+      products: [
+        {
+          sku: "SECRET-SKU-123",
+          name: "Secret product name",
+          price: 12999,
+          available: true,
+          promotion: { label: "secret promo" },
+          "123456": "dynamic-key-must-not-leak",
+        },
+      ],
+      requestId: "SECRET-REQUEST-ID",
+    });
+
+    const result = await runChizhikSchemaCanary({
+      client,
+      pageUrl: PAGE_URL,
+      resourceUrls: [HD87_RESOURCE],
+    });
+
+    expect(client.listStores).toHaveBeenCalledTimes(1);
+    expect(client.searchStore).toHaveBeenCalledWith({ sapId: "HD87", query: "кола", limit: 1 });
+    expect(result).toEqual({
+      status: "pass",
+      httpStatus: 200,
+      contentType: "application/json; charset=utf-8",
+      rootType: "object",
+      schema: [
+        { path: "$", type: "object", fields: { products: "array", requestId: "string" } },
+        { path: "$.products", type: "array" },
+        {
+          path: "$.products[]",
+          type: "object",
+          fields: {
+            sku: "string",
+            name: "string",
+            price: "number",
+            available: "boolean",
+            promotion: "object",
+          },
+        },
+        {
+          path: "$.products[].promotion",
+          type: "object",
+          fields: { label: "string" },
+        },
+      ],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("SECRET-SKU-123");
+    expect(serialized).not.toContain("Secret product name");
+    expect(serialized).not.toContain("12999");
+    expect(serialized).not.toContain("secret promo");
+    expect(serialized).not.toContain("SECRET-REQUEST-ID");
+    expect(serialized).not.toContain("123456");
+  });
+
+  it("fails closed without exactly one evidenced store and never searches", async () => {
+    for (const resourceUrls of [
+      [] as string[],
+      ["https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search"],
+      [
+        HD87_RESOURCE,
+        "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD88/categories/drinks/products",
+      ],
+      ["https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search"],
+    ]) {
+      const client = clientWithPayload({ products: [] });
+      await expect(
+        runChizhikSchemaCanary({ client, pageUrl: PAGE_URL, resourceUrls }),
+      ).resolves.toEqual({ status: "missing-context" });
+      expect(client.searchStore).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects a non-official page origin before any retailer request", async () => {
+    const client = clientWithPayload({ products: [] });
+
+    await expect(
+      runChizhikSchemaCanary({
+        client,
+        pageUrl: new URL("https://chizhik.club.evil.example/catalog"),
+        resourceUrls: [HD87_RESOURCE],
+      }),
+    ).resolves.toEqual({ status: "wrong-origin" });
+
+    expect(client.listStores).not.toHaveBeenCalled();
+    expect(client.searchStore).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when store discovery or delivery search is unavailable", async () => {
+    const discoveryUnavailable = {
+      listStores: vi.fn(async () => ({ status: "unavailable" as const, stores: [] as const })),
+      searchStore: vi.fn(),
+    };
+    await expect(
+      runChizhikSchemaCanary({
+        client: discoveryUnavailable,
+        pageUrl: PAGE_URL,
+        resourceUrls: [HD87_RESOURCE],
+      }),
+    ).resolves.toEqual({ status: "stores-unavailable" });
+    expect(discoveryUnavailable.searchStore).not.toHaveBeenCalled();
+
+    const searchUnavailable = {
+      listStores: vi.fn(async () => ({ status: "ok" as const, stores: STORES })),
+      searchStore: vi.fn(async () => ({ status: "unavailable" as const })),
+    };
+    await expect(
+      runChizhikSchemaCanary({
+        client: searchUnavailable,
+        pageUrl: PAGE_URL,
+        resourceUrls: [HD87_RESOURCE],
+      }),
+    ).resolves.toEqual({ status: "search-unavailable" });
+  });
+});

--- a/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
+++ b/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
@@ -2,190 +2,123 @@
 
 ## Status
 
-**Ready for ordinary-user-browser execution.** This document does not accept the delivery payload schema by itself.
+**Implementation in draft PR #177; ordinary-user-browser evidence still required.**
 
-Phase D1 established the technical transport split:
+This canary exists only to obtain privacy-safe structural evidence for issue #169. It does not accept the delivery payload schema, monetary unit, availability semantics, offer mapping or production/right-to-operate status by itself.
 
-- an ordinary user-opened `https://chizhik.club/` page can fetch the fixed first-party store directory at `https://app.chizhik.club/api/v1/shops/` and receive valid JSON;
-- stock GitHub-hosted Chromium was `page-unavailable`;
-- therefore Chizhik acquisition remains a normal user-browser MV3 Retailer Bridge path rather than a managed browser worker.
+## Why this procedure exists
 
-Issue: #169.
+Phase D1 and the accepted #173/#174 store-context rule established two permanent constraints:
 
-## Candidate D2 endpoint
+- Chizhik acquisition uses the normal user-browser MV3 Retailer Bridge, not a managed CI/server browser worker;
+- store context must come from an exact first-party Chizhik delivery resource already observed by the current browser session and must intersect the validated `/api/v1/shops/` directory.
 
-A public third-party implementation (`Open-Inflation/chizhik_api`) is used only as endpoint-discovery input. Its current source suggests:
+The earlier DevTools draft in this document selected the first active store from `/api/v1/shops/`. That is no longer valid and has been removed. **The canary must never guess a store from directory order, active status or convenience.**
+
+## Fixed transport under test
+
+The already-merged D2 transport uses only:
 
 ```text
-GET https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search?mode=store&include_restrict=true&q={query}&limit={limit}
+GET https://app.chizhik.club/delivery/api/catalog/v3/stores/{sap_id}/search?mode=store&include_restrict=true&q=%D0%BA%D0%BE%D0%BB%D0%B0&limit=1
 ```
 
-Its tests pass a store `sap_id` into this delivery-search path. Neither the endpoint nor its response schema becomes an accepted ZakupGotov contract until the ordinary-browser canary below succeeds.
+The canary keeps the response payload opaque to ordinary bridge behavior. It is invoked only by the user and summarizes structural field-name/type evidence without returning raw values.
 
 ## Safety boundary
 
-The canary:
+The implementation in #177:
 
-- must be run only from DevTools on an already-open official `https://chizhik.club/...` page;
-- requests only the exact `/api/v1/shops/` directory and the fixed store-scoped delivery-search template;
-- selects one active store internally and **does not print its `sap_id`, address, coordinates, or other store values**;
-- searches only the fixed term `кола` with `limit=1`;
-- uses ordinary `cors`, `same-origin` credentials and an 8-second deadline;
-- prints HTTP status plus structural schema only;
-- filters reported object field names to ASCII identifier-like keys before printing them, preventing dynamic IDs/values used as object keys from leaking into evidence;
-- never prints or persists the raw JSON body, product names, SKUs, prices, promotion values, cookies, headers or credentials.
+- runs only after an explicit toolbar-popup button click;
+- adds no new extension permissions and no `host_permissions`;
+- uses only the current official `https://chizhik.club/...` content-script session;
+- obtains valid store IDs from the fixed `/api/v1/shops/` directory;
+- derives the candidate `sap_id` only from already-observed exact first-party delivery resource paths;
+- requires exactly one distinct browser-evidenced store that is present in the validated directory;
+- fails closed on missing, foreign-origin, unknown or conflicting context;
+- issues exactly one fixed `кола`, `limit=1` D2 search per user invocation;
+- retains only HTTP status, base content type, root type and bounded field-name/type structure;
+- filters object keys to ASCII identifier-like names and bounds schema depth/node count;
+- never emits raw response bodies, store IDs, addresses, coordinates, product names, SKU values, numeric price values, promotion values, request IDs, cookies, headers or credentials;
+- leaves automatic D2 search and `BrowserObservation` / `ObservedOffer` production disabled.
 
-Do not paste a raw response body into an issue, PR, chat or repository.
+## Running the canary
 
-## DevTools canary
+Use an extension build containing #177. Until the PR is accepted and merged, use only an exact reviewed branch commit; do not treat a local or PR build as production evidence.
 
-Open an official Chizhik catalog page, open DevTools → Console, paste the whole block and run it once:
+1. Open an official Chizhik catalog/delivery page under `https://chizhik.club/` in the ordinary user browser.
+2. Interact with the official page normally until the current session has loaded a first-party delivery catalog resource for the selected store.
+3. Open the **Zakup Gotov Retailer Bridge** toolbar popup.
+4. Click **Run sanitized Chizhik canary** once.
+5. Copy only the rendered evidence text.
 
-```js
-(async () => {
-  const PAGE_ORIGIN = "https://chizhik.club";
-  const SHOPS_ENDPOINT = "https://app.chizhik.club/api/v1/shops/";
-  const SEARCH_BASE = "https://app.chizhik.club/delivery/api/catalog/v3/stores";
-  const QUERY = "кола";
-  const LIMIT = 1;
-  const TIMEOUT_MS = 8_000;
-  const SAP_ID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
-  const SAFE_FIELD = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+Expected successful shape:
 
-  const valueType = (value) => {
-    if (value === null) return "null";
-    if (Array.isArray(value)) return "array";
-    return typeof value;
-  };
-
-  const requestJson = async (url) => {
-    const controller = new AbortController();
-    const deadline = setTimeout(() => controller.abort(), TIMEOUT_MS);
-    try {
-      const response = await fetch(url, {
-        method: "GET",
-        mode: "cors",
-        credentials: "same-origin",
-        headers: { Accept: "application/json, text/plain, */*" },
-        signal: controller.signal,
-      });
-      const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-      if (!response.ok || !contentType.startsWith("application/json")) {
-        return { status: "HTTP_UNAVAILABLE", httpStatus: response.status, contentType, payload: null };
-      }
-      try {
-        return {
-          status: "RECEIVED",
-          httpStatus: response.status,
-          contentType,
-          payload: await response.json(),
-        };
-      } catch {
-        return { status: "INVALID_JSON", httpStatus: response.status, contentType, payload: null };
-      }
-    } catch {
-      return { status: "FETCH_UNAVAILABLE", httpStatus: -1, contentType: "", payload: null };
-    } finally {
-      clearTimeout(deadline);
-    }
-  };
-
-  const schema = [];
-  const seenPaths = new Set();
-  const visit = (value, path = "$", depth = 0) => {
-    if (depth > 5 || schema.length >= 80 || seenPaths.has(path)) return;
-    seenPaths.add(path);
-
-    if (Array.isArray(value)) {
-      schema.push({ path, type: "array" });
-      if (value.length > 0) visit(value[0], `${path}[]`, depth + 1);
-      return;
-    }
-    if (!value || typeof value !== "object") return;
-
-    const safeEntries = Object.entries(value).filter(([key]) => SAFE_FIELD.test(key));
-    schema.push({
-      path,
-      type: "object",
-      fields: Object.fromEntries(safeEntries.map(([key, child]) => [key, valueType(child)])),
-    });
-    for (const [key, child] of safeEntries) {
-      if (child && typeof child === "object") visit(child, `${path}.${key}`, depth + 1);
-    }
-  };
-
-  if (location.origin !== PAGE_ORIGIN) {
-    console.log("CHIZHIK_D2 status=WRONG_ORIGIN");
-    return;
-  }
-
-  const shops = await requestJson(SHOPS_ENDPOINT);
-  if (shops.status !== "RECEIVED" || !Array.isArray(shops.payload)) {
-    console.log(
-      `CHIZHIK_D2 status=SHOPS_UNAVAILABLE shops_http_status=${shops.httpStatus} search_http_status=-1 root=unknown`,
-    );
-    return;
-  }
-
-  const store = shops.payload.find(
-    (row) =>
-      row &&
-      typeof row === "object" &&
-      row.status === 1 &&
-      typeof row.sap_id === "string" &&
-      SAP_ID_PATTERN.test(row.sap_id),
-  );
-  if (!store) {
-    console.log(
-      `CHIZHIK_D2 status=NO_VALID_STORE shops_http_status=${shops.httpStatus} search_http_status=-1 root=unknown`,
-    );
-    return;
-  }
-
-  const searchUrl = `${SEARCH_BASE}/${encodeURIComponent(store.sap_id)}/search?mode=store&include_restrict=true&q=${encodeURIComponent(QUERY)}&limit=${LIMIT}`;
-  const search = await requestJson(searchUrl);
-  if (search.status !== "RECEIVED") {
-    console.log(
-      `CHIZHIK_D2 status=${search.status} shops_http_status=${shops.httpStatus} search_http_status=${search.httpStatus} root=unknown`,
-    );
-    return;
-  }
-
-  visit(search.payload);
-  console.log(
-    `CHIZHIK_D2 status=PASS shops_http_status=${shops.httpStatus} search_http_status=${search.httpStatus} content_type=application/json root=${valueType(search.payload)}`,
-  );
-  console.log(`CHIZHIK_D2_SCHEMA=${JSON.stringify(schema)}`);
-})().catch(() => {
-  console.log("CHIZHIK_D2 status=PROBE_ERROR shops_http_status=-1 search_http_status=-1 root=unknown");
-});
+```text
+CHIZHIK_D2 status=PASS search_http_status=200 content_type=application/json root=object
+CHIZHIK_D2_SCHEMA=[...field names and types only...]
 ```
+
+Possible fail-closed statuses include:
+
+```text
+CHIZHIK_D2 status=WRONG_ORIGIN
+CHIZHIK_D2 status=STORES_UNAVAILABLE
+CHIZHIK_D2 status=MISSING_CONTEXT
+CHIZHIK_D2 status=SEARCH_UNAVAILABLE
+CHIZHIK_D2 status=PROBE_ERROR
+CHIZHIK_D2 status=UNAVAILABLE
+```
+
+`MISSING_CONTEXT` is not permission to pick the first active store manually. Continue using the official page until one real first-party delivery context is observed, then invoke the canary again.
 
 ## Evidence to retain
 
-Retain only the two lines whose prefixes are:
+Retain only lines beginning with:
 
 ```text
-CHIZHIK_D2 ...
-CHIZHIK_D2_SCHEMA=...
+CHIZHIK_D2 status=
+CHIZHIK_D2_SCHEMA=
 ```
 
-A transport PASS alone is not enough for offer production. The schema line must show unambiguous fields/types for the minimum `BrowserObservation` mapping:
+Do not paste screenshots of Network response bodies or raw DevTools objects into issues, PRs, chats or repository files.
 
-- store fulfillment context remains the already validated `sap_id` from D1;
-- SKU/product identifier;
+The schema evidence should establish candidate paths/types for at least:
+
+- product array/container;
+- stable product identifier;
 - product name;
-- price plus enough evidence to determine whether it is already minor units or requires conversion;
-- availability only if an explicit, understood field exists; otherwise ZakupGotov must use `UNKNOWN`.
+- candidate price field;
+- explicit availability field, if one exists.
 
-Promotion, loyalty, package and discount semantics remain unavailable unless separately evidenced.
+### Monetary unit remains a separate gate
+
+A field name and JSON number type do **not** prove whether a price is rubles, kopeks/minor units, or another scaled representation. The structural canary therefore does not authorize `priceMinor` mapping by itself.
+
+After the candidate price field is identified, #169 still requires independent sanitized evidence of its monetary unit/scale before any price mapping is implemented. Do not infer the unit from an integer-looking value or from a third-party implementation.
+
+If explicit availability semantics are not proven, availability must remain `UNKNOWN`. Promotion, loyalty, package and discount semantics remain unavailable until separately evidenced.
+
+## Test evidence in #177
+
+The draft implementation is regression-protected so that:
+
+- no D2 search occurs before the explicit user click;
+- exactly one search occurs after invocation;
+- valid, unknown, foreign and conflicting store contexts follow the accepted #173 fail-closed rule;
+- successful evidence includes only schema field names/types and sanitized HTTP metadata;
+- sentinel store/product/SKU/price/promotion/request values are absent from rendered evidence;
+- production and E2E manifests keep `permissions: ["storage"]` with no host-permission widening;
+- real persistent-Chromium extension E2E exercises the popup → active Chizhik tab → content-script canary path.
 
 ## Next gate
 
-After sanitized browser evidence is accepted:
+After real ordinary-user-browser evidence is supplied and accepted:
 
-1. freeze a minimal fixture containing only the evidenced fields;
-2. add a failing adapter test for exact `BrowserObservation` mapping;
-3. implement the minimum mapping;
-4. add Chromium E2E for search success, malformed JSON/schema, blocked transport and unknown-field non-persistence;
-5. keep technical feasibility separate from production/right-to-operate approval.
+1. identify the minimum evidenced product container/identifier/name/price fields;
+2. establish monetary unit/scale independently;
+3. freeze a minimal sanitized fixture containing only accepted fields and semantics;
+4. add RED tests for exact `BrowserObservation` mapping;
+5. implement only the evidenced mapping;
+6. keep unknown availability as `UNKNOWN` and do not invent promotion/package/loyalty semantics;
+7. keep technical feasibility separate from production/right-to-operate approval.

--- a/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
+++ b/docs/integrations/chizhik-d2-delivery-search-canary-2026-08-18.md
@@ -37,10 +37,13 @@ The implementation in #177:
 - requires exactly one distinct browser-evidenced store that is present in the validated directory;
 - fails closed on missing, foreign-origin, unknown or conflicting context;
 - issues exactly one fixed `кола`, `limit=1` D2 search per user invocation;
-- retains only HTTP status, base content type, root type and bounded field-name/type structure;
-- filters object keys to ASCII identifier-like names and bounds schema depth/node count;
+- retains only HTTP status, base content type, root type and bounded candidate-field/type structure;
+- reports only the fixed candidate keys already recorded in the external schema hypothesis: `products`, `plu`, `name`, `prices`, `regular`, `is_available`, `stock_limit`, `uom`, `property_clarification`;
+- ignores every other object key instead of attempting generic schema discovery, preventing dynamic IDs or unrelated payload keys from entering evidence;
 - never emits raw response bodies, store IDs, addresses, coordinates, product names, SKU values, numeric price values, promotion values, request IDs, cookies, headers or credentials;
 - leaves automatic D2 search and `BrowserObservation` / `ObservedOffer` production disabled.
+
+This fixed allowlist means the canary may report that an expected candidate is absent, but it will not reveal arbitrary replacement field names if the live schema changed. That is intentional privacy-first behavior; expanding the allowlist requires a separate reviewed hypothesis update rather than dumping raw schema.
 
 ## Running the canary
 
@@ -56,7 +59,7 @@ Expected successful shape:
 
 ```text
 CHIZHIK_D2 status=PASS search_http_status=200 content_type=application/json root=object
-CHIZHIK_D2_SCHEMA=[...field names and types only...]
+CHIZHIK_D2_SCHEMA=[...approved candidate field names and types only...]
 ```
 
 Possible fail-closed statuses include:
@@ -83,17 +86,23 @@ CHIZHIK_D2_SCHEMA=
 
 Do not paste screenshots of Network response bodies or raw DevTools objects into issues, PRs, chats or repository files.
 
-The schema evidence should establish candidate paths/types for at least:
+The accepted external hypothesis currently expects the canary to confirm or reject these minimum paths/types:
 
-- product array/container;
-- stable product identifier;
-- product name;
-- candidate price field;
-- explicit availability field, if one exists.
+```text
+$.products -> array
+$.products[] -> object
+$.products[].plu -> number/integer
+$.products[].name -> string
+$.products[].prices -> object
+$.products[].prices.regular -> string/number
+$.products[].is_available -> boolean
+```
+
+`stock_limit`, `uom` and `property_clarification` may also be reported as structural hints, but they do not become accepted stock/package semantics from this canary alone.
 
 ### Monetary unit remains a separate gate
 
-A field name and JSON number type do **not** prove whether a price is rubles, kopeks/minor units, or another scaled representation. The structural canary therefore does not authorize `priceMinor` mapping by itself.
+A field name and JSON number/string type do **not** prove whether a price is rubles, kopeks/minor units, or another scaled representation. The structural canary therefore does not authorize `priceMinor` mapping by itself.
 
 After the candidate price field is identified, #169 still requires independent sanitized evidence of its monetary unit/scale before any price mapping is implemented. Do not infer the unit from an integer-looking value or from a third-party implementation.
 
@@ -106,7 +115,8 @@ The draft implementation is regression-protected so that:
 - no D2 search occurs before the explicit user click;
 - exactly one search occurs after invocation;
 - valid, unknown, foreign and conflicting store contexts follow the accepted #173 fail-closed rule;
-- successful evidence includes only schema field names/types and sanitized HTTP metadata;
+- successful evidence includes only the fixed candidate-field allowlist plus sanitized HTTP metadata;
+- identifier-like dynamic keys and unrelated fields such as request IDs, promotion and discount keys are omitted from evidence;
 - sentinel store/product/SKU/price/promotion/request values are absent from rendered evidence;
 - production and E2E manifests keep `permissions: ["storage"]` with no host-permission widening;
 - real persistent-Chromium extension E2E exercises the popup → active Chizhik tab → content-script canary path.
@@ -115,7 +125,7 @@ The draft implementation is regression-protected so that:
 
 After real ordinary-user-browser evidence is supplied and accepted:
 
-1. identify the minimum evidenced product container/identifier/name/price fields;
+1. confirm the minimum evidenced product container/identifier/name/price candidate fields;
 2. establish monetary unit/scale independently;
 3. freeze a minimal sanitized fixture containing only accepted fields and semantics;
 4. add RED tests for exact `BrowserObservation` mapping;


### PR DESCRIPTION
Implements the next #169 evidence-enablement slice for a user-invoked, sanitized Chizhik D2 schema canary.

## What this adds
- an explicit user-invoked toolbar popup for the Chizhik D2 schema canary;
- no extension permission widening: production/E2E manifests remain `permissions: ["storage"]` with no `host_permissions`;
- one shared store-context resolver implementing the accepted #173 rule: exact first-party delivery resource observed in the current browser session ∩ validated `/api/v1/shops/` directory, with exactly one distinct context required;
- exactly one fixed D2 search per explicit invocation: query `кола`, `limit=1`;
- successful transport metadata limited to HTTP status and content type plus the still-opaque JSON payload internally;
- bounded schema confirmation for a fixed candidate-field allowlist: `products`, `plu`, `name`, `prices`, `regular`, `is_available`, `stock_limit`, `uom`, `property_clarification`;
- every other JSON object key is ignored instead of being generically enumerated, reducing value-as-key/privacy leakage risk;
- sanitized evidence output through the popup;
- real persistent-Chromium extension E2E for popup → active Chizhik tab → content-script canary;
- corrected canary documentation removing the obsolete “first active store” procedure.

## Privacy / correctness boundaries
- no automatic D2 search before the user clicks the canary button;
- no raw response body, store id/address/coordinates, SKU value, product name, numeric price value, promotion value, request id, cookie, header or credential is emitted by the canary;
- identifier-like dynamic keys and unrelated fields are excluded because only the reviewed candidate-field allowlist may appear in evidence;
- missing, foreign-origin, unknown-store and conflicting store context fail closed;
- automatic `BrowserObservation` / `ObservedOffer` production remains disabled;
- structural field/type evidence does **not** establish monetary unit/scale. `priceMinor` mapping remains blocked until #169 receives separate sanitized evidence proving the price unit/scale;
- availability remains `UNKNOWN` unless an explicit understood source semantic is separately accepted;
- promotion/loyalty/package/discount semantics are not inferred.

## TDD evidence
1. **RED:** canary tests failed only because `chizhik-schema-canary` did not exist; existing bridge tests passed. **GREEN:** bounded sanitized runner implemented.
2. **RED:** real `searchStore()` lacked sanitized HTTP metadata. **GREEN:** successful result now retains only `httpStatus` + `contentType` alongside opaque payload; URL/credentials/timeout remain unchanged.
3. **RED:** canary message contract module absent. **GREEN:** exact request/result protocol and sanitized PASS format implemented.
4. **RED:** popup contract failed only because `manifest.action` and popup packaging were absent; existing tests passed. **GREEN:** toolbar popup added without permission widening.
5. **RED:** real persistent-Chromium popup E2E returned `UNAVAILABLE` because the content script had no listener; all previous Chromium E2E passed. **GREEN:** exact-message listener added; persistent-Chromium canary path passes with zero search requests before click and exactly one after click.
6. Refactor: adapter and canary now share one evidenced-store resolver so the accepted #173 security rule cannot drift between paths.
7. **Privacy RED from review:** generic field-name enumeration exposed unrelated/dynamic-looking keys (`requestId`, `secretSkuValue`, `sku123`, promotion/discount). **GREEN:** schema evidence is restricted to the fixed reviewed candidate-field allowlist; unit/type/build and real persistent-Chromium E2E all pass under the stricter policy.

## Exact-head verification
The feature branch was refreshed after automated acceptance of `v0.1.0-rc.7` by merging accepted `main=b754f5193f852db0312011f3f6c3ec6c7dd22eb2` into the previous exact feature head without force-push or history rewriting.

Current exact head: `e0b7cc39e654bd77e07f447564d8f57822d5909d`.

The merge base is exactly the accepted `main` SHA and the diff against `main` remains the intended 19 Chizhik canary files.

Fresh exact-head CI is **9/9 SUCCESS**:
- API CI;
- Web CI, including responsive browser E2E;
- Contract CI;
- Release Contract CI;
- Release Bundle CI;
- Retailer Bridge CI, including real persistent-Chromium extension E2E;
- Container Security CI;
- Dependency Review;
- CodeQL.

Final security/privacy review found no remaining P0/P1/P2 issue and no unresolved review threads. The PR is ready to merge.

## Release state
`v0.1.0-rc.7` is automated-release accepted. The previous release freeze on this feature branch is lifted. Stable `v0.1.0` remains separately gated by the manual product canary and is not implied by merging this PR.

## Acceptance still external to this PR
A real ordinary-user-browser run must still provide sanitized candidate-schema evidence. Even a structural PASS is not sufficient for price mapping until monetary unit/scale is independently evidenced and accepted in #169.