### PR TITLE
fix(chizhik): diagnose live D2 missing context safely

### DIFF
--- a/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
@@ -138,3 +138,89 @@ test("runs the Chizhik D2 schema canary only on user invocation and renders sani
     await rm(userDataDir, { recursive: true, force: true });
   }
 });
+
+test("renders only fixed route-family diagnostics when live resource shape is not accepted", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-canary-diag-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  let acceptedV3SearchRequests = 0;
+  const privateStoreId = "PRIVATE99";
+  const changedVersionResource =
+    `https://app.chizhik.club/delivery/api/catalog/v4/stores/${privateStoreId}/search?mode=store&q=cola`;
+
+  try {
+    await context.route("https://chizhik.club/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><html><body><main>Chizhik search fixture</main></body></html>",
+      }),
+    );
+    await context.route(shopsEndpoint, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(stores),
+      }),
+    );
+    await context.route("https://app.chizhik.club/delivery/api/catalog/**", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname.includes("/v3/stores/") && url.pathname.endsWith("/search")) {
+        acceptedV3SearchRequests += 1;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({ products: [] }),
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/search?q=cola");
+    await page.evaluate(async (resourceUrl) => {
+      await fetch(resourceUrl, {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+      });
+    }, changedVersionResource);
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(worker.url()).host;
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await page.bringToFront();
+
+    await popup.getByRole("button", { name: "Run sanitized Chizhik canary" }).click();
+    const evidence = popup.locator("#evidence");
+    await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
+    await expect(evidence).toContainText(
+      "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
+        "store_v2_v3=NOT_SEEN store_other_version=SEEN page_origin_delivery=NOT_SEEN",
+    );
+    expect(acceptedV3SearchRequests).toBe(0);
+
+    const rendered = await evidence.textContent();
+    expect(rendered).not.toContain(privateStoreId);
+    expect(rendered).not.toContain(changedVersionResource);
+    expect(rendered).not.toContain("/v4/");
+    expect(rendered).not.toContain("q=cola");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
+++ b/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
@@ -1,0 +1,75 @@
+const CHIZHIK_PAGE_ORIGIN = "https://chizhik.club";
+const CHIZHIK_APP_ORIGIN = "https://app.chizhik.club";
+const DELIVERY_API_PREFIX = "/delivery/api/";
+const DELIVERY_CATALOG_PREFIX = "/delivery/api/catalog/";
+const ACCEPTED_STORE_PATH =
+  /^\/delivery\/api\/catalog\/v(?:2|3)\/stores\/[A-Za-z0-9_-]{1,32}(?:\/|$)/;
+const ANY_NUMERIC_STORE_PATH =
+  /^\/delivery\/api\/catalog\/v(\d{1,2})\/stores\/[A-Za-z0-9_-]{1,64}(?:\/|$)/;
+const PAGE_ORIGIN_DELIVERY_PATH = /^\/(?:api\/)?delivery(?:\/|$)/;
+
+export type ChizhikResourceDiagnosticsSnapshot = Readonly<{
+  appOriginSeen: boolean;
+  deliveryApiSeen: boolean;
+  deliveryCatalogSeen: boolean;
+  storeScopedV2V3Seen: boolean;
+  storeScopedOtherVersionSeen: boolean;
+  pageOriginDeliverySeen: boolean;
+}>;
+
+const EMPTY_SNAPSHOT: ChizhikResourceDiagnosticsSnapshot = {
+  appOriginSeen: false,
+  deliveryApiSeen: false,
+  deliveryCatalogSeen: false,
+  storeScopedV2V3Seen: false,
+  storeScopedOtherVersionSeen: false,
+  pageOriginDeliverySeen: false,
+};
+
+export const EMPTY_CHIZHIK_RESOURCE_DIAGNOSTICS = Object.freeze({ ...EMPTY_SNAPSHOT });
+
+export function createChizhikResourceDiagnosticsTracker() {
+  const state = { ...EMPTY_SNAPSHOT };
+
+  return {
+    observe(rawUrl: string, pageUrl: URL): void {
+      if (pageUrl.origin !== CHIZHIK_PAGE_ORIGIN) return;
+
+      try {
+        const resourceUrl = new URL(rawUrl, pageUrl);
+
+        if (
+          resourceUrl.origin === pageUrl.origin &&
+          PAGE_ORIGIN_DELIVERY_PATH.test(resourceUrl.pathname)
+        ) {
+          state.pageOriginDeliverySeen = true;
+        }
+
+        if (resourceUrl.origin !== CHIZHIK_APP_ORIGIN) return;
+        state.appOriginSeen = true;
+
+        if (!resourceUrl.pathname.startsWith(DELIVERY_API_PREFIX)) return;
+        state.deliveryApiSeen = true;
+
+        if (!resourceUrl.pathname.startsWith(DELIVERY_CATALOG_PREFIX)) return;
+        state.deliveryCatalogSeen = true;
+
+        if (ACCEPTED_STORE_PATH.test(resourceUrl.pathname)) {
+          state.storeScopedV2V3Seen = true;
+          return;
+        }
+
+        const version = resourceUrl.pathname.match(ANY_NUMERIC_STORE_PATH)?.[1];
+        if (version && version !== "2" && version !== "3") {
+          state.storeScopedOtherVersionSeen = true;
+        }
+      } catch {
+        // Malformed resource names are intentionally ignored.
+      }
+    },
+
+    snapshot(): ChizhikResourceDiagnosticsSnapshot {
+      return { ...state };
+    },
+  };
+}

--- a/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
@@ -15,6 +15,10 @@ function baseContentType(contentType: string): string {
   return base?.trim() || "unknown";
 }
 
+function seen(value: boolean): "SEEN" | "NOT_SEEN" {
+  return value ? "SEEN" : "NOT_SEEN";
+}
+
 export function formatChizhikSchemaCanaryEvidence(
   result: ChizhikSchemaCanaryResult,
 ): string {
@@ -30,7 +34,15 @@ export function formatChizhikSchemaCanaryEvidence(
     case "stores-unavailable":
       return "CHIZHIK_D2 status=STORES_UNAVAILABLE";
     case "missing-context":
-      return "CHIZHIK_D2 status=MISSING_CONTEXT";
+      return (
+        "CHIZHIK_D2 status=MISSING_CONTEXT\n" +
+        `CHIZHIK_D2_DIAG app_origin=${seen(result.diagnostics.appOriginSeen)} ` +
+        `delivery_api=${seen(result.diagnostics.deliveryApiSeen)} ` +
+        `delivery_catalog=${seen(result.diagnostics.deliveryCatalogSeen)} ` +
+        `store_v2_v3=${seen(result.diagnostics.storeScopedV2V3Seen)} ` +
+        `store_other_version=${seen(result.diagnostics.storeScopedOtherVersionSeen)} ` +
+        `page_origin_delivery=${seen(result.diagnostics.pageOriginDeliverySeen)}`
+      );
     case "search-unavailable":
       return "CHIZHIK_D2 status=SEARCH_UNAVAILABLE";
   }

--- a/apps/retailer-bridge/src/chizhik-schema-canary.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary.ts
@@ -2,6 +2,10 @@ import type {
   ChizhikDeliverySearchRequest,
   ChizhikStoreDiscoveryResult,
 } from "./chizhik-active-api-client";
+import {
+  EMPTY_CHIZHIK_RESOURCE_DIAGNOSTICS,
+  type ChizhikResourceDiagnosticsSnapshot,
+} from "./chizhik-resource-diagnostics";
 import { resolveChizhikEvidencedStoreId } from "./chizhik-store-context";
 
 const OFFICIAL_PAGE_ORIGIN = "https://chizhik.club";
@@ -58,7 +62,10 @@ type CanaryClient = Readonly<{
 export type ChizhikSchemaCanaryResult =
   | Readonly<{ status: "wrong-origin" }>
   | Readonly<{ status: "stores-unavailable" }>
-  | Readonly<{ status: "missing-context" }>
+  | Readonly<{
+      status: "missing-context";
+      diagnostics: ChizhikResourceDiagnosticsSnapshot;
+    }>
   | Readonly<{ status: "search-unavailable" }>
   | Readonly<{
       status: "pass";
@@ -72,6 +79,7 @@ export type ChizhikSchemaCanaryInput = Readonly<{
   client: CanaryClient;
   pageUrl: URL;
   resourceUrls: readonly string[];
+  resourceDiagnostics?: ChizhikResourceDiagnosticsSnapshot;
 }>;
 
 function valueType(value: unknown): JsonValueType {
@@ -134,7 +142,12 @@ export async function runChizhikSchemaCanary(
     input.pageUrl,
     validStoreIds,
   );
-  if (!sapId) return { status: "missing-context" };
+  if (!sapId) {
+    return {
+      status: "missing-context",
+      diagnostics: input.resourceDiagnostics ?? EMPTY_CHIZHIK_RESOURCE_DIAGNOSTICS,
+    };
+  }
 
   const search = await input.client.searchStore({
     sapId,

--- a/apps/retailer-bridge/src/content.ts
+++ b/apps/retailer-bridge/src/content.ts
@@ -1,5 +1,6 @@
 import { retailerBrowserAdapters } from "./adapters/retailer-browser-adapters";
 import { createChizhikActiveApiClient } from "./chizhik-active-api-client";
+import { createChizhikResourceDiagnosticsTracker } from "./chizhik-resource-diagnostics";
 import { runChizhikSchemaCanary } from "./chizhik-schema-canary";
 import {
   CHIZHIK_SCHEMA_CANARY_RESULT,
@@ -22,11 +23,22 @@ const storeObservations = createChromeObservationSink(sendMessage);
 const clearObservations = createChromeObservationClearer(sendMessage);
 const observedResourceUrls = new Set<string>();
 const chizhikSchemaCanaryClient = createChizhikActiveApiClient();
+
+function currentChizhikResourceDiagnostics() {
+  const tracker = createChizhikResourceDiagnosticsTracker();
+  const pageUrl = new URL(location.href);
+  performance
+    .getEntriesByType("resource")
+    .forEach((entry) => tracker.observe(entry.name, pageUrl));
+  return tracker.snapshot();
+}
+
 const handleChizhikSchemaCanaryMessage = createChizhikSchemaCanaryMessageHandler(() =>
   runChizhikSchemaCanary({
     client: chizhikSchemaCanaryClient,
     pageUrl: new URL(location.href),
     resourceUrls: [...observedResourceUrls],
+    resourceDiagnostics: currentChizhikResourceDiagnostics(),
   }),
 );
 

--- a/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
+++ b/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createChizhikResourceDiagnosticsTracker } from "../src/chizhik-resource-diagnostics";
+
+const PAGE_URL = new URL("https://chizhik.club/catalog/search?q=%D0%BA%D0%BE%D0%BB%D0%B0");
+
+describe("Chizhik resource diagnostics", () => {
+  it("reports only fixed route-family presence without retaining raw URL or store identifiers", () => {
+    const tracker = createChizhikResourceDiagnosticsTracker();
+
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/catalog/v3/stores/SECRET87/search?mode=store&q=%D0%BA%D0%BE%D0%BB%D0%B0",
+      PAGE_URL,
+    );
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/catalog/v4/stores/SECRET99/search?mode=store&q=%D0%BA%D0%BE%D0%BB%D0%B0",
+      PAGE_URL,
+    );
+    tracker.observe("https://app.chizhik.club/api/v1/shops/", PAGE_URL);
+    tracker.observe("https://chizhik.club/api/delivery/status", PAGE_URL);
+    tracker.observe("https://tracker.example/SECRET87", PAGE_URL);
+
+    const snapshot = tracker.snapshot();
+    expect(snapshot).toEqual({
+      appOriginSeen: true,
+      deliveryApiSeen: true,
+      deliveryCatalogSeen: true,
+      storeScopedV2V3Seen: true,
+      storeScopedOtherVersionSeen: true,
+      pageOriginDeliverySeen: true,
+    });
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("SECRET87");
+    expect(serialized).not.toContain("SECRET99");
+    expect(serialized).not.toContain("tracker.example");
+    expect(serialized).not.toContain("/delivery/");
+  });
+
+  it("stays all-false for malformed and unrelated resources", () => {
+    const tracker = createChizhikResourceDiagnosticsTracker();
+    tracker.observe("not a url", PAGE_URL);
+    tracker.observe("https://example.com/catalog/v3/stores/SECRET/search", PAGE_URL);
+
+    expect(tracker.snapshot()).toEqual({
+      appOriginSeen: false,
+      deliveryApiSeen: false,
+      deliveryCatalogSeen: false,
+      storeScopedV2V3Seen: false,
+      storeScopedOtherVersionSeen: false,
+      pageOriginDeliverySeen: false,
+    });
+  });
+});

--- a/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
@@ -21,6 +21,18 @@ const PASS_RESULT = {
   ],
 };
 
+const MISSING_CONTEXT_RESULT = {
+  status: "missing-context" as const,
+  diagnostics: {
+    appOriginSeen: true,
+    deliveryApiSeen: true,
+    deliveryCatalogSeen: true,
+    storeScopedV2V3Seen: false,
+    storeScopedOtherVersionSeen: true,
+    pageOriginDeliverySeen: false,
+  },
+};
+
 describe("Chizhik schema canary message contract", () => {
   it("formats PASS as exactly two sanitized evidence lines", () => {
     expect(formatChizhikSchemaCanaryEvidence(PASS_RESULT)).toBe(
@@ -29,12 +41,22 @@ describe("Chizhik schema canary message contract", () => {
     );
   });
 
-  it("formats failures without exception, store, product, or payload details", () => {
+  it("formats missing context with fixed privacy-safe route-family diagnostics only", () => {
+    const evidence = formatChizhikSchemaCanaryEvidence(MISSING_CONTEXT_RESULT);
+    expect(evidence).toBe(
+      "CHIZHIK_D2 status=MISSING_CONTEXT\n" +
+        "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
+        "store_v2_v3=NOT_SEEN store_other_version=SEEN page_origin_delivery=NOT_SEEN",
+    );
+    expect(evidence).not.toContain("http");
+    expect(evidence).not.toContain("stores/");
+    expect(evidence).not.toContain("sap");
+    expect(evidence).not.toContain("price");
+  });
+
+  it("formats other failures without exception, store, product, or payload details", () => {
     expect(formatChizhikSchemaCanaryEvidence({ status: "wrong-origin" })).toBe(
       "CHIZHIK_D2 status=WRONG_ORIGIN",
-    );
-    expect(formatChizhikSchemaCanaryEvidence({ status: "missing-context" })).toBe(
-      "CHIZHIK_D2 status=MISSING_CONTEXT",
     );
     expect(formatChizhikSchemaCanaryEvidence({ status: "stores-unavailable" })).toBe(
       "CHIZHIK_D2 status=STORES_UNAVAILABLE",

--- a/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { EMPTY_CHIZHIK_RESOURCE_DIAGNOSTICS } from "../src/chizhik-resource-diagnostics";
 import { runChizhikSchemaCanary } from "../src/chizhik-schema-canary";
 
 const PAGE_URL = new URL("https://chizhik.club/catalog/chay-kofe--264C39224/");
@@ -119,7 +120,10 @@ describe("runChizhikSchemaCanary", () => {
       const client = clientWithPayload({ products: [] });
       await expect(
         runChizhikSchemaCanary({ client, pageUrl: PAGE_URL, resourceUrls }),
-      ).resolves.toEqual({ status: "missing-context" });
+      ).resolves.toEqual({
+        status: "missing-context",
+        diagnostics: EMPTY_CHIZHIK_RESOURCE_DIAGNOSTICS,
+      });
       expect(client.searchStore).not.toHaveBeenCalled();
     }
   });


### PR DESCRIPTION
## Problem

A real ordinary-browser #169 run reproduced `CHIZHIK_D2 status=MISSING_CONTEXT` even after the official Chizhik search UI loaded product cards for `кола`. This disproves the hypothesis that normal search interaction necessarily exposes one accepted store-scoped resource path to the content script.

## Root cause status

The external symptom is proven, but the exact live mechanism is not yet known. The accepted resolver only trusts official `/delivery/api/catalog/v2|v3/stores/{sap_id}/...` resources intersected with `/api/v1/shops/`; the ordinary browser is rendering results without producing a resolvable context under that contract.

This PR intentionally adds diagnostics rather than guessing a new store source or broadening the accepted route.

## TDD

RED head `5e505f60b52b84fd06550f16e3c33ab345f3f4bb`:
- Retailer Bridge CI `32503016280` failed at `Run bridge tests`;
- existing 15 suites / 62 tests passed;
- only new `chizhik-resource-diagnostics.test.ts` failed with `ERR_MODULE_NOT_FOUND` because the diagnostic implementation did not yet exist.

GREEN exact head `de9e9567407650fa5009850944f401d63fd483f5`:
- all 9 expected PR workflow groups SUCCESS;
- Retailer Bridge unit tests, typecheck, build and persistent-Chromium E2E SUCCESS;
- new E2E verifies a changed store-scoped API version yields `MISSING_CONTEXT` plus fixed route-family flags while leaking neither test store ID nor raw URL.

## Implementation

On explicit user canary invocation only, diagnostics scan the page's existing Resource Timing entries in memory and reduce them immediately to six booleans:
- official `app.chizhik.club` origin seen;
- delivery API family seen;
- delivery catalog family seen;
- accepted v2/v3 store-scoped family seen;
- other numeric store-scoped version family seen;
- same-page-origin delivery-like family seen.

On `MISSING_CONTEXT`, popup evidence adds one fixed `CHIZHIK_D2_DIAG ...` line using only `SEEN` / `NOT_SEEN` values.

## Privacy / security invariants

- no raw resource URL is persisted or rendered;
- no store ID, address, product/SKU/name/price/promotion value is emitted;
- no arbitrary schema/path enumeration;
- no response-body, header, cookie, credential or request-ID capture;
- no extension permission or `host_permissions` change;
- no automatic D2 search;
- no `BrowserObservation`, `ObservedOffer`, `priceMinor`, availability, promo/package/loyalty mapping enabled.

## Final verification

Exact head `de9e9567407650fa5009850944f401d63fd483f5` is `behind=0`, has no review threads, changes only 8 Retailer Bridge source/test files, and passes:
- Dependency Review;
- Release Contract CI;
- Contract CI;
- API CI;
- Retailer Bridge CI;
- CodeQL;
- Container Security CI;
- Release Bundle CI;
- Web CI.

Tracking: #169.