### PR TITLE
docs: sync Chizhik D2 diagnostics state after #192/#193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable project changes are recorded here. Zakup Gotov reached its first acc
 - PR #177 adds an explicit user-invoked privacy-hardened D2 schema canary with no permission widening, exactly one fixed bounded search, a fixed reviewed candidate-field allowlist and persistent-Chromium E2E. It passed fresh exact-head 9/9 PR CI plus final security/privacy review and was squash-merged as `9822659c1b43df978e191e6f7826775fc615926d`.
 - The canary output is limited to sanitized HTTP metadata plus bounded allowlisted field/type structure; raw store/product/SKU/name/price/promotion/request/header/cookie/credential values are not emitted.
 - Chizhik offer mapping remains blocked on ordinary-user-browser structural evidence plus independent monetary-unit/scale evidence. Availability remains `UNKNOWN` unless separately evidenced semantics are accepted.
+- PR #192 adds privacy-safe route-family diagnostics for `MISSING_CONTEXT` canary runs, after a real ordinary-browser run showed the official search UI can load results without exposing an accepted store-scoped resource. Diagnostics reduce Resource Timing entries to fixed `SEEN`/`NOT_SEEN` booleans; no raw URL, store ID, or credential is persisted or rendered.
+- PR #193 adds one further diagnostic flag (`store_categories_inout`) for a `/delivery/api/catalog/v1/categories/inout?store_id=...` route shape, observed during automated reconnaissance, that does not match the accepted `v2|v3/stores/{sap_id}/...` contract. Diagnostic-only: this route is not accepted as store context and no offer mapping is enabled.
 
 #### Release security, product acceptance and stable promotion
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Updated: 2026-08-20
+Updated: 2026-08-22
 
 ## Project
 
@@ -98,6 +98,10 @@ Issue #169 remains **OPEN**. Before any offer/price mapping it still requires:
 2. separate evidence proving the monetary unit/scale of `prices.regular` before `priceMinor` mapping;
 3. separately accepted availability semantics, otherwise availability stays `UNKNOWN`;
 4. no inferred promotion/loyalty/package/discount semantics.
+
+A real ordinary-browser #169 run reproduced `CHIZHIK_D2 status=MISSING_CONTEXT` even after the official Chizhik search UI loaded product cards for `кола`, disproving the assumption that normal search interaction necessarily exposes one accepted store-scoped resource path to the content script. Rather than guessing a new store-context source or broadening the accepted route, PR #192 (squash-merged `940b2423cb1f467f673f2c4ba967145dd7c7c074`) added privacy-safe route-family diagnostics: on `MISSING_CONTEXT`, the canary evidence now includes one fixed `CHIZHIK_D2_DIAG` line of `SEEN`/`NOT_SEEN` booleans over the Resource Timing entries already in memory, with no raw URL, store ID, or credential ever persisted or rendered.
+
+A follow-up automated-browser reconnaissance session against `app.chizhik.club` (run by Claude, not an ordinary-user session; see invariant 20) observed a successful `/delivery/api/catalog/v1/categories/inout?store_id=...` request before the session was blocked by the site's own WAF (`403 Forbidden`, consistent with D1's finding that automated Chromium is not the selected acquisition environment). That route shape does not match the accepted `v2|v3/stores/{sap_id}/...` contract and was not previously distinguished from the generic "other version" flag. PR #193 (squash-merged `7f68cb5404df77e33c08f350bdd02f033de45099`) added a dedicated `storeScopedCategoriesInoutSeen` / `store_categories_inout` diagnostic flag for this shape, verified by unit and Playwright E2E coverage before merge. This is diagnostic-only: `categories/inout?store_id=` is not accepted as a resolvable store context, and no offer/availability mapping was enabled. Ordinary-user-browser confirmation of whether this flag actually fires on a real MISSING_CONTEXT run is still outstanding.
 
 ### Verified Retailer Bridge artifact
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Updated: 2026-08-20
+Updated: 2026-08-22
 
 The roadmap is evidence-driven. Technical connectivity, production-access readiness, deterministic product/core maturity and release acceptance are separate dimensions.
 
@@ -177,6 +177,10 @@ PR #177 passed fresh exact-head **9/9 PR workflow groups** plus final security/p
 The merged canary is explicit user invocation only, performs exactly one fixed bounded search, requires exactly one browser-evidenced validated store context, adds no host permissions, and emits only bounded allowlisted field/type structure plus sanitized HTTP metadata.
 
 Do **not** implement production `BrowserObservation` / `ObservedOffer` mapping until #169 receives ordinary-user-browser evidence proving product container/identifier/name and price candidate structure, plus independent evidence of the price **monetary unit/scale**. Availability maps only from separately accepted semantics; otherwise it remains `UNKNOWN`. Promotion/package/loyalty/discount semantics are not inferred.
+
+### Chizhik D2 missing-context diagnostics — IMPLEMENTED / MERGED; LIVE CONFIRMATION PENDING
+
+A real ordinary-browser #169 run reproduced `MISSING_CONTEXT` even while the official search UI showed results, disproving the assumption that normal search interaction reliably exposes an accepted store-scoped resource. PR #192 (`940b242`) added privacy-safe route-family diagnostics (fixed `SEEN`/`NOT_SEEN` booleans, no raw URL/store ID) instead of guessing a new accepted route. PR #193 (`7f68cb5`) extended those diagnostics with one more flag for a `/delivery/api/catalog/v1/categories/inout?store_id=...` route shape observed during automated reconnaissance — a shape that does not match the accepted `v2|v3/stores/{sap_id}/...` contract. Both changes are diagnostic-only and change no accepted store-context source. The next step on #169 is an ordinary-user-browser run of the canary to see which route-family flags actually fire on a live `MISSING_CONTEXT`.
 
 ### Other mandatory retailer work
 


### PR DESCRIPTION
## Summary

Documentation-only sync. `docs/PROJECT_STATE.md` and `docs/ROADMAP.md`
were last updated 2026-08-20 (baseline `a550501`/#189) and did not yet
mention #192 (merged 2026-08-21) or #193 (merged 2026-08-22).

- `docs/PROJECT_STATE.md` (Chizhik section): records the live
  `MISSING_CONTEXT` reproduction that #192 responded to, and the
  `categories/inout?store_id=` route shape #193 diagnoses. Notes that
  ordinary-user-browser confirmation is still outstanding.
- `docs/ROADMAP.md`: adds a "Chizhik D2 missing-context diagnostics"
  entry parallel to the existing D2 schema-canary entry.
- `CHANGELOG.md`: two `[Unreleased]` bullets under Chizhik connectivity.

No executable/release-tooling baseline change (this is Retailer Bridge
extension diagnostics, not the API/Web release pipeline tracked by the
`a550501` baseline) — that baseline line is left untouched.

Tracking: #169.