### PR TITLE
fix(release): verify OCI aliases by strict manifest equivalence

### DIFF
--- a/.github/workflows/stable-promotion.yml
+++ b/.github/workflows/stable-promotion.yml
@@ -218,10 +218,28 @@ jobs:
       - name: Verify rc.7 registry identities and exact bundle
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect "$API_IMAGE:$SOURCE_RC_VERSION" | grep -F "Digest: $SOURCE_API_DIGEST"
-          docker buildx imagetools inspect "$WEB_IMAGE:$SOURCE_RC_VERSION" | grep -F "Digest: $SOURCE_WEB_DIGEST"
-          docker buildx imagetools inspect "$API_IMAGE@$SOURCE_API_DIGEST" >/dev/null
-          docker buildx imagetools inspect "$WEB_IMAGE@$SOURCE_WEB_DIGEST" >/dev/null
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE@$SOURCE_API_DIGEST" > "$WORK_ROOT/api-source-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE@$SOURCE_WEB_DIGEST" > "$WORK_ROOT/web-source-index.json"
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE:$SOURCE_RC_VERSION" > "$WORK_ROOT/api-rc-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE:$SOURCE_RC_VERSION" > "$WORK_ROOT/web-rc-index.json"
+
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$SOURCE_DIR/api-manifest.json" \
+            "$WORK_ROOT/api-source-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$SOURCE_DIR/web-manifest.json" \
+            "$WORK_ROOT/web-source-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/api-source-index.json" \
+            "$WORK_ROOT/api-rc-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/web-source-index.json" \
+            "$WORK_ROOT/web-rc-index.json"
+
           bash scripts/release/verify-published-release.sh "$SOURCE_DIR/compose.release.yaml"
 
       - name: Prepare stable release evidence and notes
@@ -277,7 +295,7 @@ jobs:
             --arg promotion_workflow_run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             '{
               schema_version: 1,
-              method: "digest-preserving-promotion",
+              method: "manifest-equivalent-promotion",
               stable_tag: $stable_tag,
               promoted_from: $promoted_from,
               source_sha: $source_sha,
@@ -329,7 +347,7 @@ jobs:
           - linux/amd64 + linux/arm64;
           - HIGH/CRITICAL vulnerability gates, SPDX SBOMs, exact-digest bundle smoke and provenance were accepted on rc.7.
 
-          Stable OCI tags \`0.1.0\` and \`latest\` point to those same accepted digests.
+          Stable OCI tags \`0.1.0\` and \`latest\` reference equivalent multi-platform indexes with the same accepted content-addressed platform manifests.
           EOF
 
       - name: Prepare or verify exact stable tag
@@ -482,8 +500,16 @@ jobs:
             --metadata-file "$WORK_ROOT/web-stable-promotion.json" \
             "$WEB_IMAGE@$SOURCE_WEB_DIGEST"
 
-          test "$(jq -r '."containerimage.descriptor".digest' "$WORK_ROOT/api-stable-promotion.json")" = "$SOURCE_API_DIGEST"
-          test "$(jq -r '."containerimage.descriptor".digest' "$WORK_ROOT/web-stable-promotion.json")" = "$SOURCE_WEB_DIGEST"
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE:0.1.0" > "$WORK_ROOT/api-stable-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE:0.1.0" > "$WORK_ROOT/web-stable-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/api-source-index.json" \
+            "$WORK_ROOT/api-stable-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/web-source-index.json" \
+            "$WORK_ROOT/web-stable-index.json"
 
       - name: Promote exact accepted digests to latest
         run: |
@@ -497,16 +523,42 @@ jobs:
             --metadata-file "$WORK_ROOT/web-latest-promotion.json" \
             "$WEB_IMAGE@$SOURCE_WEB_DIGEST"
 
-          test "$(jq -r '."containerimage.descriptor".digest' "$WORK_ROOT/api-latest-promotion.json")" = "$SOURCE_API_DIGEST"
-          test "$(jq -r '."containerimage.descriptor".digest' "$WORK_ROOT/web-latest-promotion.json")" = "$SOURCE_WEB_DIGEST"
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE:latest" > "$WORK_ROOT/api-latest-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE:latest" > "$WORK_ROOT/web-latest-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/api-source-index.json" \
+            "$WORK_ROOT/api-latest-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/web-source-index.json" \
+            "$WORK_ROOT/web-latest-index.json"
 
       - name: Verify stable and latest registry identities
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect "$API_IMAGE:0.1.0" | grep -F "Digest: $SOURCE_API_DIGEST"
-          docker buildx imagetools inspect "$WEB_IMAGE:0.1.0" | grep -F "Digest: $SOURCE_WEB_DIGEST"
-          docker buildx imagetools inspect "$API_IMAGE:latest" | grep -F "Digest: $SOURCE_API_DIGEST"
-          docker buildx imagetools inspect "$WEB_IMAGE:latest" | grep -F "Digest: $SOURCE_WEB_DIGEST"
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE:0.1.0" > "$WORK_ROOT/api-stable-final-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE:0.1.0" > "$WORK_ROOT/web-stable-final-index.json"
+          docker buildx imagetools inspect --raw \
+            "$API_IMAGE:latest" > "$WORK_ROOT/api-latest-final-index.json"
+          docker buildx imagetools inspect --raw \
+            "$WEB_IMAGE:latest" > "$WORK_ROOT/web-latest-final-index.json"
+
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/api-source-index.json" \
+            "$WORK_ROOT/api-stable-final-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/web-source-index.json" \
+            "$WORK_ROOT/web-stable-final-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/api-source-index.json" \
+            "$WORK_ROOT/api-latest-final-index.json"
+          python3 scripts/release/verify_oci_manifest_equivalence.py \
+            "$WORK_ROOT/web-source-index.json" \
+            "$WORK_ROOT/web-latest-final-index.json"
+
           bash scripts/release/verify-published-release.sh "$STABLE_DIR/compose.release.yaml"
 
       - name: Publish stable GitHub Release last
@@ -589,7 +641,7 @@ jobs:
               `Source: \`${process.env.SOURCE_RC_TAG}\` / \`${process.env.SOURCE_SHA}\``,
               '',
               result === 'success'
-                ? 'Exact accepted rc.7 API/Web digests were promoted without rebuild to `0.1.0` and `latest`, and the stable GitHub Release was published and verified.'
+                ? 'Accepted rc.7 API/Web platform manifests were promoted without rebuild to `0.1.0` and `latest`, verified equivalent to the immutable accepted digest references, and the stable GitHub Release was published and verified.'
                 : 'Stable publication did not complete successfully. Do not mutate or repoint any published stable tag; inspect the run before recovery.',
             ].join('\n');
             await github.rest.issues.createComment({

--- a/scripts/release/test_oci_manifest_equivalence.py
+++ b/scripts/release/test_oci_manifest_equivalence.py
@@ -1,0 +1,151 @@
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/release/verify_oci_manifest_equivalence.py"
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
+
+
+def descriptor(digest: str, architecture: str, *, size: int = 1234) -> dict:
+    return {
+        "mediaType": OCI_MANIFEST,
+        "digest": digest,
+        "size": size,
+        "platform": {
+            "architecture": architecture,
+            "os": "linux",
+        },
+    }
+
+
+def index(*manifests: dict, annotations: dict | None = None) -> dict:
+    payload = {
+        "schemaVersion": 2,
+        "mediaType": OCI_INDEX,
+        "manifests": list(manifests),
+    }
+    if annotations is not None:
+        payload["annotations"] = annotations
+    return payload
+
+
+class OciManifestEquivalenceTest(unittest.TestCase):
+    def run_verifier(self, source: dict, alias: dict) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = pathlib.Path(temp_dir)
+            source_path = temp / "source.json"
+            alias_path = temp / "alias.json"
+            source_path.write_text(json.dumps(source), encoding="utf-8")
+            alias_path.write_text(json.dumps(alias), encoding="utf-8")
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(source_path),
+                    str(alias_path),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def assert_passes(self, source: dict, alias: dict) -> None:
+        result = self.run_verifier(source, alias)
+        self.assertEqual(0, result.returncode, msg=result.stderr or result.stdout)
+
+    def assert_fails(self, source: dict, alias: dict) -> None:
+        result = self.run_verifier(source, alias)
+        self.assertNotEqual(0, result.returncode, msg="verifier unexpectedly accepted non-equivalent indexes")
+
+    def test_accepts_equivalent_indexes_despite_json_key_order_and_whitespace(self):
+        amd64 = descriptor("sha256:" + "a" * 64, "amd64")
+        arm64 = descriptor("sha256:" + "b" * 64, "arm64")
+        source = index(amd64, arm64)
+        alias = {
+            "manifests": [
+                {
+                    "platform": {"os": "linux", "architecture": "amd64"},
+                    "size": 1234,
+                    "digest": "sha256:" + "a" * 64,
+                    "mediaType": OCI_MANIFEST,
+                },
+                {
+                    "platform": {"architecture": "arm64", "os": "linux"},
+                    "digest": "sha256:" + "b" * 64,
+                    "mediaType": OCI_MANIFEST,
+                    "size": 1234,
+                },
+            ],
+            "mediaType": OCI_INDEX,
+            "schemaVersion": 2,
+        }
+        self.assert_passes(source, alias)
+
+    def test_accepts_changed_top_level_annotations_when_referenced_manifests_are_identical(self):
+        amd64 = descriptor("sha256:" + "a" * 64, "amd64")
+        arm64 = descriptor("sha256:" + "b" * 64, "arm64")
+        source = index(amd64, arm64, annotations={"org.opencontainers.image.version": "0.1.0-rc.7"})
+        alias = index(amd64, arm64, annotations={"org.opencontainers.image.version": "0.1.0"})
+        self.assert_passes(source, alias)
+
+    def test_rejects_changed_child_digest(self):
+        source = index(descriptor("sha256:" + "a" * 64, "amd64"))
+        alias = index(descriptor("sha256:" + "c" * 64, "amd64"))
+        self.assert_fails(source, alias)
+
+    def test_rejects_changed_child_size(self):
+        digest = "sha256:" + "a" * 64
+        source = index(descriptor(digest, "amd64", size=1234))
+        alias = index(descriptor(digest, "amd64", size=1235))
+        self.assert_fails(source, alias)
+
+    def test_rejects_changed_platform(self):
+        digest = "sha256:" + "a" * 64
+        source = index(descriptor(digest, "amd64"))
+        alias = index(descriptor(digest, "arm64"))
+        self.assert_fails(source, alias)
+
+    def test_rejects_missing_or_extra_child_descriptor(self):
+        amd64 = descriptor("sha256:" + "a" * 64, "amd64")
+        arm64 = descriptor("sha256:" + "b" * 64, "arm64")
+        self.assert_fails(index(amd64, arm64), index(amd64))
+        self.assert_fails(index(amd64), index(amd64, arm64))
+
+    def test_rejects_reordered_descriptors(self):
+        amd64 = descriptor("sha256:" + "a" * 64, "amd64")
+        arm64 = descriptor("sha256:" + "b" * 64, "arm64")
+        self.assert_fails(index(amd64, arm64), index(arm64, amd64))
+
+    def test_rejects_descriptor_metadata_drift(self):
+        digest = "sha256:" + "a" * 64
+        source_descriptor = descriptor(digest, "amd64")
+        source_descriptor["annotations"] = {"org.opencontainers.image.ref.name": "source"}
+        alias_descriptor = descriptor(digest, "amd64")
+        alias_descriptor["annotations"] = {"org.opencontainers.image.ref.name": "alias"}
+        self.assert_fails(index(source_descriptor), index(alias_descriptor))
+
+    def test_rejects_invalid_or_unsupported_top_level_contract(self):
+        manifest = {
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST,
+            "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:" + "d" * 64, "size": 10},
+            "layers": [],
+        }
+        self.assert_fails(manifest, manifest)
+        self.assert_fails({"schemaVersion": 1, "mediaType": OCI_INDEX, "manifests": []}, {"schemaVersion": 1, "mediaType": OCI_INDEX, "manifests": []})
+        self.assert_fails(index(), index())
+
+    def test_rejects_duplicate_child_descriptors(self):
+        amd64 = descriptor("sha256:" + "a" * 64, "amd64")
+        self.assert_fails(index(amd64, amd64), index(amd64, amd64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_stable_promotion_contract.py
+++ b/scripts/release/test_stable_promotion_contract.py
@@ -101,17 +101,22 @@ class StablePromotionContractTest(unittest.TestCase):
             '--arg manual_canary_run "$MANUAL_CANARY_RUN"',
             '--arg manual_acceptance_comment "$MANUAL_ACCEPTANCE_COMMENT"',
             '--arg promotion_workflow_run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"',
-            'method: "digest-preserving-promotion"',
+            'method: "manifest-equivalent-promotion"',
             'promoted_from: $promoted_from',
             'manual_canary_run: $manual_canary_run',
             'manual_acceptance_comment: $manual_acceptance_comment',
             'promotion_workflow_run: $promotion_workflow_run',
+            "same accepted content-addressed platform manifests",
+            "verified equivalent to the immutable accepted digest references",
             "Verify stable draft asset digests before registry mutation",
             "Verify published stable release",
         )
         for fragment in required:
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, workflow)
+
+        self.assertNotIn('method: "digest-preserving-promotion"', workflow)
+        self.assertNotIn("point to those same accepted digests", workflow)
 
     def test_stable_tag_is_exact_idempotent_and_release_uses_existing_tag(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/release/test_stable_promotion_contract.py
+++ b/scripts/release/test_stable_promotion_contract.py
@@ -58,6 +58,34 @@ class StablePromotionContractTest(unittest.TestCase):
             with self.subTest(fragment=fragment):
                 self.assertNotIn(fragment, workflow)
 
+    def test_oci_aliases_use_raw_manifest_equivalence_not_top_level_descriptor_digest(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        required = (
+            "scripts/release/verify_oci_manifest_equivalence.py",
+            "docker buildx imagetools inspect --raw",
+            '"$API_IMAGE@$SOURCE_API_DIGEST"',
+            '"$WEB_IMAGE@$SOURCE_WEB_DIGEST"',
+            '"$API_IMAGE:$SOURCE_RC_VERSION"',
+            '"$WEB_IMAGE:$SOURCE_RC_VERSION"',
+            '"$API_IMAGE:0.1.0"',
+            '"$WEB_IMAGE:0.1.0"',
+            '"$API_IMAGE:latest"',
+            '"$WEB_IMAGE:latest"',
+        )
+        for fragment in required:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, workflow)
+
+        forbidden = (
+            'grep -F "Digest: $SOURCE_API_DIGEST"',
+            'grep -F "Digest: $SOURCE_WEB_DIGEST"',
+            '."containerimage.descriptor".digest',
+        )
+        for fragment in forbidden:
+            with self.subTest(fragment=fragment):
+                self.assertNotIn(fragment, workflow)
+
     def test_promotion_verifies_source_release_identity_and_stable_evidence(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/release/verify_oci_manifest_equivalence.py
+++ b/scripts/release/verify_oci_manifest_equivalence.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Fail-closed comparison for OCI multi-platform image indexes.
+
+Mutable registry tags may be re-serialized by a registry and therefore acquire a
+new top-level digest even when they still reference the exact same platform
+manifests.  This verifier deliberately ignores only top-level annotations and
+requires every other part of the index, including ordered child descriptors,
+to remain identical.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+import re
+import sys
+from typing import Any
+
+
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def fail(message: str) -> "NoReturn":
+    raise SystemExit(message)
+
+
+def load_json(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        fail(f"{label}: cannot read {path}: {exc}")
+
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"{label}: invalid JSON in {path}: {exc.msg}")
+
+    if not isinstance(value, dict):
+        fail(f"{label}: top-level OCI document must be an object")
+    return value
+
+
+def validate_string(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{label}: expected non-empty string")
+    return value
+
+
+def validate_platform(value: Any, *, label: str) -> None:
+    if not isinstance(value, dict):
+        fail(f"{label}: platform must be an object")
+
+    for key, item in value.items():
+        if key == "os.features":
+            if not isinstance(item, list) or not all(
+                isinstance(feature, str) and feature for feature in item
+            ):
+                fail(f"{label}.{key}: expected a list of non-empty strings")
+            continue
+        if not isinstance(item, str) or not item:
+            fail(f"{label}.{key}: expected non-empty string")
+
+    for required in ("os", "architecture"):
+        validate_string(value.get(required), label=f"{label}.{required}")
+
+
+def validate_descriptor(value: Any, *, label: str) -> None:
+    if not isinstance(value, dict):
+        fail(f"{label}: descriptor must be an object")
+
+    validate_string(value.get("mediaType"), label=f"{label}.mediaType")
+    digest = validate_string(value.get("digest"), label=f"{label}.digest")
+    if not SHA256_RE.fullmatch(digest):
+        fail(f"{label}.digest: expected lowercase sha256 digest")
+
+    size = value.get("size")
+    if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+        fail(f"{label}.size: expected positive integer")
+
+    if "platform" in value:
+        validate_platform(value["platform"], label=f"{label}.platform")
+
+    annotations = value.get("annotations")
+    if annotations is not None:
+        if not isinstance(annotations, dict) or not all(
+            isinstance(key, str)
+            and key
+            and isinstance(item, str)
+            for key, item in annotations.items()
+        ):
+            fail(f"{label}.annotations: expected string-to-string object")
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def validate_index(value: dict[str, Any], *, label: str) -> None:
+    if value.get("schemaVersion") != 2:
+        fail(f"{label}: schemaVersion must be 2")
+    if value.get("mediaType") != OCI_INDEX:
+        fail(f"{label}: mediaType must be {OCI_INDEX}")
+
+    manifests = value.get("manifests")
+    if not isinstance(manifests, list) or not manifests:
+        fail(f"{label}: manifests must be a non-empty array")
+
+    seen: set[str] = set()
+    for index, descriptor in enumerate(manifests):
+        descriptor_label = f"{label}.manifests[{index}]"
+        validate_descriptor(descriptor, label=descriptor_label)
+        identity = canonical(descriptor)
+        if identity in seen:
+            fail(f"{label}: duplicate child descriptor at index {index}")
+        seen.add(identity)
+
+    annotations = value.get("annotations")
+    if annotations is not None:
+        if not isinstance(annotations, dict) or not all(
+            isinstance(key, str)
+            and key
+            and isinstance(item, str)
+            for key, item in annotations.items()
+        ):
+            fail(f"{label}.annotations: expected string-to-string object")
+
+
+def normalized_index(value: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(value)
+    # Registry/tag-specific metadata may legitimately change while the content
+    # addressable child descriptors stay exactly the same.  Do not ignore any
+    # child annotations or any other top-level field.
+    normalized.pop("annotations", None)
+    return normalized
+
+
+def compare(source: dict[str, Any], alias: dict[str, Any]) -> None:
+    validate_index(source, label="source")
+    validate_index(alias, label="alias")
+
+    source_normalized = normalized_index(source)
+    alias_normalized = normalized_index(alias)
+    if source_normalized == alias_normalized:
+        return
+
+    source_manifests = source_normalized.get("manifests", [])
+    alias_manifests = alias_normalized.get("manifests", [])
+    if source_manifests != alias_manifests:
+        fail("OCI index mismatch: ordered child descriptors differ")
+    fail("OCI index mismatch outside allowed top-level annotations")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            f"usage: {pathlib.Path(argv[0]).name} SOURCE_RAW_JSON ALIAS_RAW_JSON",
+            file=sys.stderr,
+        )
+        return 2
+
+    source = load_json(pathlib.Path(argv[1]), "source")
+    alias = load_json(pathlib.Path(argv[2]), "alias")
+    compare(source, alias)
+    print("OCI index equivalence verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Root cause

The first owner-gated stable promotion run (`32362833963`) stopped **before any stable mutation** at the rc.7 registry preflight. GitHub Release identity, server-side asset digests, `SHA256SUMS`, manual canary acceptance, `release-verification.json`, and the immutable API/Web digest references had already passed.

The failing assumption was that a mutable OCI tag must preserve the source index's **top-level descriptor digest**. A tag operation may reserialize/tag-specific top-level annotation metadata while still referencing the exact accepted content-addressed platform manifests.

## Fix

Stable promotion remains anchored exclusively to the accepted immutable references:

- API: `ghcr.io/true-ruslan/zakup-gotov-api@sha256:1c5c4a104fee295cd579b0e69a23b508a297b1eb931a45c0ce71d8b1791e54e1`
- Web: `ghcr.io/true-ruslan/zakup-gotov-web@sha256:5bc236f3f304dffe29f54921f5a2bbf27d3df67c18714d4cc268d6d25bafce68`

The new verifier compares raw OCI indexes fail-closed. It ignores only top-level `annotations`; ordered child descriptors (digest, size, media type, platform and child metadata) and every other top-level field must remain exact. Missing/extra/reordered/drifted child descriptors are rejected.

The mutable rc.7 tag is only an additional integrity signal. It is **never** used as the promotion source. `0.1.0` and `latest` are created from the accepted immutable digest references, then independently re-read and verified against them.

## Regression protection

Added tests for:

- harmless JSON formatting/key-order differences;
- top-level annotation differences;
- changed child digest/size/platform/metadata;
- missing/extra/reordered/duplicate descriptors;
- invalid OCI index contracts;
- workflow wiring that requires raw-manifest verification and forbids the old top-level digest assumption.

## Safety invariants

- no rebuild;
- no weakening of release-asset/checksum verification;
- no weakening of manual-canary, vulnerability, SBOM, provenance or runtime gates;
- owner-only exact release command remains required;
- stable Git tag/draft assets are verified before registry mutation;
- stable GitHub Release is still published last;
- no stable tag/release/`latest` mutation occurred while developing this PR.

## Verification

Exact head `0b5e4bb85fd6467d5eb7ad98278eb4b6785ee811` is `behind=0` and has 9/9 successful PR workflows:

- Release Contract CI `32370084181`
- Release Bundle CI `32370084379`
- Dependency Review `32370084183`
- Contract CI `32370084305`
- Container Security CI `32370084234`
- Retailer Bridge CI `32370084186`
- API CI `32370084279`
- CodeQL `32370084196`
- Web CI `32370084203`

Independent review found no blocking findings; there are no review threads.