### PR TITLE
fix(release): recover web security gate for rc.6

### DIFF
--- a/.github/workflows/container-security-ci.yml
+++ b/.github/workflows/container-security-ci.yml
@@ -64,6 +64,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_VEX: security/vex/CVE-2026-14456.openvex.json
+          TRIVY_SHOW_SUPPRESSED: "true"
         with:
           image-ref: ${{ matrix.image }}
           format: table

--- a/.github/workflows/container-security-ci.yml
+++ b/.github/workflows/container-security-ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Verify web VEX runtime assumptions
         if: matrix.name == 'Web'
-        run: bash scripts/security/verify_web_vex_runtime.sh "${{ matrix.image }}" linux/amd64
+        run: bash scripts/security/verify_web_vex_runtime.sh "${{ matrix.image }}" linux/amd64 local
 
       - name: Scan API HIGH/CRITICAL vulnerabilities
         if: matrix.name == 'API'

--- a/.github/workflows/container-security-ci.yml
+++ b/.github/workflows/container-security-ci.yml
@@ -41,8 +41,29 @@ jobs:
             --tag "${{ matrix.image }}" \
             .
 
-      - name: Scan HIGH/CRITICAL vulnerabilities
+      - name: Validate web VEX contract
+        if: matrix.name == 'Web'
+        run: python3 scripts/security/validate_web_vex.py
+
+      - name: Verify web VEX runtime assumptions
+        if: matrix.name == 'Web'
+        run: bash scripts/security/verify_web_vex_runtime.sh "${{ matrix.image }}" linux/amd64
+
+      - name: Scan API HIGH/CRITICAL vulnerabilities
+        if: matrix.name == 'API'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          scanners: vuln
+
+      - name: Scan Web HIGH/CRITICAL vulnerabilities with reviewed VEX
+        if: matrix.name == 'Web'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_VEX: security/vex/CVE-2026-14456.openvex.json
         with:
           image-ref: ${{ matrix.image }}
           format: table

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: ./scripts/verify.sh
 
       - name: Install Chromium
-        run: pnpm --filter web exec playwright install --with-deps chromium
+        run: bash scripts/ci/install-playwright-chromium.sh pnpm --filter web exec playwright install --with-deps chromium
 
       - name: Build shared API client
         run: pnpm --filter @zakup-gotov/api-client build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,10 @@ jobs:
             image=moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
 
       - name: Prepare release evidence directory
-        run: mkdir -p dist
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp security/vex/CVE-2026-14456.openvex.json dist/web-CVE-2026-14456.openvex.json
 
       - name: Build and push API candidate
         id: api-build
@@ -175,6 +178,21 @@ jobs:
           cache-from: type=gha,scope=release-web
           cache-to: type=gha,mode=max,scope=release-web
 
+      - name: Validate web VEX contract
+        run: python3 scripts/security/validate_web_vex.py
+
+      - name: Verify web VEX runtime assumptions on amd64
+        run: |
+          bash scripts/security/verify_web_vex_runtime.sh \
+            "${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}" \
+            linux/amd64
+
+      - name: Verify web VEX runtime assumptions on arm64
+        run: |
+          bash scripts/security/verify_web_vex_runtime.sh \
+            "${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}" \
+            linux/arm64
+
       - name: Scan API candidate for HIGH/CRITICAL vulnerabilities on amd64
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
@@ -209,6 +227,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/amd64
+          TRIVY_VEX: security/vex/CVE-2026-14456.openvex.json
         with:
           image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: json
@@ -223,6 +242,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_PLATFORM: linux/arm64
+          TRIVY_VEX: security/vex/CVE-2026-14456.openvex.json
         with:
           image-ref: ${{ steps.release.outputs.web_staging_image }}@${{ steps.web-build.outputs.digest }}
           format: json
@@ -230,6 +250,20 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           scanners: vuln
+
+      - name: Report vulnerability gate failure evidence
+        if: failure()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(dist/*-vulnerabilities.json)
+          if (( ${#reports[@]} == 0 )); then
+            echo "No Trivy JSON report was created before the failure."
+            exit 0
+          fi
+          for report in "${reports[@]}"; do
+            python3 scripts/security/report_trivy_json.py "${report}"
+          done
 
       - name: Generate API amd64 SPDX SBOM
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -407,6 +441,7 @@ jobs:
             dist/web-manifest.json \
             dist/*-vulnerabilities.json \
             dist/*-sbom.spdx.json \
+            dist/*.openvex.json \
             > dist/SHA256SUMS
 
       - name: Attach verified release assets
@@ -422,4 +457,5 @@ jobs:
             dist/web-manifest.json \
             dist/*-vulnerabilities.json \
             dist/*-sbom.spdx.json \
+            dist/*.openvex.json \
             --clobber

--- a/.github/workflows/retailer-bridge-ci.yml
+++ b/.github/workflows/retailer-bridge-ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm --dir apps/retailer-bridge build
 
       - name: Install Playwright Chromium
-        run: pnpm --dir apps/retailer-bridge exec playwright install --with-deps chromium
+        run: bash scripts/ci/install-playwright-chromium.sh pnpm --dir apps/retailer-bridge exec playwright install --with-deps chromium
 
       - name: Run bridge Chromium E2E
         run: pnpm --dir apps/retailer-bridge test:e2e

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm --filter web build
 
       - name: Install Chromium
-        run: pnpm --filter web exec playwright install --with-deps chromium
+        run: bash scripts/ci/install-playwright-chromium.sh pnpm --filter web exec playwright install --with-deps chromium
 
       - name: Run responsive browser tests
         run: pnpm --filter web test:e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,30 +38,59 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; this 
 - D1 is **COMPLETE / ACCEPTED**: the normal user-browser MV3 Retailer Bridge is the selected acquisition architecture.
 - D2 transport foundation (#169/#171) adds exact bounded store-scoped delivery search while keeping successful JSON opaque and automatic search/offer production disabled.
 - D2 store-context binding (#173/#174) accepts only exactly one first-party browser-evidenced store intersecting the validated directory; missing/foreign/unknown/conflicting context fails closed.
-- Draft PR #177 implements an explicit user-invoked privacy-hardened schema canary with no permission widening, fixed candidate-field allowlist and persistent-Chromium E2E; exact head `c38173f3b15b66fa892534989e1aa2f51d98468d` passed 9/9 PR workflow groups.
+- Draft PR #177 implements an explicit user-invoked privacy-hardened schema canary with no permission widening, fixed candidate-field allowlist and persistent-Chromium E2E; it remains frozen until release recovery completes.
 - Chizhik offer mapping remains blocked on ordinary-user-browser product-schema evidence plus independent monetary-unit/scale evidence. Unknown availability remains `UNKNOWN`.
+
+#### Release security recovery
+
+- Added a machine-readable OpenVEX assessment for exactly `CVE-2026-14456` on `pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2` with `not_affected / vulnerable_code_not_in_execute_path`.
+- Added a VEX contract validator that fails if the reviewed statement is widened to another CVE, package or version.
+- Added a final-image runtime guard that fails if web enables `--experimental-quic` or if runtime Node/native addons dynamically link system `libssl`/`libcrypto`.
+- Added durable release failure diagnostics that summarize already-created Trivy JSON findings into the Actions log when a fail-closed scan stops publication before release assets can be attached.
+- Successful releases now include the exact OpenVEX document in release assets and `SHA256SUMS`.
 
 ### Changed
 
-- Current deterministic product phase is **M5 Productization**; M5.1 is complete/accepted and M5.2 remains intentionally unselected until release/manual-use evidence identifies the next constraint.
-- `v0.1.0-rc.4` is now historical **failed release-contract evidence**, not the next operational target.
-- The next operational release gate is **`v0.1.0-rc.5`**, tracked by #152.
+- Current deterministic product phase remains **M5 Productization**; M5.2 remains intentionally unselected until release/manual-use evidence identifies the next constraint.
+- `v0.1.0-rc.5` is historical **failed release-contract evidence**, not an accepted prerelease.
+- The next operational release gate is **`v0.1.0-rc.6`**, tracked by #152 with recovery PR #179.
+- Web Container Security CI applies VEX only after its exact contract and final-image reachability assumptions pass; API scans remain completely unfiltered.
+- Release CI applies the same web VEX only after independent amd64 and arm64 runtime guards.
 - Stable `v0.1.0` remains blocked until a prerelease completes the immutable release workflow and manual product canary satisfactorily.
-- Technical retailer accessibility and production/right-to-operate readiness remain independent facts.
 
 ### Fixed
 
-- Release planning no longer attempts to reuse an already-published prerelease tag for newer source.
-- `v0.1.0-rc.4` exposed an operator metadata defect: a SemVer prerelease tag was published with GitHub `prerelease=false`. The release contract rejected the mismatch before any write-capable publication work.
-- Canonical release planning now requires explicit pre-release-checkbox verification before publishing `v0.1.0-rc.5`.
+- Release planning does not reuse published prerelease tags for newer source.
+- `v0.1.0-rc.4` metadata mismatch remains recorded as a failed historical candidate rather than being retroactively accepted.
+- `v0.1.0-rc.5` exposed a real web image security-gate blocker; recovery now distinguishes package inventory from reachable vulnerable code through evidence-backed VEX rather than weakening Trivy severity.
+- Failed release Trivy JSON evidence is no longer silently lost with the ephemeral runner.
 - Chizhik store context can no longer be guessed from the first active store; exactly one browser-evidenced validated context is required.
 
 ### Security
 
+- Trivy `CRITICAL,HIGH` and `exit-code=1` remain unchanged for all unsuppressed findings.
+- The rc.5 web finding was reproduced outside the release workflow as `libssl3t64 3.5.6-1~deb13u2 / CVE-2026-14456 / HIGH / fix_deferred` with zero Node-package findings.
+- The production Node process does not enable experimental QUIC, and the final image guard proves Node plus native addons do not dynamically link system `libssl`/`libcrypto` before VEX is accepted.
+- Full Node Debian 12 runtime was rejected after fresh Trivy found 29 HIGH/CRITICAL findings; Distroless Debian 12 was rejected after seven HIGH/CRITICAL OpenSSL findings. The project does not trade one non-reachable inherited finding for a broader actionable surface.
+- Normal web CI shows suppressed findings for auditability; a future package-version change is not silently covered because the VEX PURL is exact-version scoped.
 - Precise addresses, credentials, provider tokens, private headers and raw sensitive provider payloads remain excluded from ordinary evidence/logging.
-- Chizhik connectivity adds no anti-bot bypass, stealth, proxy rotation, credential extraction or private-client impersonation.
-- Release vulnerability policy remains fail-closed at `HIGH,CRITICAL`; no ignore/suppression behavior is added to make releases pass.
 - Published release tags, including failed candidates, are immutable historical evidence and are never repointed.
+
+## [0.1.0-rc.5] — 2026-08-19 — FAILED WEB SECURITY GATE
+
+Source:
+
+```text
+a485c80dc1eb36122791c629f92b247354b0ee09
+```
+
+- GitHub prerelease metadata and immutable tag/source were correct.
+- Release run `32224834303` attempt 1 timed out during external Ubuntu package retrieval while installing Chromium dependencies after repository verification had passed.
+- Exact immutable Verify was rerun; attempt 2 passed metadata, ancestry, repository verification, browser E2E and production release-bundle verification.
+- Publish built API and web staging indexes for `linux/amd64` + `linux/arm64` and passed API amd64/arm64 Trivy gates.
+- Web amd64 then failed closed on `CVE-2026-14456` in inherited `libssl3t64 3.5.6-1~deb13u2`.
+- No final `0.1.0-rc.5` OCI promotion, OCI `latest` mutation, final smoke, provenance or release evidence assets occurred.
+- Full record: `docs/v0.1.0-rc.5-release-failure-2026-08-19.md`.
 
 ## [0.1.0-rc.4] — 2026-08-18 — FAILED RELEASE METADATA CONTRACT
 
@@ -72,11 +101,8 @@ Source:
 ```
 
 - Tag/source selection was correct and immutable.
-- Release workflow run `32136955056` failed at `Release / Verify → Validate release metadata`.
-- GitHub supplied `prerelease=false` for SemVer prerelease tag `v0.1.0-rc.4`; `release_contract.py` correctly rejected the mismatch.
-- Every later verify step was skipped and `Release / Publish` never started.
-- Therefore rc.4 produced no new GHCR promotion, OCI `latest` mutation, release SBOM, provenance attestation, staging/final exact-digest release smoke or release evidence assets.
-- GitHub temporarily treated rc.4 as `Latest release` because the release object was published as non-prerelease; presentation metadata should be corrected without moving/deleting the tag.
+- Release workflow run `32136955056` failed at `Release / Verify → Validate release metadata` because GitHub supplied `prerelease=false` for the SemVer prerelease.
+- `Release / Publish` never started, so there was no final package/evidence/latest side effect.
 - Full record: `docs/v0.1.0-rc.4-release-failure-2026-08-18.md`.
 
 ## [0.1.0-rc.3] — historical prerelease

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable project changes are recorded here. Zakup Gotov is pre-release; this 
 - `v0.1.0-rc.4` metadata mismatch remains recorded as a failed historical candidate rather than being retroactively accepted.
 - `v0.1.0-rc.5` exposed a real web image security-gate blocker; recovery now distinguishes package inventory from reachable vulnerable code through evidence-backed VEX rather than weakening Trivy severity.
 - Failed release Trivy JSON evidence is no longer silently lost with the ephemeral runner.
+- Playwright Chromium installation in Web CI, Retailer Bridge CI and Release Verify now uses bounded APT retries/timeouts plus a descendant-safe Linux process supervisor, preventing timed-out privileged package-manager children from leaking into a same-run retry and holding `dpkg` locks.
 - Chizhik store context can no longer be guessed from the first active store; exactly one browser-evidenced validated context is required.
 
 ### Security
@@ -100,31 +101,49 @@ Source:
 8a269288addcb4aa8ea3d0ce46608b650cbdb6dc
 ```
 
-- Tag/source selection was correct and immutable.
-- Release workflow run `32136955056` failed at `Release / Verify → Validate release metadata` because GitHub supplied `prerelease=false` for the SemVer prerelease.
-- `Release / Publish` never started, so there was no final package/evidence/latest side effect.
+- GitHub Release was published with `prerelease=false` even though the tag is a SemVer prerelease.
+- `Release / Verify` failed closed at the metadata contract before repository verification, browser E2E or production-bundle verification.
+- `Release / Publish` never started, so rc.4 created no new GHCR promotion, Trivy/SBOM/provenance/final-smoke evidence and did not mutate OCI `latest`.
+- The immutable rc.4 tag remains historical failed release evidence; its GitHub presentation can be corrected without reusing or moving the tag.
 - Full record: `docs/v0.1.0-rc.4-release-failure-2026-08-18.md`.
 
-## [0.1.0-rc.3] — historical prerelease
+## [0.1.0-rc.3] — 2026-08-18 — AUTOMATED RELEASE CONTRACT ACCEPTED
 
-- Immutable source: `d988b8c596a737326aeac67f74b6f65a6aaed3bf`.
-- Later accepted connectivity/documentation changes belong to later prereleases rather than a rewritten rc.3.
+Source:
 
-## [0.1.0-rc.2] — 2026-08-09
+```text
+d988b8c596a737326aeac67f74b6f65a6aaed3bf
+```
 
-- `Release / Verify` completed and `Release / Publish` reached multi-platform staging publication.
-- The release correctly failed closed at the first real Trivy gate on pgJDBC `42.7.11` / `CVE-2026-54291` (`HIGH`, fixed in `42.7.12`).
-- Subsequent mainline work upgraded pgJDBC, moved the web final runtime to distroless Node 24 Debian 13/non-root and added ordinary Container Security CI.
+- `Release / Verify` and `Release / Publish` completed successfully.
+- API/web multi-platform images were published for `linux/amd64` + `linux/arm64`.
+- HIGH/CRITICAL Trivy gates passed.
+- Per-architecture SPDX SBOMs were produced.
+- Staging and final exact-digest Compose smoke tests passed.
+- Verified digests were copied/promoted without rebuild and digest identity was preserved.
+- API/web provenance attestations were created.
+- `0.1.0-rc.3` was promoted while OCI `latest` remained untouched.
+- Release verification metadata, checksums, manifests, vulnerability reports and SBOMs were attached to the GitHub Release.
+- Automated release contract accepted; separate manual product canary remained the product-acceptance gate.
 
-## [0.1.0-rc.1] — 2026-08-09
+## [0.1.0-rc.2] — 2026-08-17 — FAILED RELEASE CONTRACT
 
-- First real GitHub prerelease event proved metadata/main-ancestry validation, source verification and production browser testing.
-- It exposed executable-mode defects in release helper scripts; those modes were fixed before rc.2.
+Source:
 
-## Pre-release foundation — 2026-08-09 to 2026-08-11
+```text
+19e6080cff464de9701e2f38ff6f06959037971a
+```
 
-- Java 25 / Spring Boot 4.1 API foundation with PostgreSQL 18, Flyway, jOOQ and Testcontainers.
-- Contract-first OpenAPI 3.1 API plus generated TypeScript client.
-- Next.js 16 / React 19 responsive web foundation with Vitest and Playwright.
-- Reproducible verification, Docker/Compose release topology, CodeQL, Dependency Review, Container Security, Release Contract and Release Bundle CI.
-- Evidence-driven retailer feasibility research for X5, Magnit, Chizhik, Ozon Fresh, Samokat, Kuper, Lenta and VkusVill.
+- Release verification failed because the tag did not point to the required exact source after main moved.
+- No release publication/promotion was accepted from this candidate.
+
+## [0.1.0-rc.1] — 2026-08-17 — FAILED RELEASE CONTRACT
+
+Source:
+
+```text
+69a4566963ef99fd5204e1f0bc924f6ab242e6f7
+```
+
+- Initial release candidate exposed release-contract and publication-path defects.
+- Candidate remains immutable historical evidence and is not reused.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,7 +18,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter @zakup-gotov/api-client build \
     && pnpm --filter web build
 
-FROM node:24.19.0-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runtime
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runtime
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
@@ -27,14 +27,13 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-COPY --from=build --chown=node:node /workspace/apps/web/.next/standalone ./
-COPY --from=build --chown=node:node /workspace/apps/web/.next/static /app/apps/web/.next/static
+COPY --from=build --chown=65532:65532 /workspace/apps/web/.next/standalone ./
+COPY --from=build --chown=65532:65532 /workspace/apps/web/.next/static /app/apps/web/.next/static
 
-USER node
+USER 65532
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=10 \
-  CMD ["/usr/local/bin/node", "-e", "fetch('http://127.0.0.1:3000/').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:3000/').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
 
-ENTRYPOINT ["/usr/local/bin/node"]
 CMD ["apps/web/server.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,7 +18,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter @zakup-gotov/api-client build \
     && pnpm --filter web build
 
-FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
+FROM node:24.19.0-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runtime
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
@@ -27,13 +27,14 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-COPY --from=build --chown=65532:65532 /workspace/apps/web/.next/standalone ./
-COPY --from=build --chown=65532:65532 /workspace/apps/web/.next/static /app/apps/web/.next/static
+COPY --from=build --chown=node:node /workspace/apps/web/.next/standalone ./
+COPY --from=build --chown=node:node /workspace/apps/web/.next/static /app/apps/web/.next/static
 
-USER 65532
+USER node
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=10 \
-  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:3000/').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+  CMD ["/usr/local/bin/node", "-e", "fetch('http://127.0.0.1:3000/').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
 
+ENTRYPOINT ["/usr/local/bin/node"]
 CMD ["apps/web/server.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,7 +2,6 @@ FROM node:24.18.1-bookworm-slim AS dependencies
 
 WORKDIR /workspace
 RUN npm install --global pnpm@11.4.0
-RUN echo "=== Node dynamic dependencies ===" && ldd /usr/local/bin/node
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
@@ -17,9 +16,7 @@ COPY openapi openapi
 
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter @zakup-gotov/api-client build \
-    && pnpm --filter web build \
-    && echo "=== Native addon dynamic dependencies ===" \
-    && find apps/web/.next/standalone -type f -name '*.node' -print -exec ldd {} \;
+    && pnpm --filter web build
 
 FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,6 +2,7 @@ FROM node:24.18.1-bookworm-slim AS dependencies
 
 WORKDIR /workspace
 RUN npm install --global pnpm@11.4.0
+RUN echo "=== Node dynamic dependencies ===" && ldd /usr/local/bin/node
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
@@ -16,9 +17,11 @@ COPY openapi openapi
 
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter @zakup-gotov/api-client build \
-    && pnpm --filter web build
+    && pnpm --filter web build \
+    && echo "=== Native addon dynamic dependencies ===" \
+    && find apps/web/.next/standalone -type f -name '*.node' -print -exec ldd {} \;
 
-FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runtime
+FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-18
+Updated: 2026-08-19
 
 ## Project
 
@@ -9,7 +9,7 @@ Updated: 2026-08-18
 Repository: `True-Ruslan/zakup-gotov`  
 Visibility: Public  
 Current product phase: **M5 — Productization**  
-Immediate operational target: **`v0.1.0-rc.5` end-to-end release validation**
+Immediate operational target: **recover the release security gate and validate `v0.1.0-rc.6` end to end**
 
 The product/core and retailer-connectivity tracks remain independent. Technical retailer reachability is not production approval, and merged transport code is not automatically an accepted offer provider.
 
@@ -27,6 +27,7 @@ The product/core and retailer-connectivity tracks remain independent. Technical 
 - Chizhik D2 fixed store-scoped search transport — **IMPLEMENTED / MERGED, OFFER MAPPING DISABLED** (#169/#171);
 - Chizhik D2 browser-evidenced store-context binding — **COMPLETE / ACCEPTED** (#173/#174);
 - Chizhik D2 user-invoked schema-canary implementation — **IMPLEMENTED / DRAFT, NOT MERGED** (#177);
+- release recovery after rc.5 web security-gate failure — **IN PROGRESS** (#179);
 - M5.2 — **INTENTIONALLY UNSELECTED** until release/manual-use evidence identifies the next productization constraint.
 
 ## Accepted product/core baseline
@@ -55,7 +56,7 @@ D2 transport (#171) is merged but successful JSON remains opaque to production. 
 
 Issue #169 remains open for ordinary-user-browser schema and monetary-unit evidence before any `BrowserObservation` / `ObservedOffer` mapping. Availability remains `UNKNOWN` unless explicit semantics are proven.
 
-Draft PR #177 implements a user-invoked privacy-hardened schema canary. Exact head `c38173f3b15b66fa892534989e1aa2f51d98468d` passed 9/9 PR workflow groups, including persistent-Chromium E2E, but remains unmerged until the current release-target sequence permits it.
+Draft PR #177 implements a user-invoked privacy-hardened schema canary. Exact head `c38173f3b15b66fa892534989e1aa2f51d98468d` passed 9/9 PR workflow groups on its previous baseline, but remains unmerged while release recovery is active. After rc.6 acceptance it must be refreshed against current `main` and reverified before merge.
 
 ## Release history and current gate
 
@@ -77,36 +78,81 @@ Immutable source:
 8a269288addcb4aa8ea3d0ce46608b650cbdb6dc
 ```
 
-Release workflow run `32136955056` failed in `Release / Verify` at `Validate release metadata` because GitHub published the SemVer prerelease tag with `prerelease=false`.
+Release run `32136955056` failed at `Release / Verify → Validate release metadata` because GitHub supplied `prerelease=false` for a SemVer prerelease tag. `Release / Publish` never started, so there was no GHCR promotion, OCI `latest` mutation, release SBOM/attestation or release smoke/evidence publication.
 
-The contract raised:
-
-```text
-ValueError: GitHub prerelease flag must match the SemVer prerelease state
-```
-
-All later verify work was skipped and `Release / Publish` never started. Therefore rc.4 produced no new GHCR publication/promotion, no OCI `latest` mutation, no release SBOM/attestation/evidence assets and no staging/final release smoke evidence.
-
-GitHub temporarily treats rc.4 as `Latest release` because the release object was published as non-prerelease. Its presentation metadata should be corrected to `prerelease=true`, but the tag must remain immutable and rc.4 remains a **failed** release-contract attempt.
+The historical GitHub release presentation still reports `prerelease=false`; this UI metadata should be corrected without moving/deleting the tag. rc.4 remains failed historical evidence regardless.
 
 Failure record: [`v0.1.0-rc.4-release-failure-2026-08-18.md`](v0.1.0-rc.4-release-failure-2026-08-18.md).
 
-### `v0.1.0-rc.5` — NEXT OPERATIONAL TARGET
+### `v0.1.0-rc.5` — FAILED CLOSED AT WEB SECURITY GATE
 
-Issue: #152.
+Immutable source:
+
+```text
+a485c80dc1eb36122791c629f92b247354b0ee09
+```
+
+Release workflow `32224834303` had two Verify attempts. The first reached repository verification and then timed out while Ubuntu package mirrors stalled during Playwright Chromium dependency installation. The exact immutable Verify job was rerun; attempt 2 completed metadata, ancestry, repository verification, browser E2E and production release-bundle verification successfully.
+
+`Release / Publish` then built API and web staging indexes for `linux/amd64` + `linux/arm64`; both API HIGH/CRITICAL Trivy gates passed. The web amd64 gate failed closed on the exact staging digest:
+
+```text
+ghcr.io/true-ruslan/zakup-gotov-staging-web@sha256:8483c5e5a17d9208964230f715b312475b780cb001d7aafe684eea0f6a0fd171
+```
+
+Fresh ordinary Container Security CI reproduced the finding on the unchanged production image:
+
+```text
+package: libssl3t64
+version: 3.5.6-1~deb13u2
+CVE: CVE-2026-14456
+severity: HIGH
+status: fix_deferred
+```
+
+No Node/application package vulnerability was reported. Because the web gate failed, all downstream SBOM completion, staging/final exact-digest smoke, digest-preserving final copy, provenance, `0.1.0-rc.5` OCI promotion, `latest`, manifests/checksums and release assets were skipped. The release contract therefore failed closed correctly.
+
+Failure record: [`v0.1.0-rc.5-release-failure-2026-08-19.md`](v0.1.0-rc.5-release-failure-2026-08-19.md).
+
+### rc.5 security root cause and recovery
+
+CVE-2026-14456 affects an OpenSSL QUIC server-listener path. The production web runtime does not enable Node experimental QUIC. A final-image guard now proves before scanning that:
+
+- final Entrypoint/Cmd does not contain `--experimental-quic`;
+- `/nodejs/bin/node` does not dynamically link system `libssl` or `libcrypto`;
+- no final native `*.node` addon dynamically links system `libssl` or `libcrypto`.
+
+Two base-image substitutions were tested and rejected: full Node Debian 12 expanded the runtime surface to 29 HIGH/CRITICAL findings; Distroless Debian 12 exposed seven HIGH/CRITICAL OpenSSL findings including a CRITICAL fixable issue.
+
+Recovery PR #179 therefore keeps the minimal Distroless Debian 13 runtime and adds a reviewed OpenVEX statement scoped only to:
+
+```text
+CVE-2026-14456
+pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2
+status: not_affected
+justification: vulnerable_code_not_in_execute_path
+```
+
+The VEX is guarded by an exact contract validator and final-image reachability checks. API scans receive no VEX. Web scans retain `CRITICAL,HIGH` and `exit-code=1` for every unsuppressed finding. Normal CI exposes suppressed findings for auditability; release CI guards both architectures, includes the VEX in checksummed release evidence, and prints concise Trivy JSON evidence to logs if a future security gate fails before assets can be attached.
+
+Security assessment: [`security/CVE-2026-14456-vex-assessment.md`](security/CVE-2026-14456-vex-assessment.md).
+
+### `v0.1.0-rc.6` — NEXT OPERATIONAL TARGET
+
+Issue: #152. Recovery implementation: #179.
 
 Required sequence:
 
-1. merge this canonical documentation correction through fresh exact-head CI/review;
-2. record the resulting exact `main` SHA in #152;
-3. verify all normal exact-main push workflow groups are SUCCESS;
-4. confirm `v0.1.0-rc.5` tag/release is absent immediately before publication;
-5. publish one GitHub prerelease targeting only the recorded exact SHA with **Set as a pre-release enabled**;
-6. require `Release / Verify` and `Release / Publish` to complete the existing immutable contract;
-7. inspect multi-arch staging, Trivy `HIGH,CRITICAL`, SPDX SBOM, exact-digest staging/final smoke, copy-without-rebuild promotion, provenance, manifests, evidence/checksums and package visibility;
-8. verify OCI `latest` remains untouched;
-9. run the manual product canary from immutable rc.5 artifacts;
-10. select M5.2 only from resulting evidence.
+1. complete #179 with canonical documentation and one final exact-head 9/9 PR CI pass;
+2. require Container Security/Web to prove VEX contract + final-image reachability and to show the exact suppressed finding while all other HIGH/CRITICAL findings remain fail-closed;
+3. merge #179 only after fresh review/CI;
+4. record the resulting exact `main` SHA and verify all normal exact-main push workflow groups;
+5. confirm `v0.1.0-rc.6` tag/release is absent immediately before publication;
+6. publish one GitHub prerelease targeting only that exact SHA with **Set as a pre-release enabled**;
+7. require `Release / Verify` and `Release / Publish` to complete end to end;
+8. inspect both architecture VEX guards, all four Trivy gates, SPDX SBOMs, staging/final exact-digest smoke, copy-without-rebuild digest identity, provenance, manifests, OpenVEX/checksums and package visibility;
+9. verify OCI `latest` remains untouched;
+10. run the manual product canary from immutable rc.6 artifacts.
 
 Stable `v0.1.0` remains blocked until a prerelease completes the full release workflow and manual acceptance is satisfactory.
 
@@ -122,6 +168,7 @@ Stable `v0.1.0` remains blocked until a prerelease completes the full release wo
 - Analytics abstraction, feature flags and provider-health monitoring remain possible M5.2 candidates, not preselected work.
 - Richer substitute/package optimization and multi-store split optimization are deferred.
 - Native mobile remains future M6 work.
+- rc.4 GitHub presentation metadata remains stale (`prerelease=false`).
 
 ## Permanent invariants
 
@@ -149,6 +196,7 @@ Stable `v0.1.0` remains blocked until a prerelease completes the full release wo
 22. No price mapping is accepted until the source field and monetary unit/scale are evidenced.
 23. Published release tags are immutable historical evidence and are never repointed, including failed release candidates.
 24. Release metadata must match SemVer prerelease state before any write-capable publication work.
+25. Security exceptions must be machine-readable, narrowly scoped, evidence-backed and fail closed when their runtime assumptions change.
 
 ## Platform baseline
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -16,19 +16,24 @@ Local bundle verification:
 
 ## Pre-release security gate
 
-`Container Security CI` runs in ordinary read-only CI and scans the exact production API/web images with unchanged Trivy `HIGH,CRITICAL` fail-closed policy. No `.trivyignore`, `ignore-unfixed`, VEX suppression or severity downgrade is used to make the gate green.
+`Container Security CI` scans the exact production API/web images with Trivy `HIGH,CRITICAL` + `exit-code=1`.
+
+API has no vulnerability suppression. Web has one machine-readable OpenVEX assessment for `CVE-2026-14456` scoped to the exact inherited package `pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2`. It is accepted only after final-image guards prove that experimental QUIC is disabled and runtime Node/native addons do not dynamically link system `libssl`/`libcrypto`. Every other HIGH/CRITICAL finding remains fail-closed.
+
+Normal web CI enables suppressed-result output so the assessed CVE remains visible. The release workflow repeats the runtime guard for both `linux/amd64` and `linux/arm64` before applying the same VEX.
+
+Assessment: [`security/CVE-2026-14456-vex-assessment.md`](security/CVE-2026-14456-vex-assessment.md).
 
 ## Versioned release contract
 
 `Release Contract CI` verifies without write permissions:
 
 - strict stable/prerelease SemVer tags;
-- consistency between SemVer prerelease state and the GitHub Release prerelease flag;
+- consistency between SemVer prerelease state and GitHub Release prerelease flag;
 - prereleases never publish OCI `latest`;
 - deterministic final/staging GHCR names and digest-pinned release Compose references;
-- executable release helper modes;
-- immutable Action pins and pinned QEMU/BuildKit helper images;
-- approved trust order: build → scan → staging smoke → final copy → final smoke → attestation → version promotion → optional stable `latest` → evidence upload.
+- immutable Action pins and pinned QEMU/BuildKit helpers;
+- approved trust order: build → guard/scan → staging smoke → final copy → final smoke → attestation → version promotion → optional stable `latest` → evidence upload.
 
 `.github/workflows/release.yml` triggers only for `release: published`.
 
@@ -42,110 +47,92 @@ Only after Verify succeeds does the write-capable job receive package/attestatio
 
 1. validate metadata and derive names;
 2. authenticate to GHCR;
-3. build/push API and web staging indexes for `linux/amd64` and `linux/arm64` with provenance/SBOM;
-4. scan every platform candidate for `HIGH`/`CRITICAL` vulnerabilities;
-5. produce SPDX JSON SBOM evidence;
-6. smoke-test exact staging digests;
-7. copy verified indexes **without rebuild** into final packages, preserving digest identity;
-8. smoke-test exact final-package digests;
-9. create provenance attestations;
-10. promote SemVer tags from the already verified digests without rebuild;
-11. move OCI `latest` only for stable releases;
-12. verify final manifest architectures;
-13. attach release evidence/checksums to the GitHub Release.
+3. build/push API and web staging indexes for `linux/amd64` and `linux/arm64`;
+4. validate the web VEX contract and final-image runtime assumptions on both architectures;
+5. scan every platform candidate for unsuppressed `HIGH`/`CRITICAL` vulnerabilities;
+6. produce SPDX JSON SBOM evidence;
+7. smoke-test exact staging digests;
+8. copy verified indexes **without rebuild** into final packages, preserving digest identity;
+9. smoke-test exact final-package digests;
+10. create provenance attestations;
+11. promote SemVer tags from already verified digests;
+12. move OCI `latest` only for stable releases;
+13. verify final manifest architectures;
+14. attach release evidence/checksums, including the exact OpenVEX document.
 
-Staging packages remain a private trust boundary. Final package visibility is a separate distribution decision.
+If a vulnerability scan fails, already-created Trivy JSON reports are summarized into the durable Actions log so root-cause evidence is not lost when downstream release-asset upload is skipped.
 
 ## Runtime validation history
 
 ### `v0.1.0-rc.1` — 2026-08-09
 
-The first real release event proved metadata/main-ancestry validation, complete repository verification and responsive browser testing, then failed before container verification because release helper scripts were stored without executable Git mode. The defect was regression-tested and corrected before rc.2.
+First real release event exposed executable-mode defects in release helper scripts. They were fixed before rc.2.
 
 ### `v0.1.0-rc.2` — 2026-08-09
 
-`Release / Verify` passed completely. `Release / Publish` authenticated to GHCR, set up QEMU/Buildx and published API/web multi-platform staging indexes. It then correctly failed closed at the first Trivy gate on pgJDBC `42.7.11` / `CVE-2026-54291` (`HIGH`, fixed in `42.7.12`).
-
-Subsequent mainline work upgraded pgJDBC, moved the web final runtime to distroless Node 24 Debian 13/non-root and added ordinary Container Security CI under the same fail-closed policy.
+Verify passed; Publish failed closed on pgJDBC `42.7.11` / `CVE-2026-54291` (`HIGH`, fixed in `42.7.12`). Mainline subsequently upgraded pgJDBC and retained the security gate.
 
 ### `v0.1.0-rc.3` — historical prerelease
 
-Immutable source:
-
-```text
-d988b8c596a737326aeac67f74b6f65a6aaed3bf
-```
-
-The tag must not be moved, deleted or reused for later source.
+Immutable source: `d988b8c596a737326aeac67f74b6f65a6aaed3bf`. Do not move/delete/reuse the tag.
 
 ### `v0.1.0-rc.4` — 2026-08-18 — FAILED METADATA GATE
 
-Immutable source:
+Immutable source: `8a269288addcb4aa8ea3d0ce46608b650cbdb6dc`.
 
-```text
-8a269288addcb4aa8ea3d0ce46608b650cbdb6dc
-```
-
-Release workflow:
-
-```text
-run 32136955056
-```
-
-The tag/source was correct, but the GitHub Release was published with `prerelease=false` even though the tag is a SemVer prerelease. `Release / Verify → Validate release metadata` invoked the contract with:
-
-```text
---tag "v0.1.0-rc.4"
---prerelease "false"
-```
-
-and failed with:
-
-```text
-ValueError: GitHub prerelease flag must match the SemVer prerelease state
-```
-
-All later verify steps were skipped. `Release / Publish` was skipped entirely, so rc.4 created no new GHCR promotion, OCI `latest` mutation, SBOM, attestation, staging/final release smoke or evidence/checksum assets.
-
-Because GitHub received `prerelease=false`, the rc.4 release object was temporarily exposed as the repository's `Latest release`. That is GitHub presentation metadata only; it is not evidence of OCI `latest` mutation. The existing release presentation should be corrected to **Set as a pre-release** without moving or deleting its tag. rc.4 nevertheless remains a failed release-contract attempt.
+Run `32136955056` failed before write-capable publication because GitHub supplied `prerelease=false` for a SemVer prerelease. No final package/evidence/latest side effects occurred.
 
 Detailed record: [`v0.1.0-rc.4-release-failure-2026-08-18.md`](v0.1.0-rc.4-release-failure-2026-08-18.md).
 
-## Next validation — `v0.1.0-rc.5`
+### `v0.1.0-rc.5` — 2026-08-19 — FAILED WEB SECURITY GATE
 
-The next attempt must be a **new immutable prerelease** from a newly selected exact verified `main` SHA:
+Immutable source: `a485c80dc1eb36122791c629f92b247354b0ee09`.
+
+Run `32224834303` eventually completed Verify on attempt 2 after an infrastructure-only Chromium/Ubuntu-mirror timeout on attempt 1. Publish built API/web multi-arch staging candidates and passed both API HIGH/CRITICAL gates, then failed at web amd64.
+
+Fresh normal CI reproduced exactly one OS-level HIGH finding on the unchanged Distroless Debian 13 web runtime:
 
 ```text
-v0.1.0-rc.5
+libssl3t64 3.5.6-1~deb13u2
+CVE-2026-14456
+status: fix_deferred
 ```
 
-Issue #152 is the operational gate.
+No final `0.1.0-rc.5` OCI promotion, `latest`, final smoke, provenance or release evidence assets occurred.
+
+Detailed record: [`v0.1.0-rc.5-release-failure-2026-08-19.md`](v0.1.0-rc.5-release-failure-2026-08-19.md).
+
+## Next validation — `v0.1.0-rc.6`
+
+Issue #152 and recovery PR #179 are the operational gate.
+
+The recovery does **not** lower severity or set `ignore-unfixed`. It keeps the minimal Distroless Debian 13 runtime and applies one exact-version OpenVEX `not_affected` statement only after final-image reachability guards pass. Two base-image alternatives were tested and rejected because fresh Trivy evidence showed materially larger HIGH/CRITICAL surfaces.
 
 Before publication:
 
-1. merge canonical rc.4-failure/rc.5 documentation through fresh CI/review;
-2. record the resulting exact `main` SHA in #152;
-3. verify all normal push workflow groups against that exact SHA;
-4. confirm `v0.1.0-rc.5` is absent;
-5. in the GitHub release form, explicitly enable **Set as a pre-release**;
-6. target the exact selected SHA, not floating `main`;
-7. publish rather than save a draft.
+1. #179 must finish on one exact head with 9/9 PR workflow groups SUCCESS;
+2. Container Security/Web must prove VEX contract + final-image guard + visible exact suppression + zero unsuppressed HIGH/CRITICAL findings;
+3. merge #179 and verify all normal exact-main push workflow groups;
+4. record the exact verified `main` SHA in #152;
+5. confirm `v0.1.0-rc.6` is absent;
+6. create one GitHub prerelease targeting that exact SHA with **Set as a pre-release enabled**.
 
-A successful rc.5 must pass both release jobs end to end and prove:
+A successful rc.6 must prove:
 
 - exact metadata/main ancestry;
 - repository verification and production browser E2E;
 - API/web `linux/amd64` + `linux/arm64` staging indexes;
-- unchanged Trivy `HIGH,CRITICAL` gate;
+- VEX/runtime guards on both web architectures;
+- API scans without VEX and web scans with only the reviewed suppression;
+- unchanged fail-closed `HIGH,CRITICAL` behavior for every other finding;
 - SPDX SBOMs;
 - staging exact-digest Compose smoke;
-- copy-without-rebuild final promotion with digest identity;
+- digest-preserving copy-without-rebuild final promotion;
 - final exact-digest smoke;
 - provenance attestations;
-- prerelease OCI `0.1.0-rc.5` tags without OCI `latest` mutation;
+- prerelease OCI `0.1.0-rc.6` tags without OCI `latest` mutation;
 - final manifest architecture checks;
-- attached evidence/checksum assets;
-- package visibility evidence.
+- attached manifests, vulnerability reports, SBOMs, OpenVEX and checksums.
 
 Do not create stable `v0.1.0` until at least one prerelease completes the entire workflow and its manual product canary is accepted.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Updated: 2026-08-18
+Updated: 2026-08-19
 
 The roadmap is evidence-driven. Technical connectivity, production-access readiness and deterministic product/core maturity are separate dimensions.
 
@@ -44,60 +44,74 @@ Do not preselect accounts, analytics, feature flags, provider health or saved hi
 
 ### `v0.1.0-rc.3` — historical prerelease
 
-Immutable source:
-
-```text
-d988b8c596a737326aeac67f74b6f65a6aaed3bf
-```
-
-Do not move, delete or reuse the tag.
+Immutable source: `d988b8c596a737326aeac67f74b6f65a6aaed3bf`. Do not move, delete or reuse the tag.
 
 ### `v0.1.0-rc.4` — FAILED AT METADATA CONTRACT
 
-Immutable source:
+Immutable source: `8a269288addcb4aa8ea3d0ce46608b650cbdb6dc`.
 
-```text
-8a269288addcb4aa8ea3d0ce46608b650cbdb6dc
-```
-
-Release run `32136955056` failed closed at `Release / Verify → Validate release metadata` because GitHub published a SemVer prerelease tag with `prerelease=false`.
-
-The write-capable `Release / Publish` job was skipped, so rc.4 established no new GHCR/SBOM/attestation/staging/final-smoke evidence and did not mutate OCI `latest`.
+Release run `32136955056` failed closed at `Release / Verify → Validate release metadata` because GitHub supplied `prerelease=false` for a SemVer prerelease tag. `Release / Publish` never started, so rc.4 established no new GHCR/SBOM/attestation/staging/final-smoke evidence and did not mutate OCI `latest`.
 
 Failure record: [`v0.1.0-rc.4-release-failure-2026-08-18.md`](v0.1.0-rc.4-release-failure-2026-08-18.md).
 
-The rc.4 tag remains historical evidence. Its GitHub release presentation should be corrected to pre-release status, but rc.4 remains a failed release-contract attempt.
+### `v0.1.0-rc.5` — FAILED AT WEB SECURITY GATE
 
-## Immediate mainline target — `v0.1.0-rc.5`
+Immutable source: `a485c80dc1eb36122791c629f92b247354b0ee09`.
 
-Issue: #152.
+Release run `32224834303` eventually completed `Release / Verify` after one infrastructure-only Playwright/Ubuntu mirror timeout. `Release / Publish` built API/web multi-arch staging images and passed both API HIGH/CRITICAL scans, then failed closed at web amd64 Trivy.
 
-Required sequence:
+The unchanged production image reproduced the exact root cause in normal Container Security CI:
 
-1. merge the rc.4-failure/rc.5 canonical-documentation correction through fresh exact-head CI/review;
-2. record the exact resulting `main` SHA in #152;
-3. verify all normal push workflow groups against that exact SHA;
-4. confirm `v0.1.0-rc.5` tag/release are absent immediately before publication;
-5. publish one GitHub release targeting only that exact SHA with **Set as a pre-release enabled**;
-6. require `Release / Verify` and `Release / Publish` to complete the existing release contract;
-7. inspect all release evidence and verify OCI `latest` remains untouched;
-8. run the manual product canary from immutable rc.5 artifacts;
-9. fix release-canary defects before choosing M5.2.
+```text
+libssl3t64 3.5.6-1~deb13u2
+CVE-2026-14456
+HIGH
+fix_deferred
+```
 
-A successful rc.5 must prove:
+No final rc.5 OCI promotion, `latest`, provenance, final smoke or release evidence assets occurred.
 
-- source/main ancestry and release metadata;
-- repository verification and production browser E2E;
-- `linux/amd64` + `linux/arm64` staging images;
-- unchanged fail-closed Trivy `HIGH,CRITICAL` policy;
-- SPDX SBOM per candidate image manifest;
-- staging exact-digest Compose smoke;
-- copy-without-rebuild promotion with digest identity preserved;
-- final exact-digest smoke;
-- GitHub provenance attestations;
-- prerelease SemVer OCI promotion without mutating `latest`;
-- final manifest architecture checks;
-- attached release evidence/checksums.
+Failure record: [`v0.1.0-rc.5-release-failure-2026-08-19.md`](v0.1.0-rc.5-release-failure-2026-08-19.md).
+
+## Immediate mainline target — `v0.1.0-rc.6`
+
+Issue: #152. Recovery implementation: draft PR #179.
+
+CVE-2026-14456 affects an OpenSSL QUIC server-listener code path. The production web process does not enable experimental QUIC, and final-image inspection proves that neither runtime Node nor the current native addon set dynamically links system `libssl`/`libcrypto`.
+
+Two attempted base-image replacements were rejected by fresh Trivy evidence because they increased the actionable HIGH/CRITICAL surface. Recovery therefore keeps the minimal Distroless Debian 13 runtime and uses a narrow OpenVEX statement scoped to the exact inherited package/version and CVE, with `not_affected / vulnerable_code_not_in_execute_path`.
+
+This is **not** a weakened security threshold. Controls are:
+
+- VEX contains exactly one reviewed CVE/package-version statement;
+- CI fails if the statement is widened;
+- final-image Entrypoint/Cmd must not enable `--experimental-quic`;
+- final Node and every `*.node` addon must not link system `libssl`/`libcrypto`;
+- VEX applies only to web scans; API scans are unchanged;
+- all unsuppressed `HIGH,CRITICAL` findings retain `exit-code=1`;
+- suppressed evidence is visible in ordinary CI logs;
+- release CI repeats the runtime guard on both amd64 and arm64;
+- the exact OpenVEX file becomes checksummed release evidence;
+- future failed JSON scans are summarized into durable workflow logs.
+
+Security assessment: [`security/CVE-2026-14456-vex-assessment.md`](security/CVE-2026-14456-vex-assessment.md).
+
+### Required rc.6 sequence
+
+1. finish #179 documentation and recovery code;
+2. require a final exact-head **9/9 PR workflow** pass;
+3. explicitly inspect Container Security/Web: VEX contract PASS, runtime guard PASS, exact suppression visible, zero unsuppressed HIGH/CRITICAL findings;
+4. require Release Contract CI and Release Bundle CI PASS on that same head;
+5. merge #179 only after final review has no blocking findings/threads;
+6. verify all normal exact-main push workflows on the resulting merge SHA;
+7. confirm `v0.1.0-rc.6` tag/release are absent;
+8. freeze that exact SHA in #152;
+9. publish exactly one prerelease `v0.1.0-rc.6` with **Set as a pre-release enabled**;
+10. require `Release / Verify` + `Release / Publish` end to end;
+11. inspect both architecture runtime/VEX guards, all four vulnerability gates, SPDX SBOMs, staging/final exact-digest smoke, digest-preserving promotion, provenance, manifests, VEX/checksums and package visibility;
+12. verify prerelease OCI promotion does not mutate `latest`;
+13. run manual product canary from immutable rc.6 artifacts;
+14. only then release #177 back to mainline, refresh it against current `main`, and run fresh exact-head CI/review.
 
 Stable `v0.1.0` remains blocked until prerelease evidence and manual acceptance are satisfactory.
 
@@ -121,7 +135,7 @@ Ordinary user-browser store-directory evidence succeeds; stock GitHub-hosted Chr
 
 ### Chizhik D2 schema canary — IMPLEMENTED / DRAFT
 
-Draft PR #177 adds an explicit user-invoked sanitized schema canary with no permission widening, a fixed candidate-field allowlist and real persistent-Chromium E2E. Its exact head `c38173f3b15b66fa892534989e1aa2f51d98468d` passed 9/9 PR workflow groups.
+Draft PR #177 adds an explicit user-invoked sanitized schema canary with no permission widening, a fixed candidate-field allowlist and real persistent-Chromium E2E. It remains frozen until rc.6 release recovery is accepted; after that it must be refreshed against current `main` and reverified.
 
 Do **not** implement production `BrowserObservation` / `ObservedOffer` mapping until #169 receives ordinary-user-browser evidence proving product container/identifier/name, price field **and monetary unit/scale**, plus explicit availability semantics if any. Unknown availability remains `UNKNOWN`.
 

--- a/docs/security/CVE-2026-14456-vex-assessment.md
+++ b/docs/security/CVE-2026-14456-vex-assessment.md
@@ -1,0 +1,112 @@
+# CVE-2026-14456 web-runtime VEX assessment
+
+Date: 2026-08-19
+
+## Decision
+
+ZakupGotov declares the inherited Debian package instance below **not affected** in the production web runtime:
+
+```text
+CVE-2026-14456
+pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2
+status: not_affected
+justification: vulnerable_code_not_in_execute_path
+```
+
+This is a narrow OpenVEX statement, not a severity downgrade and not a general CVE ignore. All other `HIGH` and `CRITICAL` findings remain fail-closed with Trivy `exit-code=1`.
+
+The machine-readable statement is `security/vex/CVE-2026-14456.openvex.json`.
+
+## Why the package is present
+
+The production web image is based on `gcr.io/distroless/nodejs24-debian13:nonroot`. Distroless builds its Node image on top of the generic C/C++ base. The Debian 13 base includes `libssl3t64`, so Trivy correctly inventories the package even when the application process does not use it.
+
+Upstream Distroless source:
+
+- `nodejs/nodejs.bzl`: Node image composition;
+- `base/config.bzl`: Debian 13 base package set, including `libssl3t64`;
+- `cc/config.bzl`: C++ runtime additions.
+
+## Vulnerability precondition
+
+The OpenSSL CNA description for CVE-2026-14456 concerns denial of service in an OpenSSL **QUIC server listener** through unbounded growth of pending incoming channels.
+
+Node 24 exposes QUIC behind the `--experimental-quic` flag. ZakupGotov starts the production Next.js standalone server as:
+
+```text
+Entrypoint: /nodejs/bin/node
+Cmd: apps/web/server.js
+```
+
+No `--experimental-quic` flag is present.
+
+Primary references:
+
+- https://www.cve.org/CVERecord?id=CVE-2026-14456
+- https://nodejs.org/api/cli.html#--experimental-quic
+- https://trivy.dev/docs/v0.70/guide/supply-chain/vex/file/
+- https://github.com/openvex/spec
+
+## Runtime reachability evidence
+
+A diagnostic CI build first reproduced the original finding on the unchanged production image:
+
+- Container Security run `32233978322`;
+- web job `96009747023`;
+- Debian 13.6;
+- `libssl3t64 3.5.6-1~deb13u2`;
+- `CVE-2026-14456` HIGH;
+- no Node-package findings.
+
+A later diagnostic run inspected dynamic dependencies. The final durable guard now performs the same inspection against the **actual built final image**, rather than relying on builder-stage evidence.
+
+For every guarded image it:
+
+1. checks the final container Entrypoint/Cmd and fails if `--experimental-quic` appears;
+2. extracts `/nodejs/bin/node` from the final image and inspects ELF `NEEDED` entries with `readelf`;
+3. extracts the final `/app` tree and inspects every native `*.node` addon;
+4. fails if Node or any native addon dynamically links `libssl` or `libcrypto`.
+
+On the accepted amd64 guard run, the final Node binary required only libc/C++ runtime libraries and did **not** require `libssl` or `libcrypto`. The only native addon was Sharp; it likewise did not require system `libssl` or `libcrypto`.
+
+The release workflow applies the same guard independently to `linux/amd64` and `linux/arm64` before either web vulnerability scan.
+
+## Rejected remediation experiments
+
+### Full Node Debian 12 slim runtime
+
+Replacing Distroless with `node:24.19.0-bookworm-slim` removed the original Debian 13 OpenSSL finding but substantially expanded runtime attack surface. Fresh Trivy scanning found 29 HIGH/CRITICAL findings across Debian utilities and npm-internal packages. This was rejected.
+
+### Distroless Debian 12 runtime
+
+Changing only `nodejs24-debian13` to `nodejs24-debian12` also failed security acceptance. Fresh Trivy found seven HIGH/CRITICAL OpenSSL findings for `libssl3 3.0.18-1~deb12u2`, including a CRITICAL vulnerability with an available fixed package version. This was rejected.
+
+These experiments show that changing the base distribution would trade one non-reachable inherited finding for a broader and in part genuinely actionable vulnerability set.
+
+## Fail-closed controls
+
+The VEX exception remains valid only while all of these conditions hold:
+
+- vulnerability ID is exactly `CVE-2026-14456`;
+- product PURL is exactly `pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2`;
+- status is exactly `not_affected`;
+- justification is exactly `vulnerable_code_not_in_execute_path`;
+- final web Entrypoint/Cmd does not enable `--experimental-quic`;
+- final Node binary does not dynamically link system `libssl`/`libcrypto`;
+- no final native addon dynamically links system `libssl`/`libcrypto`.
+
+`validate_web_vex.py` prevents widening the VEX document. `verify_web_vex_runtime.sh` enforces runtime assumptions before Trivy executes.
+
+Because the OpenVEX product identifier includes the exact package version, a future Distroless rebuild that changes the OpenSSL package version will not be silently covered by this statement. Trivy will fail again unless the new image is clean or receives a separate reviewed assessment.
+
+## Auditability
+
+Normal Container Security CI enables Trivy `show-suppressed` for the web scan so the exact suppressed vulnerability remains visible in CI logs.
+
+The release workflow:
+
+- guards both architectures before scanning;
+- applies the VEX only to web vulnerability scans, never API scans;
+- keeps `CRITICAL,HIGH` + `exit-code=1` unchanged;
+- includes the exact OpenVEX document in successful release assets and `SHA256SUMS`;
+- emits concise JSON-derived vulnerability details into the job log if a future release security gate fails before asset publication.

--- a/docs/v0.1.0-rc.5-release-failure-2026-08-19.md
+++ b/docs/v0.1.0-rc.5-release-failure-2026-08-19.md
@@ -63,15 +63,12 @@ Exact immutable staging target:
 ghcr.io/true-ruslan/zakup-gotov-staging-web@sha256:8483c5e5a17d9208964230f715b312475b780cb001d7aafe684eea0f6a0fd171
 ```
 
-The release used the pinned Aqua Trivy action with Trivy `v0.70.0` and a fail-closed policy equivalent to:
+The release used pinned Aqua Trivy `v0.70.0` with the unchanged fail-closed policy:
 
 ```text
-trivy image \
-  --format json \
-  --exit-code 1 \
-  --severity CRITICAL,HIGH \
-  --scanners vuln \
-  <exact web staging digest>
+--exit-code 1
+--severity CRITICAL,HIGH
+--scanners vuln
 ```
 
 The command returned exit code `1`.
@@ -94,17 +91,80 @@ Because the web `linux/amd64` vulnerability gate failed, every downstream promot
 
 The fail-closed release contract therefore worked as intended.
 
-## Diagnostic limitation discovered
+## Root cause reproduced outside the release pipeline
 
-The release workflow writes Trivy results to `dist/*-vulnerabilities.json`, but a fail-closed scan exits before those files are attached to the GitHub Release. The failed runner therefore did not preserve the exact CVE/package details as durable release evidence.
+Draft recovery PR #179 initially changed documentation only, leaving the production web image unchanged. Fresh `Container Security CI` reproduced the same failure:
 
-Recovery must not infer or guess the vulnerable package. A fresh production-image Trivy scan with human-readable output is required before changing dependencies or base images. The release workflow should also be hardened so future failed security gates preserve their scanner output in logs or workflow artifacts without weakening the gate.
+- run `32233978322`;
+- web job `96009747023`;
+- Debian 13.6;
+- package `libssl3t64`;
+- installed version `3.5.6-1~deb13u2`;
+- vulnerability `CVE-2026-14456`;
+- Trivy severity `HIGH`;
+- status `fix_deferred`;
+- Node/application package findings: `0`.
+
+The OpenSSL CNA describes CVE-2026-14456 as a denial-of-service condition in an OpenSSL **QUIC server listener**. The package is inherited from the generic Distroless Debian 13 base.
+
+## Reachability assessment
+
+The final production web image does not execute the vulnerable code path:
+
+- final container Entrypoint is `/nodejs/bin/node`;
+- final Cmd is `apps/web/server.js`;
+- `--experimental-quic` is not enabled;
+- final runtime Node ELF dependencies contain neither `libssl` nor `libcrypto`;
+- the only native addon in the current standalone bundle is Sharp and it also contains neither system `libssl` nor `libcrypto` as an ELF dependency.
+
+These assumptions are now checked directly against every guarded final image by `scripts/security/verify_web_vex_runtime.sh` rather than being retained as one-time diagnostic output.
+
+The detailed assessment is `docs/security/CVE-2026-14456-vex-assessment.md`.
+
+## Rejected remediation experiments
+
+Two base-image substitutions were tested and rejected rather than merged:
+
+1. Full `node:24.19.0-bookworm-slim` runtime removed the original finding but introduced 29 HIGH/CRITICAL findings across the much larger Debian/npm runtime surface.
+2. `gcr.io/distroless/nodejs24-debian12:nonroot` produced seven HIGH/CRITICAL OpenSSL findings, including a CRITICAL vulnerability with an available fixed package version.
+
+Changing distributions would therefore increase or replace the security exposure rather than solve this specific non-reachable inherited finding.
+
+## Accepted recovery design for rc.6
+
+The recovery keeps the minimal Distroless Debian 13 runtime and adds a narrowly scoped OpenVEX statement:
+
+```text
+CVE: CVE-2026-14456
+PURL: pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2
+status: not_affected
+justification: vulnerable_code_not_in_execute_path
+```
+
+Controls:
+
+- the VEX document contains exactly one reviewed statement and exact package version;
+- `validate_web_vex.py` fails if that statement is widened;
+- web scans require the final-image runtime reachability guard to pass first;
+- VEX is applied only to web scans, never API scans;
+- Trivy `CRITICAL,HIGH` and `exit-code=1` remain unchanged for every other finding;
+- normal CI enables `show-suppressed` so the exception is visible rather than hidden;
+- release CI checks both `linux/amd64` and `linux/arm64` runtime assumptions before scanning;
+- successful release evidence contains the exact OpenVEX file and includes it in `SHA256SUMS`;
+- failed release scans print concise JSON findings to the workflow log even when downstream release assets cannot be attached.
+
+A fresh unchanged-image A/B test on PR #179 already demonstrated that the web runtime guard passes and the VEX-filtered HIGH/CRITICAL gate returns zero unsuppressed findings while the fail-closed threshold remains active.
+
+## Diagnostic limitation corrected
+
+The rc.5 workflow wrote Trivy JSON to `dist/*-vulnerabilities.json`, but a failing scan terminated the job before those files could become GitHub Release assets. The recovery release workflow adds an `if: failure()` diagnostic step that prints any already-created vulnerability JSON reports in concise form to the durable Actions log.
 
 ## Recovery rule
 
 1. Preserve `v0.1.0-rc.5` as failed historical evidence.
-2. Reproduce the web vulnerability gate on the unchanged source with fresh CI and capture the exact package/CVE/fixed version.
-3. Apply the smallest root-cause security fix; do not lower Trivy severity or disable the scanner.
-4. Pass fresh PR CI and exact-main push verification.
-5. Select a new immutable prerelease target; the expected next candidate is `v0.1.0-rc.6`.
-6. Keep unrelated feature PRs, including #177, out of `main` until release recovery is complete.
+2. Complete #179 with the guarded narrow VEX and synchronized release documentation.
+3. Require fresh 9/9 PR CI and review on the final exact head.
+4. Merge only after all gates pass.
+5. Require fresh exact-main push CI.
+6. Select a new immutable prerelease target: `v0.1.0-rc.6`.
+7. Keep unrelated feature PRs, including #177, out of `main` until rc.6 release recovery is accepted.

--- a/docs/v0.1.0-rc.5-release-failure-2026-08-19.md
+++ b/docs/v0.1.0-rc.5-release-failure-2026-08-19.md
@@ -1,0 +1,110 @@
+# `v0.1.0-rc.5` release failure — 2026-08-19
+
+## Verdict
+
+`v0.1.0-rc.5` is an immutable **failed prerelease candidate**.
+
+Exact source:
+
+```text
+v0.1.0-rc.5 -> a485c80dc1eb36122791c629f92b247354b0ee09
+```
+
+Release workflow:
+
+```text
+run 32224834303
+```
+
+Do not move or reuse this tag.
+
+## Attempt 1 — infrastructure timeout
+
+`Release / Verify` job `95982326591` passed release metadata, main ancestry, pinned toolchain and repository verification. It then stalled while Playwright installed Chromium dependencies through Ubuntu package mirrors and reached the workflow's 60-minute timeout.
+
+`Release / Publish` did not start, so attempt 1 produced no publication side effects.
+
+Because the failure was in external Ubuntu package retrieval after repository verification had already passed, the exact immutable Verify job was rerun without changing the tag or source SHA.
+
+## Attempt 2 — Verify accepted
+
+`Release / Verify` job `96000598173` completed successfully end to end:
+
+- release metadata: PASS;
+- release commit ancestry on `main`: PASS;
+- pinned Java / Node / pnpm: PASS;
+- repository verification: PASS;
+- Chromium installation: PASS;
+- production web build: PASS;
+- responsive browser E2E: PASS;
+- production container bundle verification: PASS.
+
+## Attempt 2 — Publish failed closed on web security gate
+
+`Release / Publish` job `96002235304` successfully completed:
+
+- release metadata resolution;
+- GHCR authentication;
+- QEMU / Buildx setup;
+- API multi-architecture staging build (`linux/amd64`, `linux/arm64`);
+- web multi-architecture staging build (`linux/amd64`, `linux/arm64`);
+- API `linux/amd64` Trivy `HIGH,CRITICAL` gate;
+- API `linux/arm64` Trivy `HIGH,CRITICAL` gate.
+
+It then failed at:
+
+```text
+Scan web candidate for HIGH/CRITICAL vulnerabilities on amd64
+```
+
+Exact immutable staging target:
+
+```text
+ghcr.io/true-ruslan/zakup-gotov-staging-web@sha256:8483c5e5a17d9208964230f715b312475b780cb001d7aafe684eea0f6a0fd171
+```
+
+The release used the pinned Aqua Trivy action with Trivy `v0.70.0` and a fail-closed policy equivalent to:
+
+```text
+trivy image \
+  --format json \
+  --exit-code 1 \
+  --severity CRITICAL,HIGH \
+  --scanners vuln \
+  <exact web staging digest>
+```
+
+The command returned exit code `1`.
+
+## What did not happen
+
+Because the web `linux/amd64` vulnerability gate failed, every downstream promotion/evidence step was skipped. In particular there was no:
+
+- web `linux/arm64` vulnerability acceptance;
+- architecture-specific release SBOM completion;
+- staging exact-digest Compose smoke;
+- digest-preserving copy into final packages;
+- final exact-digest smoke;
+- final API/web provenance attestation;
+- `0.1.0-rc.5` OCI promotion;
+- stable `latest` mutation;
+- final manifest capture;
+- `release-verification.json` / `SHA256SUMS` publication;
+- verified release-asset attachment.
+
+The fail-closed release contract therefore worked as intended.
+
+## Diagnostic limitation discovered
+
+The release workflow writes Trivy results to `dist/*-vulnerabilities.json`, but a fail-closed scan exits before those files are attached to the GitHub Release. The failed runner therefore did not preserve the exact CVE/package details as durable release evidence.
+
+Recovery must not infer or guess the vulnerable package. A fresh production-image Trivy scan with human-readable output is required before changing dependencies or base images. The release workflow should also be hardened so future failed security gates preserve their scanner output in logs or workflow artifacts without weakening the gate.
+
+## Recovery rule
+
+1. Preserve `v0.1.0-rc.5` as failed historical evidence.
+2. Reproduce the web vulnerability gate on the unchanged source with fresh CI and capture the exact package/CVE/fixed version.
+3. Apply the smallest root-cause security fix; do not lower Trivy severity or disable the scanner.
+4. Pass fresh PR CI and exact-main push verification.
+5. Select a new immutable prerelease target; the expected next candidate is `v0.1.0-rc.6`.
+6. Keep unrelated feature PRs, including #177, out of `main` until release recovery is complete.

--- a/scripts/ci/install-playwright-chromium.sh
+++ b/scripts/ci/install-playwright-chromium.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# == 0 )); then
+  echo "usage: $0 <playwright-install-command> [args...]" >&2
+  exit 64
+fi
+
+readonly max_attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-2}"
+readonly attempt_timeout_seconds="${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-360}"
+readonly apt_conf="/etc/apt/apt.conf.d/80-zakup-gotov-ci-network"
+
+if ! [[ "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PLAYWRIGHT_INSTALL_ATTEMPTS must be a positive integer" >&2
+  exit 64
+fi
+if ! [[ "${attempt_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 64
+fi
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "GNU timeout is required for bounded Playwright installation" >&2
+  exit 1
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "sudo is required to configure bounded APT networking on this runner" >&2
+    exit 1
+  fi
+
+  printf '%s\n' \
+    'Acquire::Retries "3";' \
+    'Acquire::http::Timeout "20";' \
+    'Acquire::https::Timeout "20";' \
+    | sudo tee "${apt_conf}" >/dev/null
+
+  cleanup_apt_conf() {
+    sudo rm -f "${apt_conf}" >/dev/null 2>&1 || :
+  }
+  trap cleanup_apt_conf EXIT
+fi
+
+for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+  echo "Playwright Chromium install attempt ${attempt}/${max_attempts} (timeout ${attempt_timeout_seconds}s)"
+
+  if timeout \
+    --foreground \
+    --signal=TERM \
+    --kill-after=15s \
+    "${attempt_timeout_seconds}s" \
+    "$@"; then
+    echo "Playwright Chromium install completed on attempt ${attempt}."
+    exit 0
+  else
+    rc=$?
+  fi
+
+  if (( attempt == max_attempts )); then
+    echo "Playwright Chromium install failed after ${max_attempts} bounded attempt(s), exit=${rc}." >&2
+    exit "${rc}"
+  fi
+
+  backoff_seconds=$(( attempt * 5 ))
+  echo "Playwright Chromium install attempt ${attempt} failed with exit=${rc}; retrying in ${backoff_seconds}s." >&2
+  sleep "${backoff_seconds}"
+done

--- a/scripts/ci/install-playwright-chromium.sh
+++ b/scripts/ci/install-playwright-chromium.sh
@@ -45,7 +45,6 @@ for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
   echo "Playwright Chromium install attempt ${attempt}/${max_attempts} (timeout ${attempt_timeout_seconds}s)"
 
   if timeout \
-    --foreground \
     --signal=TERM \
     --kill-after=15s \
     "${attempt_timeout_seconds}s" \

--- a/scripts/ci/install-playwright-chromium.sh
+++ b/scripts/ci/install-playwright-chromium.sh
@@ -9,6 +9,7 @@ fi
 readonly max_attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-2}"
 readonly attempt_timeout_seconds="${PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-360}"
 readonly apt_conf="/etc/apt/apt.conf.d/80-zakup-gotov-ci-network"
+readonly supervisor="scripts/ci/run_with_timeout.py"
 
 if ! [[ "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_ATTEMPTS must be a positive integer" >&2
@@ -18,8 +19,12 @@ if ! [[ "${attempt_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS must be a positive integer" >&2
   exit 64
 fi
-if ! command -v timeout >/dev/null 2>&1; then
-  echo "GNU timeout is required for bounded Playwright installation" >&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for descendant-safe Playwright installation" >&2
+  exit 1
+fi
+if [[ ! -f "${supervisor}" ]]; then
+  echo "bounded process supervisor is missing: ${supervisor}" >&2
   exit 1
 fi
 
@@ -44,10 +49,10 @@ fi
 for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
   echo "Playwright Chromium install attempt ${attempt}/${max_attempts} (timeout ${attempt_timeout_seconds}s)"
 
-  if timeout \
-    --signal=TERM \
-    --kill-after=15s \
-    "${attempt_timeout_seconds}s" \
+  if python3 "${supervisor}" \
+    --timeout-seconds "${attempt_timeout_seconds}" \
+    --kill-after-seconds 15 \
+    -- \
     "$@"; then
     echo "Playwright Chromium install completed on attempt ${attempt}."
     exit 0

--- a/scripts/ci/run_with_timeout.py
+++ b/scripts/ci/run_with_timeout.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import dataclasses
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+
+EXIT_TIMED_OUT = 124
+EXIT_INTERNAL_ERROR = 125
+PR_SET_CHILD_SUBREAPER = 36
+PROC_ROOT = pathlib.Path("/proc")
+
+
+@dataclasses.dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    ppid: int
+    start_time: int
+    state: str
+
+
+def _read_process(pid: int) -> ProcessIdentity | None:
+    try:
+        stat = (PROC_ROOT / str(pid) / "stat").read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return None
+
+    comm_end = stat.rfind(")")
+    if comm_end < 0:
+        return None
+
+    fields = stat[comm_end + 2 :].split()
+    if len(fields) < 20:
+        return None
+
+    return ProcessIdentity(
+        pid=pid,
+        state=fields[0],
+        ppid=int(fields[1]),
+        start_time=int(fields[19]),
+    )
+
+
+def _snapshot_processes() -> dict[int, ProcessIdentity]:
+    processes: dict[int, ProcessIdentity] = {}
+    if not PROC_ROOT.is_dir():
+        return processes
+
+    for entry in PROC_ROOT.iterdir():
+        if not entry.name.isdigit():
+            continue
+        identity = _read_process(int(entry.name))
+        if identity is not None:
+            processes[identity.pid] = identity
+    return processes
+
+
+def _descendants(root_pid: int) -> list[tuple[int, ProcessIdentity]]:
+    processes = _snapshot_processes()
+    by_parent: dict[int, list[ProcessIdentity]] = {}
+    for identity in processes.values():
+        by_parent.setdefault(identity.ppid, []).append(identity)
+
+    result: list[tuple[int, ProcessIdentity]] = []
+    pending: list[tuple[int, int]] = [(root_pid, 0)]
+    while pending:
+        parent_pid, depth = pending.pop()
+        for child in by_parent.get(parent_pid, []):
+            child_depth = depth + 1
+            result.append((child_depth, child))
+            pending.append((child.pid, child_depth))
+    return result
+
+
+def _same_live_process(identity: ProcessIdentity) -> bool:
+    current = _read_process(identity.pid)
+    return (
+        current is not None
+        and current.start_time == identity.start_time
+        and current.state != "Z"
+    )
+
+
+def _enable_subreaper() -> None:
+    if not sys.platform.startswith("linux"):
+        return
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, "prctl(PR_SET_CHILD_SUBREAPER) failed")
+
+
+def _signal_identity(identity: ProcessIdentity, sig: signal.Signals) -> None:
+    if not _same_live_process(identity):
+        return
+
+    try:
+        os.kill(identity.pid, sig)
+        return
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        pass
+
+    sudo = shutil.which("sudo")
+    kill = shutil.which("kill")
+    if sudo is None or kill is None:
+        raise RuntimeError(
+            f"cannot signal privileged descendant pid={identity.pid}: sudo/kill unavailable"
+        )
+
+    if not _same_live_process(identity):
+        return
+
+    completed = subprocess.run(
+        [sudo, "-n", kill, f"-{int(sig)}", "--", str(identity.pid)],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+    )
+    if completed.returncode != 0 and _same_live_process(identity):
+        raise RuntimeError(
+            f"failed to signal privileged descendant pid={identity.pid}: "
+            f"{completed.stderr.strip()}"
+        )
+
+
+def _signal_process_group(pid: int, sig: signal.Signals) -> None:
+    try:
+        os.killpg(pid, sig)
+    except ProcessLookupError:
+        return
+    except PermissionError as exc:
+        raise RuntimeError(f"cannot signal process group {pid}: {exc}") from exc
+
+
+def _reap_adopted_children() -> None:
+    if not sys.platform.startswith("linux"):
+        return
+
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if pid == 0:
+            return
+
+
+def _live_identities(identities: dict[tuple[int, int], ProcessIdentity]) -> list[ProcessIdentity]:
+    return [identity for identity in identities.values() if _same_live_process(identity)]
+
+
+def _remember(
+    identities: dict[tuple[int, int], ProcessIdentity],
+    items: list[tuple[int, ProcessIdentity]],
+) -> None:
+    for _, identity in items:
+        identities[(identity.pid, identity.start_time)] = identity
+
+
+def _terminate_tree(process: subprocess.Popen[object], kill_after_seconds: float) -> None:
+    tracked: dict[tuple[int, int], ProcessIdentity] = {}
+    root_identity = _read_process(process.pid)
+    if root_identity is not None:
+        tracked[(root_identity.pid, root_identity.start_time)] = root_identity
+    _remember(tracked, _descendants(process.pid))
+
+    descendants = sorted(
+        _descendants(process.pid),
+        key=lambda item: item[0],
+        reverse=True,
+    )
+    for _, identity in descendants:
+        _signal_identity(identity, signal.SIGTERM)
+    _signal_process_group(process.pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + kill_after_seconds
+    while time.monotonic() < deadline:
+        _remember(tracked, _descendants(os.getpid()))
+        if not _live_identities(tracked):
+            break
+        time.sleep(0.05)
+
+    _remember(tracked, _descendants(os.getpid()))
+    survivors = _live_identities(tracked)
+    for identity in survivors:
+        _signal_identity(identity, signal.SIGKILL)
+
+    try:
+        process.wait(timeout=max(1.0, min(kill_after_seconds, 5.0)))
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+    reap_deadline = time.monotonic() + max(1.0, min(kill_after_seconds, 5.0))
+    while time.monotonic() < reap_deadline:
+        _reap_adopted_children()
+        _remember(tracked, _descendants(os.getpid()))
+        if not _live_identities(tracked):
+            break
+        for identity in _live_identities(tracked):
+            _signal_identity(identity, signal.SIGKILL)
+        time.sleep(0.05)
+
+    _reap_adopted_children()
+    survivors = _live_identities(tracked)
+    if survivors:
+        pids = ", ".join(str(identity.pid) for identity in survivors)
+        raise RuntimeError(f"timed-out command left live descendant process(es): {pids}")
+
+
+def _shell_status(returncode: int) -> int:
+    return 128 + (-returncode) if returncode < 0 else returncode
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one CI command with bounded, descendant-safe timeout cleanup."
+    )
+    parser.add_argument("--timeout-seconds", type=float, required=True)
+    parser.add_argument("--kill-after-seconds", type=float, default=15.0)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a command is required after --")
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be greater than zero")
+    if args.kill_after_seconds <= 0:
+        parser.error("--kill-after-seconds must be greater than zero")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+
+    if os.name != "posix":
+        print("run_with_timeout.py requires a POSIX runner", file=sys.stderr)
+        return EXIT_INTERNAL_ERROR
+
+    try:
+        _enable_subreaper()
+        process = subprocess.Popen(args.command, start_new_session=True)
+    except FileNotFoundError as exc:
+        print(f"failed to invoke command: {exc}", file=sys.stderr)
+        return 127
+    except Exception as exc:
+        print(f"failed to start bounded command: {exc}", file=sys.stderr)
+        return EXIT_INTERNAL_ERROR
+
+    try:
+        return _shell_status(process.wait(timeout=args.timeout_seconds))
+    except subprocess.TimeoutExpired:
+        print(
+            f"command timed out after {args.timeout_seconds:g}s; terminating its process tree",
+            file=sys.stderr,
+        )
+
+    try:
+        _terminate_tree(process, args.kill_after_seconds)
+    except Exception as exc:
+        print(f"failed to clean timed-out command tree: {exc}", file=sys.stderr)
+        return EXIT_INTERNAL_ERROR
+
+    return EXIT_TIMED_OUT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/test_ci_reliability_contract.py
+++ b/scripts/release/test_ci_reliability_contract.py
@@ -71,11 +71,19 @@ class PlaywrightInstallReliabilityContractTest(unittest.TestCase):
 
 
 class WebVexPlatformContractTest(unittest.TestCase):
-    def test_runtime_guard_always_resolves_the_requested_platform(self):
+    def test_runtime_guard_separates_local_and_registry_sources(self):
         guard = (ROOT / "scripts/security/verify_web_vex_runtime.sh").read_text(
             encoding="utf-8"
         )
+        container_workflow = (
+            ROOT / ".github/workflows/container-security-ci.yml"
+        ).read_text(encoding="utf-8")
+        release_workflow = (ROOT / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
 
+        self.assertIn('source_mode="${3:-registry}"', guard)
+        self.assertIn('docker image inspect "${image_ref}"', guard)
         self.assertIn(
             'docker pull --platform "${platform}" "${image_ref}"',
             guard,
@@ -84,7 +92,14 @@ class WebVexPlatformContractTest(unittest.TestCase):
             'docker create --platform "${platform}" "${image_ref}"',
             guard,
         )
-        self.assertNotIn("docker image inspect", guard)
+        self.assertIn(
+            'verify_web_vex_runtime.sh "${{ matrix.image }}" linux/amd64 local',
+            container_workflow,
+        )
+        self.assertEqual(
+            release_workflow.count("bash scripts/security/verify_web_vex_runtime.sh"),
+            2,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/release/test_ci_reliability_contract.py
+++ b/scripts/release/test_ci_reliability_contract.py
@@ -12,7 +12,7 @@ class PlaywrightInstallReliabilityContractTest(unittest.TestCase):
             encoding="utf-8"
         )
 
-    def test_install_is_bounded_and_retried_without_foreground_escape(self):
+    def test_install_is_bounded_retried_and_descendant_safe(self):
         helper = self._helper()
 
         required_fragments = (
@@ -21,15 +21,17 @@ class PlaywrightInstallReliabilityContractTest(unittest.TestCase):
             'Acquire::Retries "3";',
             'Acquire::http::Timeout "20";',
             'Acquire::https::Timeout "20";',
-            '--signal=TERM',
-            '--kill-after=15s',
-            '"${attempt_timeout_seconds}s"',
+            'supervisor="scripts/ci/run_with_timeout.py"',
+            'python3 "${supervisor}"',
+            '--timeout-seconds "${attempt_timeout_seconds}"',
+            '--kill-after-seconds 15',
         )
 
         for fragment in required_fragments:
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, helper)
 
+        self.assertNotIn("command -v timeout", helper)
         self.assertNotIn("--foreground", helper)
 
     def test_all_browser_ci_paths_delegate_to_the_bounded_helper(self):

--- a/scripts/release/test_ci_reliability_contract.py
+++ b/scripts/release/test_ci_reliability_contract.py
@@ -1,0 +1,91 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class PlaywrightInstallReliabilityContractTest(unittest.TestCase):
+    @staticmethod
+    def _helper() -> str:
+        return (ROOT / "scripts/ci/install-playwright-chromium.sh").read_text(
+            encoding="utf-8"
+        )
+
+    def test_install_is_bounded_and_retried_without_foreground_escape(self):
+        helper = self._helper()
+
+        required_fragments = (
+            'PLAYWRIGHT_INSTALL_ATTEMPTS:-2',
+            'PLAYWRIGHT_INSTALL_TIMEOUT_SECONDS:-360',
+            'Acquire::Retries "3";',
+            'Acquire::http::Timeout "20";',
+            'Acquire::https::Timeout "20";',
+            '--signal=TERM',
+            '--kill-after=15s',
+            '"${attempt_timeout_seconds}s"',
+        )
+
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, helper)
+
+        self.assertNotIn("--foreground", helper)
+
+    def test_all_browser_ci_paths_delegate_to_the_bounded_helper(self):
+        workflows = {
+            "web": (ROOT / ".github/workflows/web-ci.yml").read_text(encoding="utf-8"),
+            "bridge": (ROOT / ".github/workflows/retailer-bridge-ci.yml").read_text(
+                encoding="utf-8"
+            ),
+            "release": (ROOT / ".github/workflows/release.yml").read_text(
+                encoding="utf-8"
+            ),
+        }
+
+        self.assertIn(
+            "bash scripts/ci/install-playwright-chromium.sh pnpm --filter web exec playwright install --with-deps chromium",
+            workflows["web"],
+        )
+        self.assertIn(
+            "bash scripts/ci/install-playwright-chromium.sh pnpm --dir apps/retailer-bridge exec playwright install --with-deps chromium",
+            workflows["bridge"],
+        )
+        self.assertIn(
+            "bash scripts/ci/install-playwright-chromium.sh pnpm --filter web exec playwright install --with-deps chromium",
+            workflows["release"],
+        )
+
+        self.assertNotIn(
+            "run: pnpm --filter web exec playwright install --with-deps chromium",
+            workflows["web"],
+        )
+        self.assertNotIn(
+            "run: pnpm --dir apps/retailer-bridge exec playwright install --with-deps chromium",
+            workflows["bridge"],
+        )
+        self.assertNotIn(
+            "run: pnpm --filter web exec playwright install --with-deps chromium",
+            workflows["release"],
+        )
+
+
+class WebVexPlatformContractTest(unittest.TestCase):
+    def test_runtime_guard_always_resolves_the_requested_platform(self):
+        guard = (ROOT / "scripts/security/verify_web_vex_runtime.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            'docker pull --platform "${platform}" "${image_ref}"',
+            guard,
+        )
+        self.assertIn(
+            'docker create --platform "${platform}" "${image_ref}"',
+            guard,
+        )
+        self.assertNotIn("docker image inspect", guard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_process_supervisor.py
+++ b/scripts/release/test_process_supervisor.py
@@ -1,0 +1,94 @@
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SUPERVISOR = ROOT / "scripts/ci/run_with_timeout.py"
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    else:
+        return True
+
+
+class ProcessSupervisorTest(unittest.TestCase):
+    def test_timeout_reaps_a_detached_grandchild_before_returning(self):
+        self.assertTrue(
+            SUPERVISOR.is_file(),
+            "bounded CI supervisor must exist before detached-child cleanup can be verified",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            pid_file = tmp_path / "grandchild.pid"
+            fixture = tmp_path / "spawn_detached_grandchild.py"
+            fixture.write_text(
+                textwrap.dedent(
+                    """
+                    import pathlib
+                    import subprocess
+                    import sys
+                    import time
+
+                    pid_file = pathlib.Path(sys.argv[1])
+                    grandchild = subprocess.Popen(
+                        [sys.executable, "-c", "import time; time.sleep(60)"],
+                        start_new_session=True,
+                    )
+                    pid_file.write_text(str(grandchild.pid), encoding="utf-8")
+                    time.sleep(60)
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SUPERVISOR),
+                    "--timeout-seconds",
+                    "1",
+                    "--kill-after-seconds",
+                    "1",
+                    "--",
+                    sys.executable,
+                    str(fixture),
+                    str(pid_file),
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(
+                124,
+                result.returncode,
+                msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertTrue(pid_file.is_file(), "fixture never created detached grandchild")
+            grandchild_pid = int(pid_file.read_text(encoding="utf-8"))
+
+            deadline = time.monotonic() + 2
+            while _process_exists(grandchild_pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+            self.assertFalse(
+                _process_exists(grandchild_pid),
+                f"detached grandchild {grandchild_pid} survived supervisor timeout",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/security/report_trivy_json.py
+++ b/scripts/security/report_trivy_json.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import json
+import pathlib
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: report_trivy_json.py REPORT.json")
+
+    path = pathlib.Path(sys.argv[1])
+    if not path.is_file():
+        print(f"Trivy report was not created: {path}")
+        return
+
+    report = json.loads(path.read_text(encoding="utf-8"))
+    findings = []
+    for result in report.get("Results") or []:
+        target = result.get("Target") or "<unknown-target>"
+        for vulnerability in result.get("Vulnerabilities") or []:
+            findings.append(
+                {
+                    "target": target,
+                    "package": vulnerability.get("PkgName"),
+                    "vulnerability": vulnerability.get("VulnerabilityID"),
+                    "severity": vulnerability.get("Severity"),
+                    "status": vulnerability.get("Status"),
+                    "installed": vulnerability.get("InstalledVersion"),
+                    "fixed": vulnerability.get("FixedVersion"),
+                    "title": vulnerability.get("Title"),
+                }
+            )
+
+    print(f"Trivy failure evidence from {path}: {len(findings)} finding(s)")
+    print(json.dumps(findings, indent=2, ensure_ascii=False, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/security/validate_web_vex.py
+++ b/scripts/security/validate_web_vex.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import json
+import pathlib
+import sys
+
+VEX_PATH = pathlib.Path("security/vex/CVE-2026-14456.openvex.json")
+EXPECTED_PURL = "pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2"
+EXPECTED_CVE = "CVE-2026-14456"
+EXPECTED_JUSTIFICATION = "vulnerable_code_not_in_execute_path"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"web VEX contract failed: {message}")
+
+
+def main() -> None:
+    document = json.loads(VEX_PATH.read_text(encoding="utf-8"))
+
+    if document.get("@context") != "https://openvex.dev/ns/v0.2.0":
+        fail("unexpected OpenVEX context")
+    if document.get("version") != 1:
+        fail("version must remain exactly 1 until the reviewed statement changes")
+
+    statements = document.get("statements")
+    if not isinstance(statements, list) or len(statements) != 1:
+        fail("exactly one VEX statement is allowed")
+
+    statement = statements[0]
+    vulnerability = statement.get("vulnerability")
+    if vulnerability != {"name": EXPECTED_CVE}:
+        fail(f"statement must target only {EXPECTED_CVE}")
+
+    products = statement.get("products")
+    if products != [{"@id": EXPECTED_PURL}]:
+        fail(f"statement must target only exact package PURL {EXPECTED_PURL}")
+
+    if statement.get("status") != "not_affected":
+        fail("status must be not_affected")
+    if statement.get("justification") != EXPECTED_JUSTIFICATION:
+        fail(f"justification must be {EXPECTED_JUSTIFICATION}")
+
+    impact = statement.get("impact_statement")
+    if not isinstance(impact, str) or not impact.strip():
+        fail("impact_statement is required")
+    for required_fragment in ("--experimental-quic", "libssl/libcrypto", "QUIC server-listener"):
+        if required_fragment not in impact:
+            fail(f"impact_statement must preserve evidence fragment: {required_fragment}")
+
+    print(
+        "web VEX contract OK: "
+        f"{EXPECTED_CVE} -> {EXPECTED_PURL} ({EXPECTED_JUSTIFICATION})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/security/verify_web_vex_runtime.sh
+++ b/scripts/security/verify_web_vex_runtime.sh
@@ -7,9 +7,7 @@ platform="${2:-linux/amd64}"
 python3 scripts/security/validate_web_vex.py
 command -v readelf >/dev/null
 
-if ! docker image inspect "${image_ref}" >/dev/null 2>&1; then
-  docker pull --platform "${platform}" "${image_ref}" >/dev/null
-fi
+docker pull --platform "${platform}" "${image_ref}" >/dev/null
 
 workdir="$(mktemp -d)"
 container_id=""

--- a/scripts/security/verify_web_vex_runtime.sh
+++ b/scripts/security/verify_web_vex_runtime.sh
@@ -1,13 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-image_ref="${1:?usage: verify_web_vex_runtime.sh IMAGE_REF [PLATFORM]}"
+image_ref="${1:?usage: verify_web_vex_runtime.sh IMAGE_REF [PLATFORM] [SOURCE]}"
 platform="${2:-linux/amd64}"
+source_mode="${3:-local}"
 
 python3 scripts/security/validate_web_vex.py
 command -v readelf >/dev/null
 
-docker pull --platform "${platform}" "${image_ref}" >/dev/null
+case "${source_mode}" in
+  local)
+    if ! docker image inspect "${image_ref}" >/dev/null 2>&1; then
+      echo "web VEX runtime guard failed: local image is missing: ${image_ref}" >&2
+      exit 1
+    fi
+    ;;
+  registry)
+    docker pull --platform "${platform}" "${image_ref}" >/dev/null
+    ;;
+  *)
+    echo "web VEX runtime guard failed: SOURCE must be local or registry" >&2
+    exit 64
+    ;;
+esac
 
 workdir="$(mktemp -d)"
 container_id=""
@@ -22,7 +37,7 @@ trap cleanup EXIT
 container_id="$(docker create --platform "${platform}" "${image_ref}")"
 container_config="$(docker inspect --format '{{json .Config.Entrypoint}} {{json .Config.Cmd}}' "${container_id}")"
 
-echo "web VEX runtime config (${platform}): ${container_config}"
+echo "web VEX runtime config (${platform}, ${source_mode}): ${container_config}"
 if grep -F -- '--experimental-quic' <<<"${container_config}" >/dev/null; then
   echo "web VEX runtime guard failed: --experimental-quic is enabled" >&2
   exit 1
@@ -55,4 +70,4 @@ while IFS= read -r -d '' addon; do
   check_elf "${addon}"
 done < <(find "${workdir}/app" -type f -name '*.node' -print0)
 
-echo "web VEX runtime guard OK (${platform}): Node + ${native_count} native addon(s) do not link libssl/libcrypto and QUIC is not enabled"
+echo "web VEX runtime guard OK (${platform}, ${source_mode}): Node + ${native_count} native addon(s) do not link libssl/libcrypto and QUIC is not enabled"

--- a/scripts/security/verify_web_vex_runtime.sh
+++ b/scripts/security/verify_web_vex_runtime.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_ref="${1:?usage: verify_web_vex_runtime.sh IMAGE_REF [PLATFORM]}"
+platform="${2:-linux/amd64}"
+
+python3 scripts/security/validate_web_vex.py
+command -v readelf >/dev/null
+
+if ! docker image inspect "${image_ref}" >/dev/null 2>&1; then
+  docker pull --platform "${platform}" "${image_ref}" >/dev/null
+fi
+
+workdir="$(mktemp -d)"
+container_id=""
+cleanup() {
+  if [[ -n "${container_id}" ]]; then
+    docker rm -f "${container_id}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+container_id="$(docker create --platform "${platform}" "${image_ref}")"
+container_config="$(docker inspect --format '{{json .Config.Entrypoint}} {{json .Config.Cmd}}' "${container_id}")"
+
+echo "web VEX runtime config (${platform}): ${container_config}"
+if grep -F -- '--experimental-quic' <<<"${container_config}" >/dev/null; then
+  echo "web VEX runtime guard failed: --experimental-quic is enabled" >&2
+  exit 1
+fi
+if ! grep -F -- '/nodejs/bin/node' <<<"${container_config}" >/dev/null; then
+  echo "web VEX runtime guard failed: expected Distroless Node entrypoint is missing" >&2
+  exit 1
+fi
+
+docker cp "${container_id}:/nodejs/bin/node" "${workdir}/runtime-node"
+docker cp "${container_id}:/app" "${workdir}/app"
+
+check_elf() {
+  local binary="$1"
+  local needed
+  needed="$(readelf -d "${binary}" 2>/dev/null | grep 'NEEDED' || true)"
+  echo "ELF dependencies: ${binary#${workdir}/}"
+  printf '%s\n' "${needed}"
+  if grep -E 'Shared library: \[(libssl|libcrypto)(\.so|[^]]*)\]' <<<"${needed}" >/dev/null; then
+    echo "web VEX runtime guard failed: ${binary#${workdir}/} dynamically links system OpenSSL" >&2
+    exit 1
+  fi
+}
+
+check_elf "${workdir}/runtime-node"
+
+native_count=0
+while IFS= read -r -d '' addon; do
+  native_count=$((native_count + 1))
+  check_elf "${addon}"
+done < <(find "${workdir}/app" -type f -name '*.node' -print0)
+
+echo "web VEX runtime guard OK (${platform}): Node + ${native_count} native addon(s) do not link libssl/libcrypto and QUIC is not enabled"

--- a/scripts/security/verify_web_vex_runtime.sh
+++ b/scripts/security/verify_web_vex_runtime.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 image_ref="${1:?usage: verify_web_vex_runtime.sh IMAGE_REF [PLATFORM] [SOURCE]}"
 platform="${2:-linux/amd64}"
-source_mode="${3:-local}"
+source_mode="${3:-registry}"
 
 python3 scripts/security/validate_web_vex.py
 command -v readelf >/dev/null

--- a/security/vex/CVE-2026-14456.openvex.json
+++ b/security/vex/CVE-2026-14456.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/True-Ruslan/zakup-gotov/security/vex/CVE-2026-14456/1",
+  "author": "True-Ruslan/zakup-gotov maintainers",
+  "timestamp": "2026-08-19T09:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-14456"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "ZakupGotov web runs the Distroless Node server without --experimental-quic. CI inspects the final image and fails if runtime Node or any native .node addon declares libssl/libcrypto as an ELF dependency. The inherited Debian libssl3t64 package is therefore not in the web execution path for the OpenSSL QUIC server-listener code affected by CVE-2026-14456."
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Recover the real `v0.1.0-rc.5` web security-gate failure without weakening the release contract, harden the repeated Playwright/Ubuntu APT runner failure mode, and prepare a fresh immutable `v0.1.0-rc.6` target.

## rc.5 evidence

`v0.1.0-rc.5` remains immutable at `a485c80dc1eb36122791c629f92b247354b0ee09`.

Release run `32224834303` eventually passed `Release / Verify` end to end, built API/web multi-arch staging candidates, passed both API HIGH/CRITICAL gates, then failed closed at web amd64 Trivy on:

`ghcr.io/true-ruslan/zakup-gotov-staging-web@sha256:8483c5e5a17d9208964230f715b312475b780cb001d7aafe684eea0f6a0fd171`

No final rc.5 OCI promotion, `latest`, final smoke, provenance or release evidence assets occurred.

## Proven security root cause

Fresh unchanged-image Container Security CI reproduced exactly:

- Debian 13.6;
- `libssl3t64 3.5.6-1~deb13u2`;
- `CVE-2026-14456`;
- severity `HIGH`;
- status `fix_deferred`;
- zero Node/application package findings.

The vulnerable code is an OpenSSL QUIC server-listener path. Final-image inspection proves the ZakupGotov web process does not enable `--experimental-quic`, and neither runtime Node nor the current native addon set dynamically links system `libssl`/`libcrypto`.

Two runtime substitutions were tested and rejected because fresh scans increased the actionable security surface instead of reducing it.

## Security recovery

- exact OpenVEX statement only for `CVE-2026-14456` + `pkg:deb/debian/libssl3t64@3.5.6-1~deb13u2`;
- `not_affected / vulnerable_code_not_in_execute_path`;
- validator fails if the statement is widened;
- final-image guard fails if QUIC is enabled or Node/any native addon links `libssl`/`libcrypto`;
- normal Container Security uses explicit `local` source mode;
- release runtime guards use registry mode and explicitly resolve amd64 and arm64 variants before inspection;
- API Trivy scan remains completely unfiltered;
- web retains `CRITICAL,HIGH` + `exit-code=1` for every unsuppressed finding;
- release VEX becomes checksummed release evidence;
- failed release JSON scans are summarized into durable Actions logs.

Final exact-head Container Security evidence:

- run `32265309400` — **SUCCESS**;
- Web VEX contract — **SUCCESS**;
- Web runtime guard — **SUCCESS** for `/nodejs/bin/node apps/web/server.js` and current Sharp native addon;
- neither runtime binary links `libssl`/`libcrypto`; QUIC is not enabled;
- unsuppressed findings: **HIGH=0, CRITICAL=0**;
- suppressed findings: exactly **1** — `libssl3t64 / CVE-2026-14456 / HIGH / not_affected / vulnerable_code_not_in_execute_path`.

## CI reliability recovery

Repeated GitHub-hosted runner failures showed `playwright install --with-deps chromium` could stall in Ubuntu APT mirror access. A first bounded GNU `timeout` wrapper exposed a deeper issue: a privileged `apt-get` descendant could survive timeout and hold the `dpkg` lock during a same-run retry.

The final implementation keeps the official Playwright Chromium `--with-deps` path but adds:

- APT `Acquire::Retries=3`;
- bounded HTTP/HTTPS connection timeouts;
- at most two bounded Playwright-install attempts;
- a Linux descendant-safe Python supervisor using a new session + subreaper behavior;
- exact descendant PID/start-time tracking via `/proc`;
- precise TERM/KILL cleanup, including `sudo -n kill` only for an identified privileged descendant when required;
- retry only after no tracked live descendant remains;
- no browser-binary cache, no skipped browser tests, no relaxed E2E gate.

TDD evidence:

1. **RED:** `test_timeout_reaps_a_detached_grandchild_before_returning` failed because the supervisor did not exist; all prior release-contract tests passed.
2. **GREEN:** `scripts/ci/run_with_timeout.py` implemented descendant-safe timeout/reaping; the forced detached-grandchild test now passes.
3. Static contracts also forbid returning to direct unbounded Chromium installs or GNU `timeout` and lock the local-vs-registry VEX source modes.

Final Release Contract run `32265309595` is **SUCCESS: 20/20 tests**, including the detached-grandchild behavioral test and the browser-install/VEX reliability contracts.

## Final acceptance gate

Exact head:

`353c75a82e28ff0ebe350553d28cc3eb6c5b70cd`

Fresh exact-head PR workflow groups — **9/9 SUCCESS**:

1. Release Contract CI — `32265309595`
2. Dependency Review — `32265309479`
3. Contract CI — `32265309417`
4. API CI — `32265309451`
5. Container Security CI — `32265309400`
6. CodeQL — `32265309492`
7. Release Bundle CI — `32265309460`
8. Web CI — `32265309318`, including responsive browser E2E
9. Retailer Bridge CI — `32265309616`, including persistent-Chromium extension E2E

Final review has no unresolved review threads. Canonical PROJECT_STATE/ROADMAP/RELEASES/CHANGELOG and the rc.5 failure/security-assessment records are synchronized for rc.6 recovery.

This PR is ready for squash merge. After merge, the resulting exact `main` SHA must pass all normal push workflow groups before it may be selected and frozen as the only `v0.1.0-rc.6` release target.

#177 remains unmerged until rc.6 automated release acceptance is complete.