### PR TITLE
test(chizhik): add direct unit coverage for evidenced store-context resolver

### DIFF
--- a/apps/retailer-bridge/test/chizhik-store-context.test.ts
+++ b/apps/retailer-bridge/test/chizhik-store-context.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { resolveChizhikEvidencedStoreId } from "../src/chizhik-store-context";
+
+const PAGE_URL = new URL("https://chizhik.club/catalog/chay-kofe--264C39224/");
+const VALID_STORE_IDS = new Set(["HD87", "HD88"]);
+const HD87_RESOURCE =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD87/search?mode=store&q=cola";
+const HD87_ALT_RESOURCE =
+  "https://app.chizhik.club/delivery/api/catalog/v2/stores/HD87/categories/drinks/products";
+const HD88_RESOURCE =
+  "https://app.chizhik.club/delivery/api/catalog/v3/stores/HD88/search?mode=store&q=cola";
+
+describe("resolveChizhikEvidencedStoreId", () => {
+  it("returns null when no resources are supplied", () => {
+    expect(resolveChizhikEvidencedStoreId([], PAGE_URL, VALID_STORE_IDS)).toBeNull();
+  });
+
+  it("resolves the sap_id from exactly one evidenced, validated resource", () => {
+    expect(
+      resolveChizhikEvidencedStoreId([HD87_RESOURCE], PAGE_URL, VALID_STORE_IDS),
+    ).toBe("HD87");
+  });
+
+  it("deduplicates repeated or differently-shaped resources for the same store", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        [HD87_RESOURCE, HD87_RESOURCE, HD87_ALT_RESOURCE],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBe("HD87");
+  });
+
+  it("fails closed when the evidenced sap_id is absent from the validated directory", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        ["https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search"],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBeNull();
+  });
+
+  it("fails closed when two different validated stores are both evidenced", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        [HD87_RESOURCE, HD88_RESOURCE],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBeNull();
+  });
+
+  it("fails closed when the validated directory is empty", () => {
+    expect(
+      resolveChizhikEvidencedStoreId([HD87_RESOURCE], PAGE_URL, new Set()),
+    ).toBeNull();
+  });
+
+  it("ignores resources that do not project a fulfillment context at all", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        [
+          "https://app.chizhik.club/api/v1/catalog/unauthorized/products/",
+          "https://app.chizhik.club/delivery/api/profile/v1/me",
+          "not a url",
+        ],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores a foreign-origin resource even when it carries a validated sap_id", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        ["https://app.chizhik.club.evil.example/delivery/api/catalog/v3/stores/HD87/search"],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores context resources from a different retailer's contextKey namespace", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        ["https://www.perekrestok.ru/api/customer/1.4.1.0/shop/HD87"],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves the single valid store even when mixed with unrelated and unknown resources", () => {
+    expect(
+      resolveChizhikEvidencedStoreId(
+        [
+          "https://app.chizhik.club/api/v1/shops/",
+          "https://app.chizhik.club/delivery/api/catalog/v3/stores/UNKNOWN/search",
+          HD87_RESOURCE,
+          "not a url",
+        ],
+        PAGE_URL,
+        VALID_STORE_IDS,
+      ),
+    ).toBe("HD87");
+  });
+});


### PR DESCRIPTION
## Why

While looking for correctness/reliability improvements ahead of the
next #169 live evidence run, I found `resolveChizhikEvidencedStoreId`
(`chizhik-store-context.ts`) had **zero direct unit tests** despite
being the exact function that:

- gates the production Chizhik `BrowserObservation` collection path
  (`adapters/chizhik-browser-adapter.ts`);
- gates the D2 schema canary (`chizhik-schema-canary.ts`);
- is the precise mechanism under active investigation for the
  `store_v2_v3=SEEN` + `MISSING_CONTEXT` paradox seen in the first
  live #169 canary run (docs/PROJECT_STATE.md).

It only had indirect coverage through the adapter and canary
integration tests. This PR adds a dedicated, fast unit-test module
for the resolver's exact contract, with no production code changes.

## Coverage added

- no resources → `null`
- single valid resource → resolves
- repeated / differently-shaped resources for the same store → dedup, resolves
- unknown sap_id (not in the validated directory) → fails closed
- two different validated stores both evidenced → fails closed (conflict)
- empty validated directory → fails closed
- non-context resources (unrelated/malformed paths, `"not a url"`) → ignored
- foreign-origin resource carrying an otherwise-valid sap_id → ignored
- a same-shaped resource from a different retailer's contextKey namespace (Perekrestok) → ignored
- resolves the one valid store correctly amid unrelated/unknown noise

## Verification

- Ran `pnpm --dir apps/retailer-bridge test` — 77/77 passed (67 baseline + 10 new).
- **Mutation check** (not just "tests pass"): temporarily changed
  `if (validStoreIds.has(sapId)) contexts.add(sapId);` to
  unconditionally add every sap_id, re-ran the suite — 5 tests failed
  (3 in the new file, 2 in the existing adapter integration tests),
  confirming the new tests exercise real behavior rather than passing
  vacuously. Reverted immediately (`git diff` on the source file is
  empty in this PR — only the new test file is added).
- `pnpm --dir apps/retailer-bridge typecheck` — clean.
- `pnpm --dir apps/retailer-bridge build` / `build:e2e` — succeed.
- `pnpm --dir apps/retailer-bridge exec playwright test` — full suite,
  17/17 passed (unchanged from before this PR, since no runtime
  behavior changed).

## Out of scope (flagged separately, not in this PR)

While reading this code I noticed `ChizhikStoreSummary.active` is
projected from the shops API but never consumed anywhere — the
validated-store `Set` used by both the adapter and the canary
includes inactive/closed stores just like active ones. This may be
intentional or may be a gap; it's a product/semantics decision, not a
test-coverage fix, so I flagged it separately rather than silently
changing behavior here.

Tracking: #169.