### PR TITLE
fix(release): accept rc.7 no-assessment canary state

### DIFF
--- a/apps/web/scripts/release-canary-capture.mjs
+++ b/apps/web/scripts/release-canary-capture.mjs
@@ -215,8 +215,7 @@ async function normalScenarios(browser) {
     const optimization = page.getByRole("region", { name: "Стоимость оформления" });
     await expect(optimization).toBeVisible();
     await expect(optimization.getByRole("heading", { name: "Пока нельзя честно выбрать минимальную стоимость" })).toBeVisible();
-    await expect(optimization.getByText("Доставка: Неизвестно").first()).toBeVisible();
-    await expect(optimization.getByText("Нельзя включать в минимум").first()).toBeVisible();
+    await expect(optimization.getByText("Расчёт оформления недоступен.", { exact: true })).toHaveCount(8);
     await capture(page, "desktop-weekly-pantry-optimization");
   });
 

--- a/scripts/release/test_manual_canary_contract.py
+++ b/scripts/release/test_manual_canary_contract.py
@@ -88,6 +88,23 @@ class ManualProductCanaryContractTest(unittest.TestCase):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, capture)
 
+    def test_canary_accepts_rc7_truthful_no_assessment_checkout_state(self):
+        capture = CAPTURE_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'optimization.getByText("Расчёт оформления недоступен.", { exact: true })',
+            capture,
+        )
+        self.assertIn("toHaveCount(8)", capture)
+        self.assertNotIn(
+            'optimization.getByText("Доставка: Неизвестно").first()',
+            capture,
+        )
+        self.assertNotIn(
+            'optimization.getByText("Нельзя включать в минимум").first()',
+            capture,
+        )
+
     def test_canary_workflow_uses_immutable_action_pins(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Follow-up to real manual canary run `32358562644`.

## Runtime evidence
The immutable `v0.1.0-rc.7` bundle passed release identity/checksum verification, startup, draft restore/clear, Recipe comparison, manual-list comparison, narrow layout, API-unavailable handling and restart/recovery. One normal scenario failed because the evidence harness required checkout-assessment copy (`Доставка: Неизвестно` / `Нельзя включать в минимум`) even though rc.7 intentionally returned `NO_COMPARABLE_CANDIDATES` with no retailer `assessment`.

The exact rc.7 UI contract for that fail-closed state is:
- optimization summary: `Пока нельзя честно выбрать минимальную стоимость`;
- every canonical retailer remains visible;
- with no checkout assessment, each checkout card renders `Расчёт оформления недоступен.`.

This is a harness expectation defect, not a product/runtime defect.

## Fix
- retain the exact `NO_COMPARABLE_CANDIDATES` heading assertion;
- require all 8 immutable-rc.7 canonical retailer checkout cards to expose `Расчёт оформления недоступен.`;
- remove the stale assumptions that an absent assessment must expose delivery/comparability fields;
- add a release-contract regression preventing those stale assertions from returning.

No rc.7 artifact, API/Web product runtime, release permission, security threshold or publication boundary is changed.

## TDD evidence
- RED head `10c76cf7671901b59a418399f57500685e638c9d`;
- Release Contract CI `32359061076` failed at `Verify release semantics` because the new regression required the truthful no-assessment expectation while the capture harness still contained the stale assessment-only assertions;
- GREEN implementation head `2d282d21f9f7841e95bcfad0f67bd689636ba948`.

## Final exact-head verification
Head `2d282d21f9f7841e95bcfad0f67bd689636ba948`: **9/9 PR workflow groups SUCCESS**:
- Release Contract CI `32359179841`;
- Dependency Review `32359179810`;
- Contract CI `32359179815`;
- API CI `32359179829`;
- Retailer Bridge CI `32359179860`;
- Container Security CI `32359179840`;
- CodeQL `32359179883`;
- Release Bundle CI `32359179821`;
- Web CI `32359179848` including responsive Web E2E.

Final compare: `behind=0`; exactly 2 intended files changed (`+18/-2`). No unresolved review threads.

After merge, run a fresh owner `/release-canary rc.7` against the immutable release. A successful evidence-capture run still requires explicit human review before stable `v0.1.0` can be considered accepted.