### PR TITLE
fix(chizhik): add categories/inout route-family diagnostic

### DIFF
--- a/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
@@ -210,7 +210,8 @@ test("renders only fixed route-family diagnostics when live resource shape is no
     await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
     await expect(evidence).toContainText(
       "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
-        "store_v2_v3=NOT_SEEN store_other_version=SEEN page_origin_delivery=NOT_SEEN",
+        "store_v2_v3=NOT_SEEN store_other_version=SEEN store_categories_inout=NOT_SEEN " +
+        "page_origin_delivery=NOT_SEEN",
     );
     expect(acceptedV3SearchRequests).toBe(0);
 
@@ -218,6 +219,92 @@ test("renders only fixed route-family diagnostics when live resource shape is no
     expect(rendered).not.toContain(privateStoreId);
     expect(rendered).not.toContain(changedVersionResource);
     expect(rendered).not.toContain("/v4/");
+    expect(rendered).not.toContain("q=cola");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("flags a categories/inout store_id resource as its own route family without accepting it as context", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-canary-inout-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  let acceptedV3SearchRequests = 0;
+  const privateStoreId = "PRIVATEHBBN";
+  const categoriesInoutResource =
+    `https://app.chizhik.club/delivery/api/catalog/v1/categories/inout?store_id=${privateStoreId}&mode=delivery`;
+
+  try {
+    await context.route("https://chizhik.club/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><html><body><main>Chizhik search fixture</main></body></html>",
+      }),
+    );
+    await context.route(shopsEndpoint, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(stores),
+      }),
+    );
+    await context.route("https://app.chizhik.club/delivery/api/catalog/**", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname.includes("/v3/stores/") && url.pathname.endsWith("/search")) {
+        acceptedV3SearchRequests += 1;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({ products: [] }),
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/search?q=cola");
+    await page.evaluate(async (resourceUrl) => {
+      await fetch(resourceUrl, {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+      });
+    }, categoriesInoutResource);
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(worker.url()).host;
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await page.bringToFront();
+
+    await popup.getByRole("button", { name: "Run sanitized Chizhik canary" }).click();
+    const evidence = popup.locator("#evidence");
+    await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
+    await expect(evidence).toContainText(
+      "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
+        "store_v2_v3=NOT_SEEN store_other_version=NOT_SEEN store_categories_inout=SEEN " +
+        "page_origin_delivery=NOT_SEEN",
+    );
+    expect(acceptedV3SearchRequests).toBe(0);
+
+    const rendered = await evidence.textContent();
+    expect(rendered).not.toContain(privateStoreId);
+    expect(rendered).not.toContain(categoriesInoutResource);
     expect(rendered).not.toContain("q=cola");
   } finally {
     await context.close();

--- a/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
+++ b/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
@@ -6,6 +6,8 @@ const ACCEPTED_STORE_PATH =
   /^\/delivery\/api\/catalog\/v(?:2|3)\/stores\/[A-Za-z0-9_-]{1,32}(?:\/|$)/;
 const ANY_NUMERIC_STORE_PATH =
   /^\/delivery\/api\/catalog\/v(\d{1,2})\/stores\/[A-Za-z0-9_-]{1,64}(?:\/|$)/;
+const CATEGORIES_INOUT_PATH =
+  /^\/delivery\/api\/catalog\/v\d{1,2}\/categories\/inout(?:\/|$)/;
 const PAGE_ORIGIN_DELIVERY_PATH = /^\/(?:api\/)?delivery(?:\/|$)/;
 
 export type ChizhikResourceDiagnosticsSnapshot = Readonly<{
@@ -14,6 +16,7 @@ export type ChizhikResourceDiagnosticsSnapshot = Readonly<{
   deliveryCatalogSeen: boolean;
   storeScopedV2V3Seen: boolean;
   storeScopedOtherVersionSeen: boolean;
+  storeScopedCategoriesInoutSeen: boolean;
   pageOriginDeliverySeen: boolean;
 }>;
 
@@ -23,6 +26,7 @@ const EMPTY_SNAPSHOT: ChizhikResourceDiagnosticsSnapshot = {
   deliveryCatalogSeen: false,
   storeScopedV2V3Seen: false,
   storeScopedOtherVersionSeen: false,
+  storeScopedCategoriesInoutSeen: false,
   pageOriginDeliverySeen: false,
 };
 
@@ -62,6 +66,13 @@ export function createChizhikResourceDiagnosticsTracker() {
         const version = resourceUrl.pathname.match(ANY_NUMERIC_STORE_PATH)?.[1];
         if (version && version !== "2" && version !== "3") {
           state.storeScopedOtherVersionSeen = true;
+        }
+
+        if (
+          CATEGORIES_INOUT_PATH.test(resourceUrl.pathname) &&
+          !!resourceUrl.searchParams.get("store_id")
+        ) {
+          state.storeScopedCategoriesInoutSeen = true;
         }
       } catch {
         // Malformed resource names are intentionally ignored.

--- a/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
@@ -41,6 +41,7 @@ export function formatChizhikSchemaCanaryEvidence(
         `delivery_catalog=${seen(result.diagnostics.deliveryCatalogSeen)} ` +
         `store_v2_v3=${seen(result.diagnostics.storeScopedV2V3Seen)} ` +
         `store_other_version=${seen(result.diagnostics.storeScopedOtherVersionSeen)} ` +
+        `store_categories_inout=${seen(result.diagnostics.storeScopedCategoriesInoutSeen)} ` +
         `page_origin_delivery=${seen(result.diagnostics.pageOriginDeliverySeen)}`
       );
     case "search-unavailable":

--- a/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
+++ b/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
@@ -15,6 +15,10 @@ describe("Chizhik resource diagnostics", () => {
       "https://app.chizhik.club/delivery/api/catalog/v4/stores/SECRET99/search?mode=store&q=%D0%BA%D0%BE%D0%BB%D0%B0",
       PAGE_URL,
     );
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/catalog/v1/categories/inout?store_id=SECRETHBBN&mode=delivery",
+      PAGE_URL,
+    );
     tracker.observe("https://app.chizhik.club/api/v1/shops/", PAGE_URL);
     tracker.observe("https://chizhik.club/api/delivery/status", PAGE_URL);
     tracker.observe("https://tracker.example/SECRET87", PAGE_URL);
@@ -26,14 +30,30 @@ describe("Chizhik resource diagnostics", () => {
       deliveryCatalogSeen: true,
       storeScopedV2V3Seen: true,
       storeScopedOtherVersionSeen: true,
+      storeScopedCategoriesInoutSeen: true,
       pageOriginDeliverySeen: true,
     });
 
     const serialized = JSON.stringify(snapshot);
     expect(serialized).not.toContain("SECRET87");
     expect(serialized).not.toContain("SECRET99");
+    expect(serialized).not.toContain("SECRETHBBN");
     expect(serialized).not.toContain("tracker.example");
     expect(serialized).not.toContain("/delivery/");
+  });
+
+  it("does not flag categories/inout without a store_id value", () => {
+    const tracker = createChizhikResourceDiagnosticsTracker();
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/catalog/v1/categories/inout?mode=delivery",
+      PAGE_URL,
+    );
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/catalog/v1/categories/inout?store_id=&mode=delivery",
+      PAGE_URL,
+    );
+
+    expect(tracker.snapshot().storeScopedCategoriesInoutSeen).toBe(false);
   });
 
   it("stays all-false for malformed and unrelated resources", () => {
@@ -47,6 +67,7 @@ describe("Chizhik resource diagnostics", () => {
       deliveryCatalogSeen: false,
       storeScopedV2V3Seen: false,
       storeScopedOtherVersionSeen: false,
+      storeScopedCategoriesInoutSeen: false,
       pageOriginDeliverySeen: false,
     });
   });

--- a/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
@@ -29,6 +29,7 @@ const MISSING_CONTEXT_RESULT = {
     deliveryCatalogSeen: true,
     storeScopedV2V3Seen: false,
     storeScopedOtherVersionSeen: true,
+    storeScopedCategoriesInoutSeen: false,
     pageOriginDeliverySeen: false,
   },
 };
@@ -46,7 +47,8 @@ describe("Chizhik schema canary message contract", () => {
     expect(evidence).toBe(
       "CHIZHIK_D2 status=MISSING_CONTEXT\n" +
         "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
-        "store_v2_v3=NOT_SEEN store_other_version=SEEN page_origin_delivery=NOT_SEEN",
+        "store_v2_v3=NOT_SEEN store_other_version=SEEN store_categories_inout=NOT_SEEN " +
+        "page_origin_delivery=NOT_SEEN",
     );
     expect(evidence).not.toContain("http");
     expect(evidence).not.toContain("stores/");


### PR DESCRIPTION
## Problem

#192 added privacy-safe route-family diagnostics for Chizhik D2
`MISSING_CONTEXT` runs. A follow-up ordinary-browser session against
`app.chizhik.club` observed a successful request to
`/delivery/api/catalog/v1/categories/inout?store_id=...` — a route
family that does not match the accepted
`/delivery/api/catalog/v2|v3/stores/{sap_id}/...` contract, and is
also structurally different from the existing `storeScopedOtherVersionSeen`
flag (that flag only matches an *unexpected version* of the `stores/{id}/...`
shape; `categories/inout?store_id=` is a different path shape entirely,
using a query parameter instead of a path segment).

This PR intentionally adds one more diagnostic boolean rather than
guessing a new store-context source or widening the accepted route —
consistent with the approach in #192.

## Implementation

- `chizhik-resource-diagnostics.ts`: adds `storeScopedCategoriesInoutSeen`,
  set only when a `/delivery/api/catalog/v{N}/categories/inout` path is
  observed together with a non-empty `store_id` query parameter. No raw
  `store_id` value, path, or URL is retained — only the boolean.
- `chizhik-schema-canary-message.ts`: appends
  `store_categories_inout=SEEN|NOT_SEEN` to the existing
  `CHIZHIK_D2_DIAG` evidence line on `MISSING_CONTEXT`.
- Unit tests cover: the flag firing on a matching resource, staying
  false without a `store_id` value, and the malformed/unrelated-input
  baseline.
- A new Playwright E2E test drives the built extension end to end
  against a `categories/inout?store_id=` fixture and asserts the
  rendered popup evidence contains `store_categories_inout=SEEN` while
  never containing the raw store ID, the full resource URL, or the
  search query.

## Privacy / security invariants (unchanged from #192)

- no raw resource URL, store ID, or query value is persisted or rendered;
- no product/SKU/name/price/promotion value is emitted;
- no extension permission or `host_permissions` change;
- no automatic D2 search;
- no `BrowserObservation` / `ObservedOffer` / offer/availability mapping enabled;
- `categories/inout?store_id=` is diagnosed only — it is **not** added
  as an accepted store-context source; `resolveChizhikEvidencedStoreId`
  is untouched.

## Verification

Ran locally (not just asserted):
- `pnpm --dir apps/retailer-bridge test` — 66/66 passed (62 baseline + 4 new).
- `pnpm --dir apps/retailer-bridge typecheck` — clean.
- `pnpm --dir apps/retailer-bridge build` / `build:e2e` — succeed.
- `pnpm --dir apps/retailer-bridge exec playwright test` — full suite,
  16/16 passed, including the 3 Chizhik canary specs (1 new).

Tracking: #169.