### PR TITLE
fix(chizhik): add delivery orders-API route-family diagnostic

### DIFF
--- a/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
+++ b/apps/retailer-bridge/e2e/chizhik-schema-canary-extension.spec.ts
@@ -210,8 +210,8 @@ test("renders only fixed route-family diagnostics when live resource shape is no
     await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
     await expect(evidence).toContainText(
       "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
-        "store_v2_v3=NOT_SEEN store_other_version=SEEN store_categories_inout=NOT_SEEN " +
-        "page_origin_delivery=NOT_SEEN",
+        "delivery_orders=NOT_SEEN store_v2_v3=NOT_SEEN store_other_version=SEEN " +
+        "store_categories_inout=NOT_SEEN page_origin_delivery=NOT_SEEN",
     );
     expect(acceptedV3SearchRequests).toBe(0);
 
@@ -297,14 +297,99 @@ test("flags a categories/inout store_id resource as its own route family without
     await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
     await expect(evidence).toContainText(
       "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
-        "store_v2_v3=NOT_SEEN store_other_version=NOT_SEEN store_categories_inout=SEEN " +
-        "page_origin_delivery=NOT_SEEN",
+        "delivery_orders=NOT_SEEN store_v2_v3=NOT_SEEN store_other_version=NOT_SEEN " +
+        "store_categories_inout=SEEN page_origin_delivery=NOT_SEEN",
     );
     expect(acceptedV3SearchRequests).toBe(0);
 
     const rendered = await evidence.textContent();
     expect(rendered).not.toContain(privateStoreId);
     expect(rendered).not.toContain(categoriesInoutResource);
+    expect(rendered).not.toContain("q=cola");
+  } finally {
+    await context.close();
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("flags a delivery orders-API resource as its own route family without treating it as catalog evidence", async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), "zg-retailer-bridge-canary-orders-"));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+
+  let acceptedV3SearchRequests = 0;
+  const privateOrderId = "PRIVATE-ORDER-ID";
+  const ordersResource = `https://app.chizhik.club/delivery/api/orders/v3/orders/${privateOrderId}/?in_action=true`;
+
+  try {
+    await context.route("https://chizhik.club/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><html><body><main>Chizhik search fixture</main></body></html>",
+      }),
+    );
+    await context.route(shopsEndpoint, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(stores),
+      }),
+    );
+    await context.route("https://app.chizhik.club/delivery/api/**", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname.includes("/v3/stores/") && url.pathname.endsWith("/search")) {
+        acceptedV3SearchRequests += 1;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "https://chizhik.club",
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({ products: [] }),
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://chizhik.club/catalog/search?q=cola");
+    await page.evaluate(async (resourceUrl) => {
+      await fetch(resourceUrl, {
+        method: "GET",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: { Accept: "application/json, text/plain, */*" },
+      });
+    }, ordersResource);
+
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(worker.url()).host;
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await page.bringToFront();
+
+    await popup.getByRole("button", { name: "Run sanitized Chizhik canary" }).click();
+    const evidence = popup.locator("#evidence");
+    await expect(evidence).toContainText("CHIZHIK_D2 status=MISSING_CONTEXT");
+    await expect(evidence).toContainText(
+      "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=NOT_SEEN " +
+        "delivery_orders=SEEN store_v2_v3=NOT_SEEN store_other_version=NOT_SEEN " +
+        "store_categories_inout=NOT_SEEN page_origin_delivery=NOT_SEEN",
+    );
+    expect(acceptedV3SearchRequests).toBe(0);
+
+    const rendered = await evidence.textContent();
+    expect(rendered).not.toContain(privateOrderId);
+    expect(rendered).not.toContain(ordersResource);
     expect(rendered).not.toContain("q=cola");
   } finally {
     await context.close();

--- a/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
+++ b/apps/retailer-bridge/src/chizhik-resource-diagnostics.ts
@@ -8,12 +8,14 @@ const ANY_NUMERIC_STORE_PATH =
   /^\/delivery\/api\/catalog\/v(\d{1,2})\/stores\/[A-Za-z0-9_-]{1,64}(?:\/|$)/;
 const CATEGORIES_INOUT_PATH =
   /^\/delivery\/api\/catalog\/v\d{1,2}\/categories\/inout(?:\/|$)/;
+const DELIVERY_ORDERS_PREFIX = "/delivery/api/orders/";
 const PAGE_ORIGIN_DELIVERY_PATH = /^\/(?:api\/)?delivery(?:\/|$)/;
 
 export type ChizhikResourceDiagnosticsSnapshot = Readonly<{
   appOriginSeen: boolean;
   deliveryApiSeen: boolean;
   deliveryCatalogSeen: boolean;
+  deliveryOrdersSeen: boolean;
   storeScopedV2V3Seen: boolean;
   storeScopedOtherVersionSeen: boolean;
   storeScopedCategoriesInoutSeen: boolean;
@@ -24,6 +26,7 @@ const EMPTY_SNAPSHOT: ChizhikResourceDiagnosticsSnapshot = {
   appOriginSeen: false,
   deliveryApiSeen: false,
   deliveryCatalogSeen: false,
+  deliveryOrdersSeen: false,
   storeScopedV2V3Seen: false,
   storeScopedOtherVersionSeen: false,
   storeScopedCategoriesInoutSeen: false,
@@ -54,6 +57,10 @@ export function createChizhikResourceDiagnosticsTracker() {
 
         if (!resourceUrl.pathname.startsWith(DELIVERY_API_PREFIX)) return;
         state.deliveryApiSeen = true;
+
+        if (resourceUrl.pathname.startsWith(DELIVERY_ORDERS_PREFIX)) {
+          state.deliveryOrdersSeen = true;
+        }
 
         if (!resourceUrl.pathname.startsWith(DELIVERY_CATALOG_PREFIX)) return;
         state.deliveryCatalogSeen = true;

--- a/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
+++ b/apps/retailer-bridge/src/chizhik-schema-canary-message.ts
@@ -39,6 +39,7 @@ export function formatChizhikSchemaCanaryEvidence(
         `CHIZHIK_D2_DIAG app_origin=${seen(result.diagnostics.appOriginSeen)} ` +
         `delivery_api=${seen(result.diagnostics.deliveryApiSeen)} ` +
         `delivery_catalog=${seen(result.diagnostics.deliveryCatalogSeen)} ` +
+        `delivery_orders=${seen(result.diagnostics.deliveryOrdersSeen)} ` +
         `store_v2_v3=${seen(result.diagnostics.storeScopedV2V3Seen)} ` +
         `store_other_version=${seen(result.diagnostics.storeScopedOtherVersionSeen)} ` +
         `store_categories_inout=${seen(result.diagnostics.storeScopedCategoriesInoutSeen)} ` +

--- a/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
+++ b/apps/retailer-bridge/test/chizhik-resource-diagnostics.test.ts
@@ -19,6 +19,10 @@ describe("Chizhik resource diagnostics", () => {
       "https://app.chizhik.club/delivery/api/catalog/v1/categories/inout?store_id=SECRETHBBN&mode=delivery",
       PAGE_URL,
     );
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/orders/v1/orders/stores/?lon=1&lat=2",
+      PAGE_URL,
+    );
     tracker.observe("https://app.chizhik.club/api/v1/shops/", PAGE_URL);
     tracker.observe("https://chizhik.club/api/delivery/status", PAGE_URL);
     tracker.observe("https://tracker.example/SECRET87", PAGE_URL);
@@ -28,6 +32,7 @@ describe("Chizhik resource diagnostics", () => {
       appOriginSeen: true,
       deliveryApiSeen: true,
       deliveryCatalogSeen: true,
+      deliveryOrdersSeen: true,
       storeScopedV2V3Seen: true,
       storeScopedOtherVersionSeen: true,
       storeScopedCategoriesInoutSeen: true,
@@ -56,6 +61,25 @@ describe("Chizhik resource diagnostics", () => {
     expect(tracker.snapshot().storeScopedCategoriesInoutSeen).toBe(false);
   });
 
+  it("flags a delivery orders-API resource without treating it as a catalog resource", () => {
+    const tracker = createChizhikResourceDiagnosticsTracker();
+    tracker.observe(
+      "https://app.chizhik.club/delivery/api/orders/v3/orders/?in_action=true",
+      PAGE_URL,
+    );
+
+    expect(tracker.snapshot()).toEqual({
+      appOriginSeen: true,
+      deliveryApiSeen: true,
+      deliveryCatalogSeen: false,
+      deliveryOrdersSeen: true,
+      storeScopedV2V3Seen: false,
+      storeScopedOtherVersionSeen: false,
+      storeScopedCategoriesInoutSeen: false,
+      pageOriginDeliverySeen: false,
+    });
+  });
+
   it("stays all-false for malformed and unrelated resources", () => {
     const tracker = createChizhikResourceDiagnosticsTracker();
     tracker.observe("not a url", PAGE_URL);
@@ -65,6 +89,7 @@ describe("Chizhik resource diagnostics", () => {
       appOriginSeen: false,
       deliveryApiSeen: false,
       deliveryCatalogSeen: false,
+      deliveryOrdersSeen: false,
       storeScopedV2V3Seen: false,
       storeScopedOtherVersionSeen: false,
       storeScopedCategoriesInoutSeen: false,

--- a/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
+++ b/apps/retailer-bridge/test/chizhik-schema-canary-message.test.ts
@@ -27,6 +27,7 @@ const MISSING_CONTEXT_RESULT = {
     appOriginSeen: true,
     deliveryApiSeen: true,
     deliveryCatalogSeen: true,
+    deliveryOrdersSeen: false,
     storeScopedV2V3Seen: false,
     storeScopedOtherVersionSeen: true,
     storeScopedCategoriesInoutSeen: false,
@@ -47,8 +48,8 @@ describe("Chizhik schema canary message contract", () => {
     expect(evidence).toBe(
       "CHIZHIK_D2 status=MISSING_CONTEXT\n" +
         "CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=SEEN " +
-        "store_v2_v3=NOT_SEEN store_other_version=SEEN store_categories_inout=NOT_SEEN " +
-        "page_origin_delivery=NOT_SEEN",
+        "delivery_orders=NOT_SEEN store_v2_v3=NOT_SEEN store_other_version=SEEN " +
+        "store_categories_inout=NOT_SEEN page_origin_delivery=NOT_SEEN",
     );
     expect(evidence).not.toContain("http");
     expect(evidence).not.toContain("stores/");


### PR DESCRIPTION
## Problem

A second ordinary-user-browser #169 canary run returned:

```
CHIZHIK_D2 status=MISSING_CONTEXT
CHIZHIK_D2_DIAG app_origin=SEEN delivery_api=SEEN delivery_catalog=NOT_SEEN
store_v2_v3=NOT_SEEN store_other_version=NOT_SEEN store_categories_inout=NOT_SEEN
page_origin_delivery=NOT_SEEN
```

`delivery_api=SEEN` but `delivery_catalog=NOT_SEEN` and every other
flag `NOT_SEEN` — the existing diagnostics could confirm *something*
under `/delivery/api/` fired, but not what, since every other flag is
scoped to `/delivery/api/catalog/...`.

Path-shape evidence (URLs only — no headers, geolocation, device id,
or order id, per the canary's own no-raw-value discipline) showed the
page had instead called:

```
/delivery/api/orders/v3/orders/?in_action=true
/delivery/api/orders/v10/orders/{id}/
/delivery/api/orders/v1/orders/stores/?lon=...&lat=...
```

An entirely different route family (`/delivery/api/orders/...`, not
`.../catalog/...`) — most likely because the page had an active order
in progress and checked order status ahead of/instead of catalog
search on that particular run.

## Implementation

- `chizhik-resource-diagnostics.ts`: adds `deliveryOrdersSeen` /
  `delivery_orders`, matching only the `/delivery/api/orders/` prefix.
  Evaluated before the existing catalog-scoped early return so it is
  independent of `deliveryCatalogSeen`. No path segment beyond the
  fixed prefix, order id, or coordinate is retained — boolean only.
- `chizhik-schema-canary-message.ts`: appends `delivery_orders=SEEN|NOT_SEEN`
  to the `CHIZHIK_D2_DIAG` line.
- Unit tests cover the new flag firing/not firing, plus the
  malformed/unrelated-input baseline.
- A new Playwright E2E test drives the built extension against an
  orders-API fixture and asserts the rendered evidence shows
  `delivery_orders=SEEN` / `delivery_catalog=NOT_SEEN` while never
  containing the order id, coordinates, or full resource URL.

## Privacy / security invariants (unchanged from #192/#193)

- no raw resource URL, order id, coordinate, or device id is
  persisted or rendered;
- no extension permission or `host_permissions` change;
- no automatic D2 search;
- `/delivery/api/orders/...` is diagnosed only — it is **not** added
  as an accepted store-context source; `resolveChizhikEvidencedStoreId`
  is untouched.

## Verification

Ran locally before opening the PR:
- `pnpm --dir apps/retailer-bridge test` — 67/67 passed (66 baseline + 1 new).
- `pnpm --dir apps/retailer-bridge typecheck` — clean.
- `pnpm --dir apps/retailer-bridge build` / `build:e2e` — succeed.
- `pnpm --dir apps/retailer-bridge exec playwright test` — full suite,
  17/17 passed, including all 4 Chizhik canary specs (1 new).

Tracking: #169.