### PR TITLE
fix(release): verify rc.7 asset checksums by release path

### DIFF
--- a/.github/workflows/release-product-canary.yml
+++ b/.github/workflows/release-product-canary.yml
@@ -95,16 +95,17 @@ jobs:
             --pattern 'release-verification.json' \
             --pattern 'SHA256SUMS'
 
-          cd "$RELEASE_DIR"
-          for required in compose.release.yaml release-verification.json; do
-            if ! grep -Eq "[ *]${required}$" SHA256SUMS; then
-              echo "SHA256SUMS does not cover required canary asset: $required" >&2
-              exit 1
-            fi
-          done
-          sha256sum --check --ignore-missing SHA256SUMS
+          python3 "$GITHUB_WORKSPACE/scripts/release/verify_release_asset_checksums.py" \
+            "$RELEASE_DIR/SHA256SUMS" \
+            "$RELEASE_DIR" \
+            compose.release.yaml \
+            release-verification.json
 
-          cp compose.release.yaml release-verification.json SHA256SUMS "$CANARY_EVIDENCE_DIR/"
+          cp \
+            "$RELEASE_DIR/compose.release.yaml" \
+            "$RELEASE_DIR/release-verification.json" \
+            "$RELEASE_DIR/SHA256SUMS" \
+            "$CANARY_EVIDENCE_DIR/"
           printf '%s\n' "$RC7_TAG" > "$CANARY_EVIDENCE_DIR/release-tag.txt"
           printf '%s\n' "$RC7_SOURCE_SHA" > "$CANARY_EVIDENCE_DIR/release-source-sha.txt"
 

--- a/scripts/release/test_manual_canary_contract.py
+++ b/scripts/release/test_manual_canary_contract.py
@@ -23,11 +23,13 @@ class ManualProductCanaryContractTest(unittest.TestCase):
             "SHA256SUMS",
             "compose.release.yaml",
             "release-verification.json",
-            "sha256sum --check --ignore-missing SHA256SUMS",
+            "scripts/release/verify_release_asset_checksums.py",
         )
         for fragment in required:
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, workflow)
+
+        self.assertNotIn("sha256sum --check --ignore-missing SHA256SUMS", workflow)
 
     def test_canary_cannot_publish_or_mutate_release_state(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/release/test_release_asset_checksums.py
+++ b/scripts/release/test_release_asset_checksums.py
@@ -1,5 +1,6 @@
 import hashlib
 import pathlib
+import re
 import tempfile
 import unittest
 
@@ -69,6 +70,24 @@ class ReleaseAssetChecksumTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "malformed checksum"):
             verify_assets(checksums, self.root, ["compose.release.yaml"])
+
+
+class ReleaseAssetChecksumWorkflowWiringTest(unittest.TestCase):
+    def test_canary_invokes_exact_release_asset_verifier(self):
+        repository_root = pathlib.Path(__file__).resolve().parents[2]
+        workflow = (repository_root / ".github/workflows/release-product-canary.yml").read_text(
+            encoding="utf-8"
+        )
+
+        invocation = re.compile(
+            r'python3 "\$GITHUB_WORKSPACE/scripts/release/verify_release_asset_checksums\.py" \\\n'
+            r'\s+"\$RELEASE_DIR/SHA256SUMS" \\\n'
+            r'\s+"\$RELEASE_DIR" \\\n'
+            r'\s+compose\.release\.yaml \\\n'
+            r'\s+release-verification\.json'
+        )
+        self.assertRegex(workflow, invocation)
+        self.assertNotIn("sha256sum --check --ignore-missing SHA256SUMS", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/release/test_release_asset_checksums.py
+++ b/scripts/release/test_release_asset_checksums.py
@@ -1,0 +1,75 @@
+import hashlib
+import pathlib
+import tempfile
+import unittest
+
+from verify_release_asset_checksums import verify_assets
+
+
+class ReleaseAssetChecksumTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = pathlib.Path(self.tmp.name)
+        (self.root / "compose.release.yaml").write_text("services: {}\n", encoding="utf-8")
+        (self.root / "release-verification.json").write_text('{"version":"0.1.0-rc.7"}\n', encoding="utf-8")
+
+    def digest(self, name: str) -> str:
+        return hashlib.sha256((self.root / name).read_bytes()).hexdigest()
+
+    def write_checksums(self, lines: list[str]) -> pathlib.Path:
+        path = self.root / "SHA256SUMS"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def test_verifies_downloaded_basenames_against_release_dist_paths(self):
+        checksums = self.write_checksums([
+            f"{self.digest('compose.release.yaml')}  dist/compose.release.yaml",
+            f"{self.digest('release-verification.json')}  dist/release-verification.json",
+            f"{'a' * 64}  dist/api-manifest.json",
+        ])
+
+        verify_assets(
+            checksums,
+            self.root,
+            ["compose.release.yaml", "release-verification.json"],
+        )
+
+    def test_rejects_checksum_mismatch(self):
+        checksums = self.write_checksums([
+            f"{'0' * 64}  dist/compose.release.yaml",
+            f"{self.digest('release-verification.json')}  dist/release-verification.json",
+        ])
+
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            verify_assets(checksums, self.root, ["compose.release.yaml"])
+
+    def test_rejects_missing_required_entry(self):
+        checksums = self.write_checksums([
+            f"{self.digest('release-verification.json')}  dist/release-verification.json",
+        ])
+
+        with self.assertRaisesRegex(ValueError, "exactly one checksum entry"):
+            verify_assets(checksums, self.root, ["compose.release.yaml"])
+
+    def test_rejects_duplicate_required_entry(self):
+        digest = self.digest("compose.release.yaml")
+        checksums = self.write_checksums([
+            f"{digest}  dist/compose.release.yaml",
+            f"{digest} *dist/compose.release.yaml",
+        ])
+
+        with self.assertRaisesRegex(ValueError, "exactly one checksum entry"):
+            verify_assets(checksums, self.root, ["compose.release.yaml"])
+
+    def test_rejects_malformed_digest(self):
+        checksums = self.write_checksums([
+            "not-a-sha256  dist/compose.release.yaml",
+        ])
+
+        with self.assertRaisesRegex(ValueError, "malformed checksum"):
+            verify_assets(checksums, self.root, ["compose.release.yaml"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/verify_release_asset_checksums.py
+++ b/scripts/release/verify_release_asset_checksums.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import re
+import sys
+from collections.abc import Sequence
+
+
+CHECKSUM_LINE = re.compile(r"^([0-9a-f]{64}) ([ *])(.+)$")
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_asset_name(asset: str) -> None:
+    if not asset or pathlib.PurePosixPath(asset).name != asset or asset in {".", ".."}:
+        raise ValueError(f"asset must be a basename: {asset!r}")
+
+
+def verify_assets(
+    checksum_file: pathlib.Path,
+    download_directory: pathlib.Path,
+    assets: Sequence[str],
+) -> None:
+    lines = checksum_file.read_text(encoding="utf-8").splitlines()
+
+    parsed: list[tuple[str, str]] = []
+    malformed: list[str] = []
+    for line in lines:
+        if not line:
+            continue
+        match = CHECKSUM_LINE.fullmatch(line)
+        if match is None:
+            malformed.append(line)
+            continue
+        digest, _mode, filename = match.groups()
+        parsed.append((digest, filename))
+
+    for asset in assets:
+        _validate_asset_name(asset)
+        release_path = f"dist/{asset}"
+
+        if any(line.endswith(release_path) for line in malformed):
+            raise ValueError(f"malformed checksum entry for {release_path}")
+
+        matches = [digest for digest, filename in parsed if filename == release_path]
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one checksum entry for {release_path}, found {len(matches)}"
+            )
+
+        downloaded = download_directory / asset
+        if not downloaded.is_file():
+            raise ValueError(f"downloaded release asset is missing: {asset}")
+
+        actual = _sha256(downloaded)
+        expected = matches[0]
+        if actual != expected:
+            raise ValueError(
+                f"checksum mismatch for {asset}: expected {expected}, got {actual}"
+            )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify selected downloaded GitHub Release assets against dist/ paths in SHA256SUMS."
+    )
+    parser.add_argument("checksums", type=pathlib.Path)
+    parser.add_argument("download_directory", type=pathlib.Path)
+    parser.add_argument("assets", nargs="+")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        verify_assets(args.checksums, args.download_directory, args.assets)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"release asset checksum verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Root-cause fix for manual canary run `32350204308` failing before product startup.

## Observed runtime evidence
- rc.7 tag/source and release metadata passed;
- release assets downloaded successfully;
- harness failed with `SHA256SUMS does not cover required canary asset: compose.release.yaml`;
- accepted release workflow writes checksum entries as `dist/<asset>`, while GitHub release download stores selected assets as basenames.

## Fix
- add a dedicated fail-closed release-asset checksum verifier;
- require exactly one `dist/<basename>` entry for each required downloaded asset;
- verify the actual downloaded SHA-256 digest;
- reject checksum mismatch, missing entries, duplicates, malformed entries and non-basename asset names;
- wire the verifier directly into `release-product-canary.yml`;
- remove the old `grep + sha256sum --ignore-missing` path;
- keep rc.7 immutable and preserve all existing release/security permissions and no-build/no-mutation boundaries.

## TDD evidence
- RED: head `c9c72f2718505e761395a5d2c90609e3b013468e`, Release Contract CI `32358098651` failed because the new workflow-wiring regression test required the verifier invocation while the canary still used the old checksum path;
- first GREEN attempt exposed an intentionally stale existing manual-canary contract that still required `sha256sum --check --ignore-missing SHA256SUMS`;
- that contract was updated to require the dedicated verifier and explicitly reject the old path;
- final exact head: `a79667f8d61f6376002318a14a2d1b84a20a322b`.

## Final verification
Exact head `a79667f8d61f6376002318a14a2d1b84a20a322b`: **9/9 PR workflow groups SUCCESS**:
- Release Contract CI `32358253083`;
- Dependency Review `32358253089`;
- Contract CI `32358252979`;
- API CI `32358252986`;
- Retailer Bridge CI `32358252990`;
- Container Security CI `32358253070`;
- CodeQL `32358253000` (Java + JavaScript/TypeScript SUCCESS);
- Release Bundle CI `32358253099`;
- Web CI `32358252967` (Web + responsive E2E SUCCESS).

Final compare: `behind=0`; exactly four intended files changed. No unresolved review threads.

After merge, run a fresh owner `/release-canary rc.7` trigger against the immutable release. A successful evidence-capture run remains evidence for manual review; it is not itself stable `v0.1.0` acceptance.